### PR TITLE
Sharp corners on Sonner toasts and alert banners

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -86,7 +86,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       {!lookups.version ? (
         <div
           role="alert"
-          className="flex flex-col gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
+          className="flex flex-col gap-3 rounded-none border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
         >
           <Warning weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
           <div className="flex-1">
@@ -104,7 +104,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       ) : versionCheck.schemaOutdated ? (
         <div
           role="alert"
-          className="flex flex-col gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
+          className="flex flex-col gap-3 rounded-none border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
         >
           <Warning weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
           <div className="flex-1">
@@ -122,7 +122,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       ) : versionCheck.needsResync ? (
         <div
           role="status"
-          className="flex flex-col gap-3 rounded-lg border border-blue-500/30 bg-blue-500/5 p-4 text-sm sm:flex-row sm:items-start"
+          className="flex flex-col gap-3 rounded-none border border-blue-500/30 bg-blue-500/5 p-4 text-sm sm:flex-row sm:items-start"
         >
           <Info weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
           <div className="flex-1">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -275,4 +275,15 @@
       opacity: 0;
     }
   }
+
+  /* Sonner defaults use --border-radius and circular close buttons; match app sharp UI. */
+  [data-sonner-toaster].toaster {
+    --border-radius: 0;
+  }
+  [data-sonner-toaster].toaster [data-sonner-toast][data-styled="true"] [data-close-button] {
+    border-radius: 0;
+  }
+  [data-sonner-toaster].toaster [data-sonner-toast][data-styled="true"] [data-button] {
+    border-radius: 0;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
           {auth_error ? (
             <div
               role="alert"
-              className="flex w-full items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive-foreground"
+              className="flex w-full items-start gap-3 rounded-none border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive-foreground"
             >
               <Warning weight="duotone" className="mt-0.5 h-5 w-5 shrink-0" />
               <span>Couldn&rsquo;t complete sign-in: {auth_error}</span>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -12,12 +12,13 @@ export function Toaster(props: ToasterProps) {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "group toast rounded-none group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+            "group-[.toast]:rounded-none group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+            "group-[.toast]:rounded-none group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+          closeButton: "rounded-none",
         },
       }}
       {...props}

--- a/src/components/workspace/tracker-panel.tsx
+++ b/src/components/workspace/tracker-panel.tsx
@@ -435,7 +435,7 @@ export function TrackerPanel({
             {payload.needsClass ? (
               <div
                 role="alert"
-                className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200"
+                className="rounded-none border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200"
               >
                 <p className="font-medium">No class assigned</p>
                 <p className="text-muted-foreground">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sonner’s default stylesheet uses an 8px `--border-radius` on the toast shell, 4px on toast action buttons, and a circular close control. Those values outrank plain Tailwind utilities on the same nodes, so this change adds scoped overrides on `[data-sonner-toaster].toaster` and aligns inline alert/status banners with `rounded-none` instead of `rounded-lg`.

## Changes

- **`globals.css`**: Set `--border-radius: 0` for our toaster; force square corners on toast `[data-close-button]` and `[data-button]` with specificity over Sonner’s CSS.
- **`sonner.tsx`**: `rounded-none` on the toast node and toast action/cancel/close classNames (belt-and-suspenders with globals).
- **Banners**: Dashboard manifest warnings/info strip, landing auth error, and tracker “no class assigned” callout now use `rounded-none`.

## Verification

- `npm run build` passes.
- `npm run lint` still reports existing issues in `spike/`, `scripts/`, and `tracker-panel.tsx` (refs); none were introduced by these edits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26611be6-6959-4ab4-8648-47a05b4c0825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26611be6-6959-4ab4-8648-47a05b4c0825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

