### PR TITLE
fix(workspace): prevent merged tracker content clipping at bottom

### DIFF
--- a/src/components/workspace/canvas-workspace.tsx
+++ b/src/components/workspace/canvas-workspace.tsx
@@ -20,7 +20,9 @@ import {
 import {
   arrangeLayoutEaseDurationMs,
   TRACKER_DEFAULT_HEIGHT,
+  TRACKER_MERGED_DEFAULT_HEIGHT,
   TRACKER_WIDTH,
+  trackerShellHeightPx,
   trackerWidthForTertiaryColumns,
   WORKSPACE_CANVAS_ELEMENT_ID,
   WORKSPACE_CANVAS_HEIGHT,
@@ -925,7 +927,10 @@ export function CanvasWorkspace({
       const self = current.find((t) => t.view.id === viewId);
       const selfLo = self ? parseWorkspaceLayout(self.view.layout) : null;
       const dragFootprint = selfLo
-        ? { w: selfLo.w, h: selfLo.h }
+        ? {
+            w: selfLo.w,
+            h: trackerShellHeightPx(selfLo),
+          }
         : { w: TRACKER_WIDTH, h: TRACKER_DEFAULT_HEIGHT };
 
       const { targetId, valid } = pickMergeDropTarget(
@@ -953,7 +958,9 @@ export function CanvasWorkspace({
       if (!self) return;
 
       const selfLo = parseWorkspaceLayout(self.view.layout);
-      const h = TRACKER_DEFAULT_HEIGHT;
+      const existingMergeWith =
+        (layout.mergedWith ?? selfLo.mergedWith) ?? null;
+      const h = trackerShellHeightPx({ mergedWith: existingMergeWith });
       const normalized: WorkspaceLayoutJson = {
         ...layout,
         h,
@@ -992,12 +999,13 @@ export function CanvasWorkspace({
           unionTertiaryStats(self, tgt).length,
           { dualSlotRails: true },
         );
+        const mergedPairH = TRACKER_MERGED_DEFAULT_HEIGHT;
         const sourceLayout: WorkspaceLayoutJson = {
           ...selfLo,
           x: snapX,
           y: snapY,
           w: mergedW,
-          h,
+          h: mergedPairH,
           z: maxZ + 2,
           mergedWith: tgt.view.id,
         };
@@ -1006,7 +1014,7 @@ export function CanvasWorkspace({
           x: snapX,
           y: snapY,
           w: mergedW,
-          h,
+          h: mergedPairH,
           z: maxZ + 1,
           mergedWith: self.view.id,
         };
@@ -1116,15 +1124,22 @@ export function CanvasWorkspace({
 
   const mergePreviewPath = useMemo(() => {
     if (!draggingId || !dragLive || !mergeDropTargetId) return null;
+    const dragT = trackers.find((t) => t.view.id === draggingId);
     const tgt = trackers.find((t) => t.view.id === mergeDropTargetId);
     if (!tgt) return null;
+    const dragLo = dragT ? parseWorkspaceLayout(dragT.view.layout) : null;
+    const tgtLoParsed = parseWorkspaceLayout(tgt.view.layout);
+    const previewH = Math.max(
+      dragLo ? trackerShellHeightPx(dragLo) : TRACKER_DEFAULT_HEIGHT,
+      trackerShellHeightPx(tgtLoParsed),
+    );
     const d = mergePreviewUnionPathD(
       dragLive.x,
       dragLive.y,
       tgt.view.layout.x,
       tgt.view.layout.y,
       TRACKER_WIDTH,
-      TRACKER_DEFAULT_HEIGHT,
+      previewH,
       14,
     );
     if (!d) return null;

--- a/src/components/workspace/tracker-panel.tsx
+++ b/src/components/workspace/tracker-panel.tsx
@@ -24,8 +24,8 @@ import {
 import { TrackerIdentBadges } from "@/components/workspace/tracker-ident-badges";
 import type { SerializableTrackerPayload } from "@/lib/workspace/types";
 import {
-  TRACKER_DEFAULT_HEIGHT,
   TRACKER_WIDTH,
+  trackerShellHeightPx,
   trackerWidthForTertiaryColumns,
 } from "@/lib/workspace/workspace-constants";
 import {
@@ -156,6 +156,7 @@ export function TrackerPanel({
     parseWorkspaceLayout(view.layout),
   );
   const merged = Boolean(view.layout.mergedWith) && mergePartnerPayload !== null;
+  const shellHeightPx = trackerShellHeightPx(view.layout);
 
   const panelWidth =
     merged && mergePartnerPayload
@@ -234,7 +235,7 @@ export function TrackerPanel({
         bounds="parent"
         scale={rndScale}
         position={{ x: layout.x, y: layout.y }}
-        size={{ width: panelWidth, height: TRACKER_DEFAULT_HEIGHT }}
+        size={{ width: panelWidth, height: shellHeightPx }}
         enableResizing={false}
         enableDragging={false}
         style={
@@ -255,7 +256,7 @@ export function TrackerPanel({
       scale={rndScale}
       enableResizing={false}
       position={{ x: layout.x, y: layout.y }}
-      size={{ width: panelWidth, height: TRACKER_DEFAULT_HEIGHT }}
+      size={{ width: panelWidth, height: shellHeightPx }}
       style={easeMotionStyle}
       onDrag={(e, d) => {
         onDragPosition?.(view.id, d.x, d.y, e);
@@ -269,7 +270,7 @@ export function TrackerPanel({
           x: d.x,
           y: d.y,
           w: panelWidth,
-          h: TRACKER_DEFAULT_HEIGHT,
+          h: shellHeightPx,
         };
         layoutLiveRef.current = next;
         setLayout(next);
@@ -426,7 +427,7 @@ export function TrackerPanel({
 
             <div
               className={`flex min-h-0 flex-1 flex-col gap-4 px-4 pt-4 pb-2 ${
-                !showMergedGrid && payload.needsClass
+                showMergedGrid || payload.needsClass
                   ? "overflow-y-auto"
                   : "overflow-hidden"
               }`}

--- a/src/lib/views/canvas-merge.ts
+++ b/src/lib/views/canvas-merge.ts
@@ -2,6 +2,7 @@ import type { SerializableTrackerPayload } from "@/lib/workspace/types";
 import {
   TRACKER_DEFAULT_HEIGHT,
   TRACKER_WIDTH,
+  trackerShellHeightPx,
 } from "@/lib/workspace/workspace-constants";
 import { parseWorkspaceLayout } from "@/lib/workspace/workspace-schema";
 
@@ -87,10 +88,10 @@ export function pickMergeDropTarget(
     const ratio = mergeOverlapRatio(
       dragRect.x,
       dragRect.y,
-      t.view.layout.x,
-      t.view.layout.y,
+      tLo.x,
+      tLo.y,
       dragFootprint,
-      { w: tLo.w, h: tLo.h },
+      { w: tLo.w, h: trackerShellHeightPx(tLo) },
     );
     if (ratio < MERGE_OVERLAP_TRIGGER_RATIO) continue;
     if (!best || ratio > best.ratio) best = { id: t.view.id, ratio };

--- a/src/lib/workspace/workspace-arrange-grid.ts
+++ b/src/lib/workspace/workspace-arrange-grid.ts
@@ -1,6 +1,6 @@
 import type { SerializableTrackerPayload } from "@/lib/workspace/types";
 import {
-  TRACKER_DEFAULT_HEIGHT,
+  TRACKER_MAX_SHELL_HEIGHT_PX,
   TRACKER_WIDTH,
   WORKSPACE_CANVAS_HEIGHT,
   WORKSPACE_CANVAS_WIDTH,
@@ -93,7 +93,7 @@ function computeClassClusterLayouts(
   idToPayload: Map<string, SerializableTrackerPayload>,
 ): ArrangeGridComputation {
   const SLOT_W = TRACKER_WIDTH + GAP;
-  const SLOT_H = TRACKER_DEFAULT_HEIGHT + GAP;
+  const SLOT_H = TRACKER_MAX_SHELL_HEIGHT_PX + GAP;
 
   /** merge-group rectangles (canvas px) excluding outer gap */
   interface PlacedBucket {
@@ -352,7 +352,7 @@ function computeNestedPrimarySecondaryLayouts(
   });
 
   const SLOT_W = TRACKER_WIDTH + GAP;
-  const SLOT_H = TRACKER_DEFAULT_HEIGHT + GAP;
+  const SLOT_H = TRACKER_MAX_SHELL_HEIGHT_PX + GAP;
   const pillarW = innerGridWidthPx();
   const packMaxW = clusterPackMaxWidthPx();
 
@@ -497,7 +497,7 @@ export function computeWorkspaceGridLayouts(
 
   const orderedGroups = orderedBuckets.flat();
   const SLOT_W = TRACKER_WIDTH + GAP;
-  const SLOT_H = TRACKER_DEFAULT_HEIGHT + GAP;
+  const SLOT_H = TRACKER_MAX_SHELL_HEIGHT_PX + GAP;
   const rows = Math.ceil(orderedGroups.length / COLS);
   const gridW = Math.min(orderedGroups.length, COLS) * SLOT_W - GAP;
   const gridH = rows * SLOT_H - GAP;

--- a/src/lib/workspace/workspace-constants.ts
+++ b/src/lib/workspace/workspace-constants.ts
@@ -46,6 +46,28 @@ export function trackerWidthForTertiaryColumns(
  */
 export const TRACKER_DEFAULT_HEIGHT = 384;
 
+/**
+ * Merged trackers need more vertical space than {@link TRACKER_DEFAULT_HEIGHT}:
+ * dual ident headers (badges wrap more in each half), optional “grid complete”
+ * copy, and the same stat table — without clipping the last armor row.
+ */
+export const TRACKER_MERGED_DEFAULT_HEIGHT = 456;
+
+/** Largest tracker shell height (used for arrange grid vertical pitch). */
+export const TRACKER_MAX_SHELL_HEIGHT_PX = Math.max(
+  TRACKER_DEFAULT_HEIGHT,
+  TRACKER_MERGED_DEFAULT_HEIGHT,
+);
+
+/** Canvas shell height from layout (height is not user-resizable). */
+export function trackerShellHeightPx(layout: {
+  mergedWith?: string | null;
+}): number {
+  return layout.mergedWith != null
+    ? TRACKER_MERGED_DEFAULT_HEIGHT
+    : TRACKER_DEFAULT_HEIGHT;
+}
+
 /** `transform` ease when trackers move programmatically (sort/cluster arrange). */
 export const ARRANGE_LAYOUT_EASE_DURATION_MS = 420;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Merged trackers reuse the solo shell height (384px) while their chrome needs more vertical space: dual ident headers (especially when badges wrap in narrow halves), optional “combined inventory fills every cell” copy, and the same five-row compare grid. The body stack used `overflow-hidden`, so the last rows were clipped.

## Changes

- Added `TRACKER_MERGED_DEFAULT_HEIGHT` (456px) and `trackerShellHeightPx()` derived from `layout.mergedWith`.
- `TrackerPanel` sizes `react-rnd` with the shell height, persists it on drag end, and enables `overflow-y-auto` for merged bodies as a fallback.
- Merge-on-drop and merged drag-sync persist the taller `h`; `pickMergeDropTarget` uses canonical shell height for overlap; arrange grid vertical pitch uses `TRACKER_MAX_SHELL_HEIGHT_PX` so stacked layouts do not collide; merge preview outline uses the max of dragged and target shell heights.

## Verification

- `npm run build` succeeds.
- Targeted ESLint on touched files still reports existing `tracker-panel` hook rules; no new issues from this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c431e3ec-0950-47b2-878f-fa9c97667a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c431e3ec-0950-47b2-878f-fa9c97667a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

