### PR TITLE
feat(dashboard): armor inventory table view and workspace switcher

### DIFF
--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -60,11 +60,34 @@ export async function POST(req: NextRequest) {
   const lookupsPromise = getManifestLookups();
   const cachedPromise = getCachedInventoryWithSyncedAt(session.userId);
   const { layout: layoutPayload, ...createFields } = parsed.data;
+  const trimmedName = createFields.name.trim();
+
+  const { data: duplicateRow } = await sb
+    .from("views")
+    .select("id")
+    .eq("user_id", session.userId)
+    .eq("name", trimmedName)
+    .eq("set_hash", createFields.set_hash)
+    .eq("archetype_hash", createFields.archetype_hash)
+    .eq("tuning_hash", createFields.tuning_hash)
+    .eq("class_type", createFields.class_type)
+    .maybeSingle();
+
+  if (duplicateRow) {
+    return NextResponse.json(
+      {
+        error:
+          "A tracker with this name and build already exists. Change something and try again.",
+      },
+      { status: 409 },
+    );
+  }
+
   const { data, error } = await sb
     .from("views")
     .insert({
       user_id: session.userId,
-      name: createFields.name.trim(),
+      name: trimmedName,
       set_hash: createFields.set_hash,
       archetype_hash: createFields.archetype_hash,
       tuning_hash: createFields.tuning_hash,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,10 +10,9 @@ import {
 import { listViewsForUser } from "@/lib/views/queries";
 import { getManifestLookups } from "@/lib/manifest/lookups";
 import { checkManifestVersion } from "@/lib/manifest/version-check";
-import { AppHeader } from "@/components/app-header";
 import { SyncManifestButton } from "@/components/dashboard/sync-manifest-button";
 import { buildSerializableTrackerPayload } from "@/lib/workspace/build-tracker-payload";
-import { CanvasWorkspace } from "@/components/workspace/canvas-workspace";
+import { DashboardWorkspace } from "@/components/dashboard/dashboard-workspace";
 import { manifestSelectorsFromLookups } from "@/lib/views/manifest-selectors-from-lookup";
 import { parseWorkspaceCamera } from "@/lib/workspace/workspace-schema";
 import { bungieIconUrl } from "@/lib/bungie/constants";
@@ -145,18 +144,17 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
   );
 
   return (
-    <>
-      <AppHeader displayName={displayName} profilePictureUrl={profilePictureUrl} />
-
-      <CanvasWorkspace
-        banners={banners}
-        initialTrackers={trackerPayloads}
-        initialCamera={initialCamera}
-        focusTrackerId={focusTrackerId}
-        syncWarning={syncWarning}
-        hasInventory={cached !== null}
-        selectors={selectors}
-      />
-    </>
+    <DashboardWorkspace
+      displayName={displayName}
+      profilePictureUrl={profilePictureUrl}
+      banners={banners}
+      initialTrackers={trackerPayloads}
+      initialCamera={initialCamera}
+      focusTrackerId={focusTrackerId}
+      syncWarning={syncWarning}
+      hasInventory={cached !== null}
+      selectors={selectors}
+      inventory={inventory}
+    />
   );
 }

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { SignOut } from "@phosphor-icons/react/dist/ssr";
 import { FeedbackHeaderDialog } from "@/components/feedback-header-dialog";
@@ -17,31 +18,44 @@ interface AppHeaderProps {
   displayName: string;
   /** Absolute URL from `bungieIconUrl(profile_picture_path)` */
   profilePictureUrl?: string | null;
+  /** Shown immediately to the right of the brand link (e.g. Canvas / Table). */
+  leadingAccessory?: ReactNode;
 }
 
 /**
  * Top nav: brand cluster (D2 Tuning Tracker), compact icon actions, profile + sign-out.
  */
-export function AppHeader({ displayName, profilePictureUrl }: AppHeaderProps) {
+export function AppHeader({
+  displayName,
+  profilePictureUrl,
+  leadingAccessory,
+}: AppHeaderProps) {
   return (
     <header className="pointer-events-none fixed left-0 right-0 top-0 z-40 flex flex-col gap-3 px-3 pt-3 sm:flex-row sm:items-start sm:justify-between sm:gap-3 sm:px-4 sm:pt-4">
-      <Link
-        href="/dashboard"
-        className="pointer-events-auto flex items-center gap-2 rounded-none border border-[#4d4e4e] bg-[#2e2f2f] px-2.5 py-2 text-left transition-colors hover:bg-[#353636] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
-      >
-        {/* eslint-disable-next-line @next/next/no-img-element -- static brand asset */}
-        <img
-          src="/skull.svg"
-          alt=""
-          width={17}
-          height={24}
-          className="h-6 w-auto shrink-0"
-          aria-hidden
-        />
-        <span className="min-w-0 text-sm font-medium tracking-tight text-white">
-          D2 Tuning Tracker
-        </span>
-      </Link>
+      <div className="pointer-events-none flex min-w-0 flex-wrap items-center gap-2 sm:gap-3">
+        <Link
+          href="/dashboard"
+          className="pointer-events-auto flex items-center gap-2 rounded-none border border-[#4d4e4e] bg-[#2e2f2f] px-2.5 py-2 text-left transition-colors hover:bg-[#353636] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element -- static brand asset */}
+          <img
+            src="/skull.svg"
+            alt=""
+            width={17}
+            height={24}
+            className="h-6 w-auto shrink-0"
+            aria-hidden
+          />
+          <span className="min-w-0 text-sm font-medium tracking-tight text-white">
+            D2 Tuning Tracker
+          </span>
+        </Link>
+        {leadingAccessory ? (
+          <div className="pointer-events-auto flex shrink-0 items-center">
+            {leadingAccessory}
+          </div>
+        ) : null}
+      </div>
 
       <div className="pointer-events-auto flex flex-wrap items-center gap-2.5 sm:gap-3">
         <FeedbackHeaderDialog />

--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import type { SerializableTrackerPayload } from "@/lib/workspace/types";
+import type { WorkspaceCameraJson } from "@/lib/workspace/workspace-schema";
+import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
+import { AppHeader } from "@/components/app-header";
+import { CanvasWorkspace } from "@/components/workspace/canvas-workspace";
+import { InventoryTableView } from "@/components/dashboard/inventory-table-view";
+import {
+  WorkspaceViewModeTabs,
+  type WorkspaceViewMode,
+} from "@/components/dashboard/workspace-view-mode-tabs";
+
+export interface DashboardWorkspaceProps {
+  displayName: string;
+  profilePictureUrl: string | null;
+  banners: ReactNode;
+  initialTrackers: SerializableTrackerPayload[];
+  initialCamera: WorkspaceCameraJson;
+  focusTrackerId: string | null;
+  syncWarning: string | null;
+  hasInventory: boolean;
+  selectors: TrackerFormSelectors;
+  inventory: DerivedArmorPieceJson[];
+}
+
+export function DashboardWorkspace({
+  displayName,
+  profilePictureUrl,
+  banners,
+  initialTrackers,
+  initialCamera,
+  focusTrackerId,
+  syncWarning,
+  hasInventory,
+  selectors,
+  inventory,
+}: DashboardWorkspaceProps) {
+  const [mode, setMode] = useState<WorkspaceViewMode>("canvas");
+  const tabs = <WorkspaceViewModeTabs mode={mode} onModeChange={setMode} />;
+
+  return (
+    <>
+      <AppHeader
+        displayName={displayName}
+        profilePictureUrl={profilePictureUrl}
+        leadingAccessory={tabs}
+      />
+      {mode === "table" ? (
+        <InventoryTableView
+          banners={banners}
+          syncWarning={syncWarning}
+          hasInventory={hasInventory}
+          inventory={inventory}
+          selectors={selectors}
+        />
+      ) : (
+        <CanvasWorkspace
+          banners={banners}
+          initialTrackers={initialTrackers}
+          initialCamera={initialCamera}
+          focusTrackerId={focusTrackerId}
+          syncWarning={syncWarning}
+          hasInventory={hasInventory}
+          selectors={selectors}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { ARMOR_STAT_NAMES, type DerivedArmorPieceJson } from "@/lib/db/types";
+import {
+  CLASS_NAMES,
+  SLOT_LABELS,
+  SLOT_ORDER,
+  type ArmorSlot,
+} from "@/lib/bungie/constants";
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ArmorSetCombobox } from "@/components/views/armor-set-combobox";
+import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
+import { chromeToolbarShellClass } from "@/components/ui/chrome-square-icon-button";
+
+const ALL_SENTINEL = "__all__";
+
+type InventoryClass = 0 | 1 | 2;
+
+const CLASS_TABS: Array<{ value: InventoryClass; label: string }> = [
+  { value: 0, label: "Titan" },
+  { value: 1, label: "Hunter" },
+  { value: 2, label: "Warlock" },
+];
+
+function slotRank(slot: ArmorSlot): number {
+  return SLOT_ORDER.indexOf(slot);
+}
+
+function formatLocation(piece: DerivedArmorPieceJson): string {
+  const loc = piece.location;
+  if (loc.kind === "vault") return "Vault";
+  if (loc.equipped) return "Equipped";
+  return "Inventory";
+}
+
+interface InventoryTableViewProps {
+  className?: string;
+  banners?: ReactNode;
+  syncWarning: string | null;
+  hasInventory: boolean;
+  inventory: DerivedArmorPieceJson[];
+  selectors: TrackerFormSelectors;
+}
+
+export function InventoryTableView({
+  className = "",
+  banners,
+  syncWarning,
+  hasInventory,
+  inventory,
+  selectors,
+}: InventoryTableViewProps) {
+  const [inventoryClass, setInventoryClass] = useState<InventoryClass>(0);
+  const [setHash, setSetHash] = useState("");
+  const [archetypeHash, setArchetypeHash] = useState(ALL_SENTINEL);
+  const [tuningHash, setTuningHash] = useState(ALL_SENTINEL);
+  const [tertiaryStat, setTertiaryStat] = useState<string>(ALL_SENTINEL);
+
+  const sortedSets = useMemo(
+    () => selectors.setsByClass[inventoryClass],
+    [selectors.setsByClass, inventoryClass],
+  );
+
+  const sortedArchetypes = useMemo(
+    () => [...selectors.archetypes].sort((a, b) => a.name.localeCompare(b.name)),
+    [selectors.archetypes],
+  );
+  const sortedTunings = useMemo(
+    () => [...selectors.tunings].sort((a, b) => a.name.localeCompare(b.name)),
+    [selectors.tunings],
+  );
+
+  const filteredRows = useMemo(() => {
+    let rows = inventory.filter((p) => p.classType === inventoryClass);
+    if (setHash) {
+      const h = Number(setHash);
+      rows = rows.filter((p) => p.setHash === h);
+    }
+    if (archetypeHash !== ALL_SENTINEL) {
+      const h = Number(archetypeHash);
+      rows = rows.filter((p) => p.archetypeHash === h);
+    }
+    if (tuningHash !== ALL_SENTINEL) {
+      const h = Number(tuningHash);
+      rows = rows.filter((p) => p.tuningHash === h);
+    }
+    if (tertiaryStat !== ALL_SENTINEL) {
+      rows = rows.filter((p) => p.tertiaryStat === tertiaryStat);
+    }
+    rows = [...rows].sort((a, b) => {
+      const sd = slotRank(a.slot) - slotRank(b.slot);
+      if (sd !== 0) return sd;
+      const na = (a.setName ?? "").localeCompare(b.setName ?? "");
+      if (na !== 0) return na;
+      return a.itemHash - b.itemHash;
+    });
+    return rows;
+  }, [
+    inventory,
+    inventoryClass,
+    setHash,
+    archetypeHash,
+    tuningHash,
+    tertiaryStat,
+  ]);
+
+  const hasTopMessage = Boolean(banners) || Boolean(syncWarning);
+
+  return (
+    <div className={`flex min-h-0 flex-1 flex-col ${className}`}>
+      {hasTopMessage ? (
+        <div className="shrink-0 pt-[76px]">
+          {banners ? (
+            <div className="space-y-2 border-b border-border bg-background px-4 py-3 sm:px-6">
+              {banners}
+            </div>
+          ) : null}
+          {syncWarning ? (
+            <div className="border-b border-destructive/20 bg-destructive/10 px-4 py-2 sm:px-6">
+              <p role="alert" className="text-sm text-destructive">
+                {syncWarning}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-[#1a1b1b]">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto px-4 pb-8 pt-[4.75rem] sm:px-6">
+          {!hasInventory ? (
+            <p className="text-sm text-white/60">
+              No armor inventory loaded yet. Use Refresh in the header after
+              signing in with Bungie.
+            </p>
+          ) : (
+            <>
+              <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end lg:gap-x-4 lg:gap-y-3">
+                <div className="grid gap-2">
+                  <Label className="text-xs font-medium uppercase tracking-wide text-white/50">
+                    Class
+                  </Label>
+                  <div className={cn(chromeToolbarShellClass, "w-fit")}>
+                    {CLASS_TABS.map((tab, i) => (
+                      <button
+                        key={tab.value}
+                        type="button"
+                        className={cn(
+                          "flex h-10 shrink-0 items-center px-3 text-xs font-medium text-white/70 transition-colors hover:bg-white/[0.06] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/35",
+                          i > 0 && "border-l border-white/15",
+                          inventoryClass === tab.value &&
+                            "bg-white/[0.08] text-white",
+                        )}
+                        onClick={() => {
+                          setInventoryClass(tab.value);
+                          setSetHash((prev) =>
+                            prev &&
+                            selectors.setsByClass[tab.value].some(
+                              (s) => String(s.hash) === prev,
+                            )
+                              ? prev
+                              : "",
+                          );
+                        }}
+                      >
+                        {tab.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="grid min-w-[min(100%,14rem)] flex-1 gap-2">
+                  <Label htmlFor="inv-filter-set" className="text-white/50">
+                    Armor set
+                  </Label>
+                  <ArmorSetCombobox
+                    id="inv-filter-set"
+                    options={sortedSets}
+                    value={setHash}
+                    onValueChange={setSetHash}
+                    aria-label="Armor set filter"
+                    placeholder="Any armor set"
+                    sharpCorners
+                    emptyCatalogMessage={
+                      selectors.manifestEmpty
+                        ? "Sync the manifest first."
+                        : "No sets for this class."
+                    }
+                  />
+                </div>
+
+                <div className="grid min-w-[min(100%,12rem)] flex-1 gap-2">
+                  <Label htmlFor="inv-filter-archetype" className="text-white/50">
+                    Archetype
+                  </Label>
+                  <Select
+                    value={archetypeHash}
+                    onValueChange={setArchetypeHash}
+                  >
+                    <SelectTrigger
+                      id="inv-filter-archetype"
+                      aria-label="Archetype filter"
+                      className="rounded-none border-white/15 bg-[#2d2e32] text-white"
+                    >
+                      <SelectValue placeholder="Any archetype" />
+                    </SelectTrigger>
+                    <SelectContent className="rounded-none border-white/15 bg-[#2d2e32] text-white">
+                      <SelectItem
+                        value={ALL_SENTINEL}
+                        className="rounded-none focus:bg-white/10 focus:text-white"
+                      >
+                        Any archetype
+                      </SelectItem>
+                      {sortedArchetypes.length === 0 ? (
+                        <div className="px-2 py-3 text-sm text-white/50">
+                          No archetypes — sync the manifest first.
+                        </div>
+                      ) : (
+                        sortedArchetypes.map((a) => (
+                          <SelectItem
+                            key={a.hash}
+                            value={String(a.hash)}
+                            className="rounded-none focus:bg-white/10 focus:text-white"
+                          >
+                            {a.name}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="grid min-w-[min(100%,12rem)] flex-1 gap-2">
+                  <Label htmlFor="inv-filter-tuning" className="text-white/50">
+                    Tuning stat
+                  </Label>
+                  <Select value={tuningHash} onValueChange={setTuningHash}>
+                    <SelectTrigger
+                      id="inv-filter-tuning"
+                      aria-label="Tuning stat filter"
+                      className="rounded-none border-white/15 bg-[#2d2e32] text-white"
+                    >
+                      <SelectValue placeholder="Any tuning" />
+                    </SelectTrigger>
+                    <SelectContent className="rounded-none border-white/15 bg-[#2d2e32] text-white">
+                      <SelectItem
+                        value={ALL_SENTINEL}
+                        className="rounded-none focus:bg-white/10 focus:text-white"
+                      >
+                        Any tuning
+                      </SelectItem>
+                      {sortedTunings.length === 0 ? (
+                        <div className="px-2 py-3 text-sm text-white/50">
+                          No tunings — sync the manifest first.
+                        </div>
+                      ) : (
+                        sortedTunings.map((t) => (
+                          <SelectItem
+                            key={t.hash}
+                            value={String(t.hash)}
+                            className="rounded-none focus:bg-white/10 focus:text-white"
+                          >
+                            {t.name}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="grid min-w-[min(100%,12rem)] flex-1 gap-2">
+                  <Label htmlFor="inv-filter-tertiary" className="text-white/50">
+                    Tertiary stat
+                  </Label>
+                  <Select value={tertiaryStat} onValueChange={setTertiaryStat}>
+                    <SelectTrigger
+                      id="inv-filter-tertiary"
+                      aria-label="Tertiary stat filter"
+                      className="rounded-none border-white/15 bg-[#2d2e32] text-white"
+                    >
+                      <SelectValue placeholder="Any tertiary" />
+                    </SelectTrigger>
+                    <SelectContent className="rounded-none border-white/15 bg-[#2d2e32] text-white">
+                      <SelectItem
+                        value={ALL_SENTINEL}
+                        className="rounded-none focus:bg-white/10 focus:text-white"
+                      >
+                        Any tertiary
+                      </SelectItem>
+                      {ARMOR_STAT_NAMES.map((stat) => (
+                        <SelectItem
+                          key={stat}
+                          value={stat}
+                          className="rounded-none focus:bg-white/10 focus:text-white"
+                        >
+                          {stat}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <p className="text-xs text-white/45">
+                Showing {filteredRows.length} piece
+                {filteredRows.length === 1 ? "" : "s"} for{" "}
+                {CLASS_NAMES[inventoryClass] ?? "class"}.
+              </p>
+
+              <div className="rounded-none border border-white/10 bg-[#141515]/80">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-white/10 hover:bg-transparent">
+                      <TableHead className="text-white/60">Slot</TableHead>
+                      <TableHead className="text-white/60">Armor set</TableHead>
+                      <TableHead className="text-white/60">Archetype</TableHead>
+                      <TableHead className="text-white/60">Tuning</TableHead>
+                      <TableHead className="text-white/60">Primary</TableHead>
+                      <TableHead className="text-white/60">Secondary</TableHead>
+                      <TableHead className="text-white/60">Tertiary</TableHead>
+                      <TableHead className="text-white/60">Location</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredRows.length === 0 ? (
+                      <TableRow className="border-white/10 hover:bg-white/[0.02]">
+                        <TableCell
+                          colSpan={8}
+                          className="py-8 text-center text-sm text-white/50"
+                        >
+                          No armor matches these filters.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      filteredRows.map((piece) => (
+                        <TableRow
+                          key={piece.itemInstanceId}
+                          className="border-white/10 hover:bg-white/[0.04]"
+                        >
+                          <TableCell className="font-medium text-white">
+                            {SLOT_LABELS[piece.slot]}
+                          </TableCell>
+                          <TableCell className="text-white/90">
+                            {piece.setName ?? "—"}
+                          </TableCell>
+                          <TableCell className="text-white/90">
+                            {piece.archetypeName ?? "—"}
+                          </TableCell>
+                          <TableCell className="text-white/90">
+                            {piece.tuningName ?? "—"}
+                          </TableCell>
+                          <TableCell className="text-white/80">
+                            {piece.primaryStat ?? "—"}
+                          </TableCell>
+                          <TableCell className="text-white/80">
+                            {piece.secondaryStat ?? "—"}
+                          </TableCell>
+                          <TableCell className="text-white/80">
+                            {piece.tertiaryStat ?? "—"}
+                          </TableCell>
+                          <TableCell className="text-white/70">
+                            {formatLocation(piece)}
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/workspace-view-mode-tabs.tsx
+++ b/src/components/dashboard/workspace-view-mode-tabs.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { SquaresFour, Table } from "@phosphor-icons/react/dist/ssr";
+import { cn } from "@/lib/utils";
+import { chromeToolbarShellClass } from "@/components/ui/chrome-square-icon-button";
+
+export type WorkspaceViewMode = "canvas" | "table";
+
+interface WorkspaceViewModeTabsProps {
+  mode: WorkspaceViewMode;
+  onModeChange: (mode: WorkspaceViewMode) => void;
+}
+
+const segmentBtn =
+  "flex h-10 shrink-0 items-center gap-1.5 px-3 text-xs font-medium uppercase tracking-wide text-white/70 transition-colors hover:bg-white/[0.06] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/35 disabled:pointer-events-none disabled:opacity-50";
+
+export function WorkspaceViewModeTabs({
+  mode,
+  onModeChange,
+}: WorkspaceViewModeTabsProps) {
+  return (
+    <div
+      className={cn(chromeToolbarShellClass, "pointer-events-auto")}
+      role="tablist"
+      aria-label="Workspace view"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "canvas"}
+        className={cn(
+          segmentBtn,
+          mode === "canvas" && "bg-white/[0.08] text-white",
+        )}
+        onClick={() => onModeChange("canvas")}
+      >
+        <SquaresFour className="h-4 w-4" weight="duotone" aria-hidden />
+        Canvas
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "table"}
+        className={cn(
+          segmentBtn,
+          "border-l border-white/15",
+          mode === "table" && "bg-white/[0.08] text-white",
+        )}
+        onClick={() => onModeChange("table")}
+      >
+        <Table className="h-4 w-4" weight="duotone" aria-hidden />
+        Table
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -16,9 +16,12 @@ const PopoverPortal = PopoverPrimitive.Portal;
 
 const PopoverContent = React.forwardRef<
   React.ComponentRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPortal>
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    /** Portal mount node (defaults to `document.body`). Use a parent modal node so nested pickers scroll under react-remove-scroll. */
+    container?: HTMLElement | null;
+  }
+>(({ className, align = "center", sideOffset = 4, container, ...props }, ref) => (
+  <PopoverPortal container={container ?? undefined}>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}

--- a/src/components/views/armor-set-combobox.tsx
+++ b/src/components/views/armor-set-combobox.tsx
@@ -26,6 +26,11 @@ interface ArmorSetComboboxProps {
   sharpCorners?: boolean;
   /** Highlight as invalid (e.g. after submit with empty required value). */
   invalid?: boolean;
+  /**
+   * Mount the popover inside this element instead of `document.body`.
+   * Required for wheel scrolling inside a Radix modal (RemoveScroll only allows scroll in dialog shards).
+   */
+  portalContainer?: HTMLElement | null;
   "aria-label"?: string;
 }
 
@@ -39,6 +44,7 @@ export function ArmorSetCombobox({
   emptyCatalogMessage = "No sets available — sync the manifest first.",
   sharpCorners = false,
   invalid = false,
+  portalContainer,
   "aria-label": ariaLabel,
 }: ArmorSetComboboxProps) {
   const listboxId = useId();
@@ -124,8 +130,10 @@ export function ArmorSetCombobox({
       <PopoverContent
         align="start"
         sideOffset={4}
+        container={portalContainer}
+        data-skip-canvas-wheel=""
         className={cn(
-          "z-[90] overflow-hidden border border-border bg-popover p-0 text-popover-foreground shadow-xl outline-none",
+          "z-[90] flex flex-col overflow-hidden border border-border bg-popover p-0 text-popover-foreground shadow-xl outline-none",
           sharpCorners ? "rounded-none" : "rounded-lg",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:duration-150",
@@ -136,61 +144,63 @@ export function ArmorSetCombobox({
           queueMicrotask(() => searchRef.current?.focus({ preventScroll: true }));
         }}
       >
-        <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 pb-2 pt-1.5">
-          <MagnifyingGlass
-            weight="regular"
-            className="pointer-events-none h-4 w-4 shrink-0 text-muted-foreground"
-            aria-hidden
-          />
-          <input
-            ref={searchRef}
-            type="text"
-            value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setHighlightIndex(0);
-            }}
-            placeholder="Search armor sets..."
-            aria-label="Search armor sets"
-            className={cn(
-              "h-8 w-full min-w-0 bg-transparent px-2 py-0 text-sm text-foreground caret-foreground outline-none placeholder:text-muted-foreground",
-              "border-0 border-transparent shadow-none ring-0 focus:border-transparent focus-visible:ring-0 focus:ring-0",
-              sharpCorners ? "rounded-none" : "rounded-md",
-            )}
-            onKeyDown={(e) => {
-              if (!filtered.length) return;
-              if (e.key === "ArrowDown") {
-                e.preventDefault();
-                setHighlightIndex((i) =>
-                  Math.min(i + 1, filtered.length - 1),
-                );
-              }
-              if (e.key === "ArrowUp") {
-                e.preventDefault();
-                setHighlightIndex((i) => Math.max(i - 1, 0));
-              }
-              if (e.key === "Enter") {
-                e.preventDefault();
-                const picked = filtered[focusedIndex];
-                if (picked) select(String(picked.hash));
-              }
-              if (e.key === "Home") {
-                e.preventDefault();
+        <div className="flex max-h-[min(90vh,24rem)] flex-col overflow-hidden">
+          <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 pb-2 pt-1.5">
+            <MagnifyingGlass
+              weight="regular"
+              className="pointer-events-none h-4 w-4 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
                 setHighlightIndex(0);
-              }
-              if (e.key === "End") {
-                e.preventDefault();
-                setHighlightIndex(filtered.length - 1);
-              }
-            }}
-          />
-        </div>
-        <ul
-          id={listboxId}
-          role="listbox"
-          className="max-h-60 overflow-y-auto px-0 py-1 motion-reduce:scroll-auto"
-        >
-          {filtered.length === 0 ? (
+              }}
+              placeholder="Search armor sets..."
+              aria-label="Search armor sets"
+              className={cn(
+                "h-8 w-full min-w-0 bg-transparent px-2 py-0 text-sm text-foreground caret-foreground outline-none placeholder:text-muted-foreground",
+                "border-0 border-transparent shadow-none ring-0 focus:border-transparent focus-visible:ring-0 focus:ring-0",
+                sharpCorners ? "rounded-none" : "rounded-md",
+              )}
+              onKeyDown={(e) => {
+                if (!filtered.length) return;
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  setHighlightIndex((i) =>
+                    Math.min(i + 1, filtered.length - 1),
+                  );
+                }
+                if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  setHighlightIndex((i) => Math.max(i - 1, 0));
+                }
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const picked = filtered[focusedIndex];
+                  if (picked) select(String(picked.hash));
+                }
+                if (e.key === "Home") {
+                  e.preventDefault();
+                  setHighlightIndex(0);
+                }
+                if (e.key === "End") {
+                  e.preventDefault();
+                  setHighlightIndex(filtered.length - 1);
+                }
+              }}
+            />
+          </div>
+          <ul
+            id={listboxId}
+            role="listbox"
+            data-skip-canvas-wheel=""
+            className="max-h-60 min-h-0 touch-pan-y overflow-y-auto overscroll-contain px-0 py-1 motion-reduce:scroll-auto"
+          >
+            {filtered.length === 0 ? (
             <li className="px-2 py-2.5 text-sm text-muted-foreground">
               {options.length === 0 ? emptyCatalogMessage : "No matches."}
             </li>
@@ -226,8 +236,9 @@ export function ArmorSetCombobox({
                 </li>
               );
             })
-          )}
-        </ul>
+            )}
+          </ul>
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/src/components/views/merged-compare-grid.tsx
+++ b/src/components/views/merged-compare-grid.tsx
@@ -339,7 +339,7 @@ export function MergedCompareGrid({
                             <span
                               role="img"
                               aria-label={EXOTIC_SLOT_HINT_TITLE}
-                              className="pointer-events-auto box-content absolute left-full top-1/2 ml-1.5 size-[8px] -translate-y-1/2 cursor-default !rounded-none border border-solid border-white bg-[#e8b84a] shadow-[0_0_4px_-1px_rgba(232,184,74,0.6)] [border-image:linear-gradient(130deg,rgba(255,255,255,0.24)_0%,rgba(77,71,10,0.24)_100%)_1]"
+                              className="pointer-events-auto overflow-hidden box-content absolute left-full top-1/2 ml-1.5 size-[8px] -translate-y-1/2 cursor-default rounded-[2px] border border-solid border-white/12 bg-[linear-gradient(140deg,rgba(232,184,74,1)_0%,rgba(218,186,114,1)_100%)] text-[rgba(255,255,255,0)] shadow-[0_0_4px_-1px_rgba(232,184,74,0.6)]"
                             />
                           </TooltipTrigger>
                           <TooltipContent>

--- a/src/components/views/new-view-form.tsx
+++ b/src/components/views/new-view-form.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, FloppyDisk } from "@phosphor-icons/react/dist/ssr";
 import { toast } from "sonner";
@@ -38,7 +45,35 @@ export interface NewTrackerLayoutDraft {
   className: string;
 }
 
+/** Initial values for duplicate / pre-filled create. Use `class_type` from DB; negative legacy values leave class unset in the form. */
+export interface NewViewFormPrefill {
+  name: string;
+  classType: number;
+  setHash: number;
+  archetypeHash: number;
+  tuningHash: number;
+}
+
 type ClassValue = "0" | "1" | "2";
+
+type PrefillBaseline = {
+  name: string;
+  classType: ClassValue | "";
+  setHash: string;
+  archetypeHash: string;
+  tuningHash: string;
+};
+
+function baselineFromPrefill(prefill: NewViewFormPrefill): PrefillBaseline {
+  return {
+    name: prefill.name.trim(),
+    classType:
+      prefill.classType >= 0 ? (String(prefill.classType) as ClassValue) : "",
+    setHash: String(prefill.setHash),
+    archetypeHash: String(prefill.archetypeHash),
+    tuningHash: String(prefill.tuningHash),
+  };
+}
 
 interface NewViewFormProps {
   setsByClass: { 0: OptionItem[]; 1: OptionItem[]; 2: OptionItem[] };
@@ -57,13 +92,35 @@ interface NewViewFormProps {
    * (e.g. viewport center or cluster-aware placement). Overrides {@link initialLayout}.
    */
   resolveLayoutOnSubmit?: (draft: NewTrackerLayoutDraft) => WorkspaceLayoutJson;
+  /** Populate fields (e.g. duplicate). Prefer remounting the form with `key` when the source changes. */
+  prefillFrom?: NewViewFormPrefill;
+  /**
+   * When true with {@link prefillFrom}, submit stays disabled until at least one field differs from the pre-fill.
+   */
+  requireChangeFromPrefill?: boolean;
+  /**
+   * With {@link embedded} + {@link externalSubmit}, hide the inline cancel row so the parent can render a shared footer (e.g. dialog).
+   */
+  suppressEmbeddedActionRow?: boolean;
   /** Includes `tracker` when the API returns workspace payload so the dashboard can merge without refetching. */
   onCreated?: (viewId: string, tracker?: SerializableTrackerPayload) => void;
   onCancel?: () => void;
   onBusyChange?: (busy: boolean) => void;
   /** Fires when embedded “Create” via external submit becomes allowed (all required fields + not busy). */
   onCanSubmitChange?: (canSubmit: boolean) => void;
+  /** Whether name, class, set, archetype, and tuning are all set (independent of duplicate “must change” rule). */
+  onFieldsCompleteChange?: (complete: boolean) => void;
+  /**
+   * When set, the armor set dropdown panel portals into this node (e.g. the dialog content element)
+   * so the list stays wheel-scrollable under Radix modal scroll lock.
+   */
+  armorSetComboboxPortalContainer?: HTMLElement | null;
 }
+
+export type NewViewFormHandle = {
+  /** Turns the duplicate-flow hint red (blocked create: unchanged from pre-fill). */
+  signalUnchangedDuplicateAttempt: () => void;
+};
 
 const CLASS_OPTIONS: Array<{ value: ClassValue; label: string }> = [
   { value: "0", label: "Titan" },
@@ -71,20 +128,29 @@ const CLASS_OPTIONS: Array<{ value: ClassValue; label: string }> = [
   { value: "2", label: "Warlock" },
 ];
 
-export function NewViewForm({
-  setsByClass,
-  archetypes,
-  tunings,
-  embedded,
-  formId,
-  externalSubmit,
-  initialLayout,
-  resolveLayoutOnSubmit,
-  onCreated,
-  onCancel,
-  onBusyChange,
-  onCanSubmitChange,
-}: NewViewFormProps) {
+export const NewViewForm = forwardRef<NewViewFormHandle, NewViewFormProps>(
+  function NewViewForm(
+    {
+      setsByClass,
+      archetypes,
+      tunings,
+      embedded,
+      formId,
+      externalSubmit,
+      initialLayout,
+      resolveLayoutOnSubmit,
+      prefillFrom,
+      requireChangeFromPrefill = false,
+      onCreated,
+      onCancel,
+      onBusyChange,
+      onCanSubmitChange,
+      onFieldsCompleteChange,
+      suppressEmbeddedActionRow = false,
+      armorSetComboboxPortalContainer,
+    },
+    ref,
+  ) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [submitting, setSubmitting] = useState(false);
@@ -93,12 +159,35 @@ export function NewViewForm({
     onBusyChange?.(submitting || isPending);
   }, [submitting, isPending, onBusyChange]);
 
-  const [name, setName] = useState("");
-  const [classType, setClassType] = useState<ClassValue | "">("");
-  const [setHash, setSetHash] = useState<string>("");
-  const [archetypeHash, setArchetypeHash] = useState<string>("");
-  const [tuningHash, setTuningHash] = useState<string>("");
+  const [name, setName] = useState(() => prefillFrom?.name ?? "");
+  const [classType, setClassType] = useState<ClassValue | "">(() =>
+    prefillFrom && prefillFrom.classType >= 0
+      ? (String(prefillFrom.classType) as ClassValue)
+      : "",
+  );
+  const [setHash, setSetHash] = useState(() =>
+    prefillFrom ? String(prefillFrom.setHash) : "",
+  );
+  const [archetypeHash, setArchetypeHash] = useState(() =>
+    prefillFrom ? String(prefillFrom.archetypeHash) : "",
+  );
+  const [tuningHash, setTuningHash] = useState(() =>
+    prefillFrom ? String(prefillFrom.tuningHash) : "",
+  );
   const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [unchangedDuplicateSubmitAttempted, setUnchangedDuplicateSubmitAttempted] =
+    useState(false);
+
+  useImperativeHandle(ref, () => ({
+    signalUnchangedDuplicateAttempt: () => {
+      setUnchangedDuplicateSubmitAttempted(true);
+    },
+  }));
+
+  const prefillBaseline = useMemo((): PrefillBaseline | null => {
+    if (!prefillFrom) return null;
+    return baselineFromPrefill(prefillFrom);
+  }, [prefillFrom]);
 
   const sortedSets = useMemo(() => {
     if (classType !== "") {
@@ -133,21 +222,50 @@ export function NewViewForm({
       (CLASS_OPTIONS.find((o) => o.value === classType)?.label ?? "")
     : "";
 
-  const canSubmit =
+  const matchesPrefill =
+    Boolean(prefillBaseline) &&
+    name.trim() === prefillBaseline!.name &&
+    classType === prefillBaseline!.classType &&
+    setHash === prefillBaseline!.setHash &&
+    archetypeHash === prefillBaseline!.archetypeHash &&
+    tuningHash === prefillBaseline!.tuningHash;
+
+  const blockedUnchangedDuplicate =
+    Boolean(requireChangeFromPrefill && prefillBaseline && matchesPrefill);
+
+  const fieldsComplete =
     name.trim().length > 0 &&
     classType !== "" &&
     setHash !== "" &&
     archetypeHash !== "" &&
-    tuningHash !== "" &&
-    !submitting;
+    tuningHash !== "";
+
+  const canSubmit =
+    fieldsComplete && !submitting && !blockedUnchangedDuplicate;
 
   const canSubmitWithTransition = canSubmit && !isPending;
+
+  const showUnchangedHint =
+    Boolean(
+      requireChangeFromPrefill &&
+        prefillBaseline &&
+        fieldsComplete &&
+        matchesPrefill,
+    );
 
   const sharpMenus = Boolean(embedded);
 
   useEffect(() => {
     onCanSubmitChange?.(canSubmitWithTransition);
   }, [canSubmitWithTransition, onCanSubmitChange]);
+
+  useEffect(() => {
+    onFieldsCompleteChange?.(fieldsComplete);
+  }, [fieldsComplete, onFieldsCompleteChange]);
+
+  useEffect(() => {
+    if (!matchesPrefill) setUnchangedDuplicateSubmitAttempted(false);
+  }, [matchesPrefill]);
 
   useEffect(() => {
     if (canSubmit) setSubmitAttempted(false);
@@ -175,6 +293,9 @@ export function NewViewForm({
     e.preventDefault();
     if (!canSubmit) {
       setSubmitAttempted(true);
+      if (blockedUnchangedDuplicate) {
+        setUnchangedDuplicateSubmitAttempted(true);
+      }
       return;
     }
 
@@ -211,6 +332,13 @@ export function NewViewForm({
         view?: { id: string };
         tracker?: SerializableTrackerPayload;
       };
+      if (res.status === 409) {
+        toast.error(
+          body.error ??
+            "A tracker with this name and build already exists. Change something and try again.",
+        );
+        return;
+      }
       if (!res.ok || !body.view) {
         toast.error(body.error ?? "Could not create view");
         return;
@@ -283,6 +411,7 @@ export function NewViewForm({
           placeholder="Select an armor set"
           sharpCorners={sharpMenus}
           invalid={showSetError}
+          portalContainer={armorSetComboboxPortalContainer}
         />
       </div>
 
@@ -378,33 +507,54 @@ export function NewViewForm({
         </p>
       </div>
 
-      <div
-        className={`flex gap-3 pt-2 ${embedded && externalSubmit ? "justify-start" : "items-center justify-between"}`}
-      >
-        {embedded && onCancel ? (
-          <Button variant="ghost" type="button" onClick={() => onCancel()}>
-            <ArrowLeft weight="duotone" />
-            Cancel
-          </Button>
-        ) : (
-          <Button asChild variant="ghost" type="button">
-            <Link href="/dashboard">
+      {showUnchangedHint ? (
+        <p
+          className={cn(
+            "text-xs",
+            unchangedDuplicateSubmitAttempted
+              ? "text-destructive"
+              : "text-muted-foreground",
+          )}
+        >
+          Change something to create a new tracker.
+        </p>
+      ) : null}
+
+      {!(
+        embedded &&
+        externalSubmit &&
+        suppressEmbeddedActionRow
+      ) ?
+        <div
+          className={`flex gap-3 pt-2 ${embedded && externalSubmit ? "justify-start" : "items-center justify-between"}`}
+        >
+          {embedded && onCancel ?
+            <Button variant="ghost" type="button" onClick={() => onCancel()}>
               <ArrowLeft weight="duotone" />
               Cancel
-            </Link>
-          </Button>
-        )}
-        {!externalSubmit ? (
-          <Button type="submit" disabled={!canSubmit || isPending}>
-            <FloppyDisk weight="duotone" />
-            {submitting || isPending
-              ? "Saving..."
-              : embedded
-                ? "Create tracker"
-                : "Create view"}
-          </Button>
-        ) : null}
-      </div>
+            </Button>
+          : (
+            <Button asChild variant="ghost" type="button">
+              <Link href="/dashboard">
+                <ArrowLeft weight="duotone" />
+                Cancel
+              </Link>
+            </Button>
+          )}
+          {!externalSubmit ?
+            <Button type="submit" disabled={!canSubmit || isPending}>
+              <FloppyDisk weight="duotone" />
+              {submitting || isPending
+                ? "Saving..."
+                : embedded
+                  ? "Create tracker"
+                  : "Create view"}
+            </Button>
+          : null}
+        </div>
+      : null}
     </form>
   );
-}
+});
+
+NewViewForm.displayName = "NewViewForm";

--- a/src/components/views/tuning-header-glyph.tsx
+++ b/src/components/views/tuning-header-glyph.tsx
@@ -21,12 +21,6 @@ export function TuningHeaderGlyph({ tuningName, iconPath }: TuningHeaderGlyphPro
     <Tooltip>
       <TooltipTrigger asChild>
         <div className="flex shrink-0 cursor-default items-center gap-1.5 text-white/45">
-          <span
-            className="text-lg font-medium leading-none tabular-nums tracking-tight"
-            aria-hidden
-          >
-            +/-
-          </span>
           {iconPath ? (
             // eslint-disable-next-line @next/next/no-img-element -- Bungie CDN
             <img
@@ -44,7 +38,12 @@ export function TuningHeaderGlyph({ tuningName, iconPath }: TuningHeaderGlyphPro
               +
             </span>
           )}
-          <span className="sr-only">Tuning: {tuningName}</span>
+          <span className="text-sm font-medium leading-none" aria-hidden>
+            Tuning
+          </span>
+          <span className="sr-only">
+            Tuning: {tuningName}
+          </span>
         </div>
       </TooltipTrigger>
       <TooltipContent>Tuning: {tuningName}</TooltipContent>

--- a/src/components/workspace/canvas-viewport-wheel.ts
+++ b/src/components/workspace/canvas-viewport-wheel.ts
@@ -95,11 +95,16 @@ export function attachCanvasViewportWheel(
   getMinScale: () => number,
 ): () => void {
   const onWheel = (e: WheelEvent) => {
-    // Targets may be SVG elements (icon paths), so use the general Element
-    // interface — HTMLElement would miss Phosphor icon hits and make the
-    // handler silently no-op as the cursor passes over them.
     const t = e.target;
-    if (!t || !(t instanceof Element)) return;
+    if (!t) return;
+
+    // Wheel targets are often Text nodes or deep SVG paths; walk the full path
+    // so portaled UI (e.g. armor set popover) still opts out of canvas routing.
+    for (const n of typeof e.composedPath === "function" ? e.composedPath() : []) {
+      if (n instanceof Element && n.hasAttribute("data-skip-canvas-wheel")) {
+        return;
+      }
+    }
 
     // While a Radix modal/alert dialog is open, leave wheels outside the
     // dialog content alone. The dialog and its scrollable body handle their
@@ -108,7 +113,7 @@ export function attachCanvasViewportWheel(
     const openModal = document.querySelector(
       '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
     );
-    if (openModal && !openModal.contains(t)) return;
+    if (openModal && t instanceof Node && !openModal.contains(t)) return;
 
     const api = getApi();
     if (!api?.state || typeof api.setTransform !== "function") return;
@@ -132,8 +137,17 @@ export function attachCanvasViewportWheel(
     // tracker bodies) that can still scroll in the wheel direction. Zoom
     // gestures always route to canvas.
     if (!isZoomGesture) {
-      const scrollable = findScrollableAncestor(t, document.body, dx, dy);
-      if (scrollable) return;
+      const scrollFrom: Element | null =
+        t instanceof Element ? t : t instanceof Node ? t.parentElement : null;
+      if (scrollFrom) {
+        const scrollable = findScrollableAncestor(
+          scrollFrom,
+          document.body,
+          dx,
+          dy,
+        );
+        if (scrollable) return;
+      }
     }
 
     e.preventDefault();

--- a/src/components/workspace/canvas-workspace.tsx
+++ b/src/components/workspace/canvas-workspace.tsx
@@ -70,6 +70,7 @@ import {
   chromeToolbarInsetSegmentTileClass,
   chromeToolbarShellClass,
 } from "@/components/ui/chrome-square-icon-button";
+import { DuplicateTrackerDialog } from "@/components/workspace/duplicate-tracker-dialog";
 import {
   NewTrackerDialog,
   type TrackerFormSelectors,
@@ -217,6 +218,7 @@ function TrackerLayer({
   mergeDropTargetId,
   mergeDropValid,
   onUnmergeAnchor,
+  onRequestDuplicate,
   spawnHighlightId,
   easeLayoutPulse,
 }: {
@@ -235,6 +237,7 @@ function TrackerLayer({
   mergeDropTargetId: string | null;
   mergeDropValid: boolean;
   onUnmergeAnchor: (anchorViewId: string) => void;
+  onRequestDuplicate?: (payload: SerializableTrackerPayload) => void;
   spawnHighlightId: string | null;
   easeLayoutPulse: { durationMs: number } | null;
 }) {
@@ -277,6 +280,9 @@ function TrackerLayer({
                 ? () => onUnmergeAnchor(t.view.id)
                 : undefined
             }
+            onRequestDuplicate={
+              mergeRole === "mergedPartner" ? undefined : onRequestDuplicate
+            }
             spawnHighlight={spawnHighlightId === t.view.id}
             easeLayoutPulse={easeLayoutPulse}
           />
@@ -310,6 +316,8 @@ export function CanvasWorkspace({
   const router = useRouter();
   const [trackers, setTrackers] = useState(initialTrackers);
   const [newTrackerOpen, setNewTrackerOpen] = useState(false);
+  const [duplicateSource, setDuplicateSource] =
+    useState<SerializableTrackerPayload | null>(null);
   const twRef = useRef<ReactZoomPanPinchContentRef | null>(null);
   const viewportSurfaceRef = useRef<HTMLDivElement | null>(null);
   const lastFocused = useRef<string | null>(null);
@@ -772,7 +780,7 @@ export function CanvasWorkspace({
       const groupBySecondary =
         opts?.groupBySecondary ?? arrangeMenuRecipeRef.current.groupBySecondary ?? null;
 
-      const adjustViewport = opts?.adjustViewport ?? true;
+      const adjustViewport = opts?.adjustViewport ?? false;
       const animateLayouts = opts?.animateLayouts === true;
 
       const usesClassColumns =
@@ -871,7 +879,6 @@ export function CanvasWorkspace({
         sort: recipe.sort,
         groupBy: recipe.groupBy,
         groupBySecondary: recipe.groupBySecondary,
-        adjustViewport: false,
         animateLayouts: true,
       });
     },
@@ -1326,6 +1333,10 @@ export function CanvasWorkspace({
                   mergeDropTargetId={mergeDropTargetId}
                   mergeDropValid={mergeDropValid}
                   onUnmergeAnchor={handleUnmergeAnchor}
+                  onRequestDuplicate={(payload) => {
+                    setNewTrackerOpen(false);
+                    setDuplicateSource(payload);
+                  }}
                   spawnHighlightId={spawnHighlightId}
                   easeLayoutPulse={easeLayoutPulse}
                 />
@@ -1476,7 +1487,30 @@ export function CanvasWorkspace({
             <div className="pointer-events-none absolute bottom-6 left-1/2 z-30 flex -translate-x-1/2 gap-2">
               <NewTrackerDialog
                 open={newTrackerOpen}
-                onOpenChange={setNewTrackerOpen}
+                onOpenChange={(open) => {
+                  setNewTrackerOpen(open);
+                  if (open) setDuplicateSource(null);
+                }}
+                selectors={selectors}
+                resolveLayoutOnSubmit={resolveNewTrackerLayout}
+                onCreated={(tracker) => {
+                  if (tracker) {
+                    setTrackers((prev) =>
+                      prev.some((t) => t.view.id === tracker.view.id)
+                        ? prev
+                        : [...prev, tracker],
+                    );
+                    scheduleSpawnHighlight(tracker.view.id);
+                  } else {
+                    router.refresh();
+                  }
+                }}
+              />
+              <DuplicateTrackerDialog
+                source={duplicateSource}
+                onOpenChange={(open) => {
+                  if (!open) setDuplicateSource(null);
+                }}
                 selectors={selectors}
                 resolveLayoutOnSubmit={resolveNewTrackerLayout}
                 onCreated={(tracker) => {

--- a/src/components/workspace/duplicate-tracker-dialog.tsx
+++ b/src/components/workspace/duplicate-tracker-dialog.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { Warning } from "@phosphor-icons/react/dist/ssr";
+import {
+  NewViewForm,
+  type NewTrackerLayoutDraft,
+  type NewViewFormHandle,
+} from "@/components/views/new-view-form";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
+import type { WorkspaceLayoutJson } from "@/lib/workspace/workspace-schema";
+import type { SerializableTrackerPayload } from "@/lib/workspace/types";
+
+const WORKSPACE_DUPLICATE_TRACKER_FORM_ID = "workspace-duplicate-tracker-form";
+
+interface DuplicateTrackerDialogProps {
+  source: SerializableTrackerPayload | null;
+  onOpenChange: (open: boolean) => void;
+  selectors: TrackerFormSelectors;
+  onCreated: (tracker?: SerializableTrackerPayload) => void;
+  resolveLayoutOnSubmit?: (draft: NewTrackerLayoutDraft) => WorkspaceLayoutJson;
+}
+
+export function DuplicateTrackerDialog({
+  source,
+  onOpenChange,
+  selectors,
+  onCreated,
+  resolveLayoutOnSubmit,
+}: DuplicateTrackerDialogProps) {
+  const formRef = useRef<NewViewFormHandle>(null);
+  const [armorSetComboboxPortalContainer, setArmorSetComboboxPortalContainer] =
+    useState<HTMLElement | null>(null);
+  const dialogContentRef = useCallback((node: HTMLElement | null) => {
+    setArmorSetComboboxPortalContainer(node);
+  }, []);
+  const [submitBusy, setSubmitBusy] = useState(false);
+  const [canSubmitForm, setCanSubmitForm] = useState(false);
+  const [fieldsComplete, setFieldsComplete] = useState(false);
+
+  const open = source !== null;
+  const showUnchangedBlockedLayer =
+    fieldsComplete && !canSubmitForm && !submitBusy && !selectors.manifestEmpty;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          setCanSubmitForm(false);
+          setFieldsComplete(false);
+          onOpenChange(false);
+        }
+      }}
+    >
+      <DialogContent
+        ref={dialogContentRef}
+        className="max-h-[min(90vh,44rem)] max-w-lg overflow-y-auto rounded-none border-[#424347] bg-[#2d2e32] p-8 text-white shadow-xl sm:rounded-none [&_.text-muted-foreground]:text-white/65"
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        {source ?
+          <>
+            <DialogHeader className="space-y-2 text-left">
+              <DialogTitle className="text-lg font-semibold text-white">
+                Duplicate tracker
+              </DialogTitle>
+              <DialogDescription className="text-sm text-white/65">
+                Adjust anything that should differ from &quot;{source.view.name}
+                &quot;, then create the new tracker on your canvas.
+              </DialogDescription>
+            </DialogHeader>
+
+            {selectors.manifestEmpty ?
+              <div
+                role="alert"
+                className="flex items-start gap-3 rounded-none border border-amber-500/30 bg-amber-500/10 p-4 text-sm"
+              >
+                <Warning
+                  weight="duotone"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-amber-500"
+                />
+                <div className="space-y-1">
+                  <p className="font-medium">Manifest not synced</p>
+                  <p className="text-muted-foreground">
+                    Selectors stay empty until a manifest sync completes.
+                  </p>
+                </div>
+              </div>
+            : null}
+
+            <NewViewForm
+              ref={formRef}
+              key={source.view.id}
+              armorSetComboboxPortalContainer={armorSetComboboxPortalContainer}
+              setsByClass={selectors.setsByClass}
+              archetypes={selectors.archetypes}
+              tunings={selectors.tunings}
+              embedded
+              formId={WORKSPACE_DUPLICATE_TRACKER_FORM_ID}
+              externalSubmit
+              suppressEmbeddedActionRow
+              resolveLayoutOnSubmit={resolveLayoutOnSubmit}
+              prefillFrom={{
+                name: source.view.name,
+                classType: source.view.class_type,
+                setHash: source.view.set_hash,
+                archetypeHash: source.view.archetype_hash,
+                tuningHash: source.view.tuning_hash,
+              }}
+              requireChangeFromPrefill
+              onBusyChange={setSubmitBusy}
+              onCanSubmitChange={setCanSubmitForm}
+              onFieldsCompleteChange={setFieldsComplete}
+              onCreated={(_viewId, tracker) => {
+                onCreated(tracker);
+                onOpenChange(false);
+              }}
+            />
+
+            <DialogFooter className="w-full gap-2 sm:items-center sm:justify-start sm:gap-2 sm:space-x-0">
+              <Button
+                type="button"
+                variant="outline"
+                className="h-9 w-fit shrink-0 self-start rounded-none"
+                onClick={() => onOpenChange(false)}
+                disabled={submitBusy}
+              >
+                Cancel
+              </Button>
+              <div className="relative min-w-0 sm:flex-1 sm:w-auto">
+                <Button
+                  type="submit"
+                  form={WORKSPACE_DUPLICATE_TRACKER_FORM_ID}
+                  disabled={
+                    !canSubmitForm ||
+                    submitBusy ||
+                    selectors.manifestEmpty
+                  }
+                  className="relative h-9 min-w-0 w-full rounded-none border border-transparent"
+                >
+                  {submitBusy ? "Saving..." : "Create tracker"}
+                </Button>
+                {showUnchangedBlockedLayer ?
+                  <button
+                    type="button"
+                    tabIndex={-1}
+                    aria-label="Create tracker unavailable: change something from the duplicate first"
+                    className="absolute inset-0 z-[1] cursor-not-allowed bg-transparent"
+                    onClick={() =>
+                      formRef.current?.signalUnchangedDuplicateAttempt()}
+                  />
+                : null}
+              </div>
+            </DialogFooter>
+          </>
+        : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/workspace/tracker-panel.tsx
+++ b/src/components/workspace/tracker-panel.tsx
@@ -5,6 +5,7 @@ import { flushSync } from "react-dom";
 import type { DraggableEvent } from "react-draggable";
 import { Rnd } from "react-rnd";
 import {
+  CopySimple,
   DotsSixVertical,
   SquareSplitHorizontal,
 } from "@phosphor-icons/react/dist/ssr";
@@ -60,6 +61,8 @@ interface TrackerPanelProps {
   mergePartnerPayload: SerializableTrackerPayload | null;
   mergeDropHighlight: "none" | "valid" | "invalid";
   onUnmerge?: () => void;
+  /** Open duplicate flow (dashboard) pre-filled from this tracker. */
+  onRequestDuplicate?: (payload: SerializableTrackerPayload) => void;
   /** Brief light-blue frame after the tracker is created on the canvas. */
   spawnHighlight?: boolean;
   /**
@@ -131,6 +134,7 @@ export function TrackerPanel({
   mergePartnerPayload,
   mergeDropHighlight,
   onUnmerge,
+  onRequestDuplicate,
   spawnHighlight = false,
   easeLayoutPulse = null,
 }: TrackerPanelProps) {
@@ -303,6 +307,22 @@ export function TrackerPanel({
           <span className="no-drag inline-flex">
             <RefreshButton variant="icon" />
           </span>
+
+          {onRequestDuplicate ?
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Duplicate tracker"
+                  onClick={() => onRequestDuplicate(payload)}
+                  className="no-drag flex h-5 w-5 cursor-pointer items-center justify-center text-white/70 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+                >
+                  <CopySimple className="h-5 w-5" weight="duotone" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">Duplicate tracker</TooltipContent>
+            </Tooltip>
+          : null}
 
           <span aria-hidden className="h-px w-full bg-white/10" />
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,12 +1,19 @@
 import { z } from "zod";
 
-/** Optional nonempty string env (after trim); empty/absent becomes undefined */
-const optionalGithubFeedbackString = z.preprocess((v: unknown) => {
-  if (v === undefined || v === null || v === "") return undefined;
-  if (typeof v !== "string") return undefined;
-  const t = v.trim();
-  return t === "" ? undefined : t;
-}, z.string().min(1).optional());
+/**
+ * Optional nonempty string env (after trim); empty/absent becomes undefined.
+ * Zod 4's `z.preprocess` + inner `.optional()` rejects plain `undefined` input in
+ * some builds; use transform so unset GitHub feedback vars don't block boot.
+ */
+const optionalGithubFeedbackString = z
+  .string()
+  .optional()
+  .transform((s) => {
+    if (s === undefined) return undefined;
+    const t = s.trim();
+    return t === "" ? undefined : t;
+  })
+  .refine((v) => v === undefined || v.length >= 1);
 
 const supabaseProjectUrl = z
   .string()


### PR DESCRIPTION
## Summary

- Add **DashboardWorkspace** with **Canvas** vs **Table** modes; table lists cached armor with class and set / archetype / tuning / tertiary filters aligned with tracker creation.
- Render **Canvas / Table** tabs in **AppHeader** beside the brand link so they stay above the canvas stack.
- Optional GitHub feedback env parsing compatible with **Zod 4** when vars are unset.
- Tracker/workspace polish: duplicate dialog flow, armor set combobox, new-view form, views API, canvas wheel routing, and related UI tweaks.

## Test plan

- [x] Dashboard: switch Canvas ↔ Table; table filters and class segments behave as expected.
- [x] Sign-in / trackers still work on Canvas.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new dashboard UI paths (Canvas/Table switching, inventory table, duplicate-tracker dialog) and introduces server-side duplicate detection in `POST /api/views`, which could affect tracker creation behavior and wheel/scroll interactions.
> 
> **Overview**
> Introduces a new `DashboardWorkspace` that lets users switch between the existing canvas workspace and a new *table view* that lists cached armor with filters for class, set, archetype, tuning, and tertiary stat.
> 
> Adds a *duplicate tracker* flow from each tracker panel (modal with prefilled `NewViewForm`), including client-side “must change something” gating and a new `409` handling path.
> 
> Tightens creation semantics and UX polish: `POST /api/views` now rejects exact duplicates server-side, `AppHeader` supports a leading accessory for the mode tabs, popovers/comboboxes can portal into a modal container to preserve wheel scrolling, canvas wheel routing respects `data-skip-canvas-wheel`, and GitHub feedback env parsing is updated for Zod 4 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2fc5a54d43da2e17a951ab42019e1231dcb119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->