### PR TITLE
feat(dashboard): inventory table chrome and filter UX

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,10 +3,11 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Simple 3-color token system from Figma reference:
+/* Token system from Figma reference:
    - background = page (#ffffff / #212121)
    - surface    = single elevation for menus (#ececec / #2f2f2f)
                   → card, popover, secondary, muted all collapse to this
+   - table-header = band behind sticky column labels (+ top control row)
    - primary    = brand green (#07ad6b, same in both modes)
    --accent is one shade off surface so menu-item hover/focus stays visible.
    --success and --destructive remain their own status colors. */
@@ -24,6 +25,8 @@
   --secondary-foreground: oklch(0.145 0 0);
   --muted: oklch(0.928 0 0);                /* surface */
   --muted-foreground: oklch(0.45 0 0);
+  --table-header: oklch(0.91 0 0);         /* slightly darker than card */
+  --table-header-foreground: oklch(0.45 0 0);
   --accent: oklch(0.88 0 0);               /* one shade darker than surface */
   --accent-foreground: oklch(0.145 0 0);
   --destructive: oklch(0.577 0.245 27.325);
@@ -48,6 +51,8 @@
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.298 0 0);
   --muted-foreground: oklch(0.7 0 0);
+  --table-header: oklch(0.315 0 0);        /* slightly lighter than card */
+  --table-header-foreground: oklch(0.7 0 0);
   --accent: oklch(0.345 0 0);              /* one shade lighter than surface */
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
@@ -72,6 +77,8 @@
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
+  --color-table-header: var(--table-header);
+  --color-table-header-foreground: var(--table-header-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);

--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -43,7 +43,7 @@ export function DashboardWorkspace({
   const tabs = <WorkspaceViewModeTabs mode={mode} onModeChange={setMode} />;
 
   return (
-    <>
+    <div className="flex h-full min-h-0 flex-col">
       <AppHeader
         displayName={displayName}
         profilePictureUrl={profilePictureUrl}
@@ -68,6 +68,6 @@ export function DashboardWorkspace({
           selectors={selectors}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/dashboard/inventory-table-view.stories.tsx
+++ b/src/components/dashboard/inventory-table-view.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof InventoryTableView>;
 
 export const Loaded: Story = {
   render: () => (
-    <div className="h-[80vh] bg-background">
+    <div className="flex h-[80vh] flex-col bg-background">
       <InventoryTableView
         hasInventory
         inventory={MOCK_INVENTORY}
@@ -32,7 +32,7 @@ export const Loaded: Story = {
 
 export const NoInventory: Story = {
   render: () => (
-    <div className="h-[80vh] bg-background">
+    <div className="flex h-[80vh] flex-col bg-background">
       <InventoryTableView
         hasInventory={false}
         inventory={EMPTY_INVENTORY}
@@ -45,7 +45,7 @@ export const NoInventory: Story = {
 
 export const SyncWarning: Story = {
   render: () => (
-    <div className="h-[80vh] bg-background">
+    <div className="flex h-[80vh] flex-col bg-background">
       <InventoryTableView
         hasInventory
         inventory={MOCK_INVENTORY}

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { ARMOR_STAT_NAMES, type DerivedArmorPieceJson } from "@/lib/db/types";
 import {
@@ -11,11 +11,14 @@ import {
   type ArmorSlot,
 } from "@/lib/bungie/constants";
 import { cn } from "@/lib/utils";
-import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -26,41 +29,25 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  ArmorSetMultiCombobox,
-} from "@/components/views/armor-set-combobox";
+import { ArmorSetMultiSelectPanel } from "@/components/views/armor-set-combobox";
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
-import { CaretDown, MagnifyingGlass, X } from "@phosphor-icons/react/dist/ssr";
+import { MagnifyingGlass, SlidersHorizontal, X } from "@phosphor-icons/react/dist/ssr";
 import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
 
 const TABLE_FILTER_MENU_CONTENT =
-  "max-h-[min(60vh,20rem)] overflow-y-auto rounded-none py-2 shadow-xl";
+  "max-h-[min(60vh,20rem)] min-w-56 overflow-y-auto rounded-none py-2 shadow-xl";
 
-const INVENTORY_TABLE_FILTER_TRIGGER =
-  "flex h-9 w-full min-w-0 items-center justify-between gap-2 rounded-none border border-input bg-card px-3 py-2 text-left text-sm text-foreground shadow-sm focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
-
-function multiOptionSummary(
-  selected: string[],
-  labelForValue: (v: string) => string | undefined,
-  emptyPlaceholder: string,
-): string {
-  if (selected.length === 0) return emptyPlaceholder;
-  const names = selected
-    .map((v) => labelForValue(v))
-    .filter((n): n is string => Boolean(n));
-  if (names.length === 0) return emptyPlaceholder;
-  if (names.length === 1) return names[0]!;
-  if (names.length === 2) return `${names[0]}, ${names[1]}`;
-  return `${names[0]}, ${names[1]} +${names.length - 2}`;
-}
-
-type InventoryClass = 0 | 1 | 2;
-
-const CLASS_TABS: Array<{ value: InventoryClass; label: string }> = [
-  { value: 0, label: "Titan" },
-  { value: 1, label: "Hunter" },
-  { value: 2, label: "Warlock" },
-];
+/** Shared by header + body tables so columns line up (`table-fixed`). */
+const INVENTORY_TABLE_COLGROUP = (
+  <colgroup>
+    <col className="w-14" />
+    <col />
+    <col />
+    <col />
+    <col />
+    <col />
+  </colgroup>
+);
 
 function slotRank(slot: ArmorSlot): number {
   return SLOT_ORDER.indexOf(slot);
@@ -72,6 +59,14 @@ function formatLocation(piece: DerivedArmorPieceJson): string {
   if (loc.equipped) return "Equipped";
   return "Inventory";
 }
+
+type InventoryClass = 0 | 1 | 2;
+
+const CLASS_TABS: Array<{ value: InventoryClass; label: string }> = [
+  { value: 0, label: "Titan" },
+  { value: 1, label: "Hunter" },
+  { value: 2, label: "Warlock" },
+];
 
 interface InventoryTableViewProps {
   className?: string;
@@ -96,6 +91,9 @@ export function InventoryTableView({
   const [tuningHashes, setTuningHashes] = useState<string[]>([]);
   const [tertiaryStats, setTertiaryStats] = useState<string[]>([]);
   const [search, setSearch] = useState("");
+  const [searchUiOpen, setSearchUiOpen] = useState(false);
+  const searchExpanded = searchUiOpen || search.trim().length > 0;
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
 
   const sortedSets = useMemo(
@@ -111,6 +109,15 @@ export function InventoryTableView({
     () => [...selectors.tunings].sort((a, b) => a.name.localeCompare(b.name)),
     [selectors.tunings],
   );
+
+  const activeFilterDimCount = useMemo(() => {
+    let n = 0;
+    if (setHashes.length > 0) n += 1;
+    if (archetypeHashes.length > 0) n += 1;
+    if (tuningHashes.length > 0) n += 1;
+    if (tertiaryStats.length > 0) n += 1;
+    return n;
+  }, [setHashes, archetypeHashes, tuningHashes, tertiaryStats]);
 
   const filteredRows = useMemo(() => {
     let rows = inventory.filter((p) => p.classType === inventoryClass);
@@ -172,23 +179,18 @@ export function InventoryTableView({
     search,
   ]);
 
-  const archetypeSummary = multiOptionSummary(
-    archetypeHashes,
-    (h) => sortedArchetypes.find((a) => String(a.hash) === h)?.name,
-    "All archetypes",
-  );
-  const tuningSummary = multiOptionSummary(
-    tuningHashes,
-    (h) => sortedTunings.find((t) => String(t.hash) === h)?.name,
-    "All tuning stats",
-  );
-  const tertiarySummary = multiOptionSummary(
-    tertiaryStats,
-    (s) => s,
-    "All tertiary stats",
-  );
+  const armorSetEmptyCopy = selectors.manifestEmpty
+    ? "Sync the manifest first."
+    : "No sets for this class.";
 
   const hasTopMessage = Boolean(banners) || Boolean(syncWarning);
+
+  function openSearchField() {
+    setSearchUiOpen(true);
+    queueMicrotask(() =>
+      searchInputRef.current?.focus({ preventScroll: true }),
+    );
+  }
 
   return (
     <div className={`flex min-h-0 flex-1 flex-col ${className}`}>
@@ -209,359 +211,379 @@ export function InventoryTableView({
         </div>
       ) : null}
 
-      <div className="relative flex min-h-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-background">
-        <div className="flex min-h-0 flex-col gap-4 px-4 pb-8 pt-[4.75rem] sm:px-6">
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-[4.75rem] sm:px-6">
           {!hasInventory ? (
             <p className="text-sm text-muted-foreground">
               No armor inventory loaded yet. Use Refresh in the header after
               signing in with Bungie.
             </p>
           ) : (
-            <>
-              <div className="shrink-0 flex flex-col gap-3 sm:gap-4">
-                <div className="grid min-w-0 gap-2">
-                  <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Class
-                  </Label>
-                  <div className="flex h-10 w-full shrink-0 overflow-hidden rounded-none bg-card sm:w-fit">
-                    {CLASS_TABS.map((tab) => (
-                      <button
-                        key={tab.value}
-                        type="button"
-                        className={cn(
-                          "flex h-10 shrink-0 items-center border border-transparent px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                          inventoryClass === tab.value &&
-                            "border-border bg-accent text-foreground",
-                        )}
-                        onClick={() => {
-                          setInventoryClass(tab.value);
-                          setSetHashes((prev) =>
-                            prev.filter((h) =>
-                              selectors.setsByClass[tab.value].some(
-                                (s) => String(s.hash) === h,
-                              ),
-                            ),
-                          );
-                        }}
-                      >
-                        {tab.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+            <div className="flex max-h-full min-h-0 min-w-0 w-full flex-col self-start overflow-hidden rounded-none border border-border bg-card">
+              <div className="flex min-h-0 min-w-0 flex-col overflow-x-auto overflow-y-hidden">
+                <div className="min-w-0 shrink-0">
+                  <Table
+                    className="w-full table-fixed border-separate border-spacing-0"
+                    containerClassName="overflow-visible"
+                  >
+                    {INVENTORY_TABLE_COLGROUP}
+                <TableHeader className="[&_tr]:border-b-0">
+                  <TableRow className="border-b-0 border-border hover:bg-transparent [&:hover]:bg-transparent">
+                    <TableHead
+                      colSpan={6}
+                      className="h-auto border-b-0 bg-table-header px-3 py-0 text-left align-middle font-medium text-muted-foreground shadow-[inset_0_-1px_0_0_var(--border)] [&:has([role=checkbox])]:pr-0"
+                    >
+                      <div className="grid min-h-[52px] min-w-0 grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-2">
+                        <div className="flex min-w-0 shrink-0 overflow-hidden rounded-none bg-card">
+                          {CLASS_TABS.map((tab) => (
+                            <button
+                              key={tab.value}
+                              type="button"
+                              className={cn(
+                                "flex h-9 shrink-0 items-center border border-transparent px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                                inventoryClass === tab.value &&
+                                  "border-border bg-accent text-foreground",
+                              )}
+                              onClick={() => {
+                                setInventoryClass(tab.value);
+                                setSetHashes((prev) =>
+                                  prev.filter((h) =>
+                                    selectors.setsByClass[tab.value].some(
+                                      (s) => String(s.hash) === h,
+                                    ),
+                                  ),
+                                );
+                              }}
+                            >
+                              {tab.label}
+                            </button>
+                          ))}
+                        </div>
 
-                <div
-                  role="search"
-                  aria-label="Inventory filter bar"
-                  className="flex min-w-0 flex-col gap-2 lg:flex-row lg:items-stretch"
-                >
-                  <div className="relative flex min-w-0 items-center lg:w-72 lg:shrink-0">
-                    <MagnifyingGlass
-                      weight="regular"
-                      className="pointer-events-none absolute left-3 h-4 w-4 text-muted-foreground"
-                      aria-hidden
-                    />
-                    <input
-                      id="inv-filter-search"
-                      type="search"
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
-                      placeholder="Search armor"
-                      aria-label="Search armor"
-                      className="h-9 w-full min-w-0 rounded-none border border-input bg-card pl-9 pr-9 text-sm text-foreground shadow-sm placeholder:text-muted-foreground/80 focus:outline-none focus:ring-1 focus:ring-ring [&::-webkit-search-cancel-button]:hidden"
-                    />
-                    {search ? (
-                      <button
-                        type="button"
-                        aria-label="Clear search"
-                        onClick={() => setSearch("")}
-                        className="absolute right-2 inline-flex h-5 w-5 items-center justify-center rounded-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                      >
-                        <X weight="bold" className="h-3.5 w-3.5" aria-hidden />
-                      </button>
-                    ) : null}
-                  </div>
-
-                  <div className="grid min-w-0 grid-cols-2 gap-2 sm:grid-cols-4 lg:flex-1">
-                    <ArmorSetMultiCombobox
-                      id="inv-filter-set"
-                      options={sortedSets}
-                      values={setHashes}
-                      onValuesChange={setSetHashes}
-                      aria-label="Armor set filter"
-                      placeholder="All armor sets"
-                      sharpCorners
-                      triggerClassName={INVENTORY_TABLE_FILTER_TRIGGER}
-                      summaryEmptyClassName="text-muted-foreground/80"
-                      caretClassName="opacity-60"
-                      emptyCatalogMessage={
-                        selectors.manifestEmpty
-                          ? "Sync the manifest first."
-                          : "No sets for this class."
-                      }
-                      pinnedHashes={pinnedHashes}
-                      onTogglePin={togglePin}
-                    />
-
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
-                          id="inv-filter-archetype"
-                          aria-label="Archetype filter"
-                          className={INVENTORY_TABLE_FILTER_TRIGGER}
-                        >
-                          <span
-                            className={cn(
-                              "min-w-0 flex-1 truncate",
-                              archetypeHashes.length === 0 &&
-                                "text-muted-foreground/80",
-                            )}
+                        <div className="flex min-w-0 shrink-0 items-center gap-2 self-center sm:gap-3">
+                          <DropdownMenu modal={false}>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              aria-label="Armor filters"
+                              className="relative h-9 shrink-0 gap-1.5 rounded-none px-3 text-xs"
+                            >
+                              <SlidersHorizontal
+                                weight="duotone"
+                                aria-hidden
+                                className="size-4"
+                              />
+                              <span className="hidden sm:inline">Filters</span>
+                              {activeFilterDimCount > 0 ?
+                                <span
+                                  className="flex h-4 min-w-4 items-center justify-center rounded-none bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"
+                                  aria-hidden
+                                >
+                                  {activeFilterDimCount}
+                                </span>
+                              : null}
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent
+                            align="start"
+                            className="min-w-48 rounded-none py-1"
                           >
-                            {archetypeSummary}
-                          </span>
-                          <CaretDown
-                            weight="duotone"
-                            className="h-4 w-4 shrink-0 opacity-60"
-                            aria-hidden
-                          />
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        align="start"
-                        className={cn(
-                          TABLE_FILTER_MENU_CONTENT,
-                          "min-w-[var(--radix-dropdown-menu-trigger-width)]",
-                        )}
-                      >
-                        {sortedArchetypes.length === 0 ? (
-                          <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
-                            No archetypes — sync the manifest first.
-                          </div>
-                        ) : (
-                          sortedArchetypes.map((a) => {
-                            const id = String(a.hash);
-                            return (
-                              <DropdownMenuCheckboxItem
-                                key={a.hash}
-                                checked={archetypeHashes.includes(id)}
-                                onSelect={(e) => e.preventDefault()}
-                                onCheckedChange={(c) => {
-                                  setArchetypeHashes((prev) =>
-                                    c
-                                      ? [...prev, id]
-                                      : prev.filter((h) => h !== id),
-                                  );
-                                }}
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger inset>
+                                Armor sets
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent
+                                className="w-[min(90vw,22rem)] min-w-[18rem] rounded-none border-border p-0 shadow-xl"
+                                collisionPadding={16}
                               >
-                                {a.name}
-                              </DropdownMenuCheckboxItem>
-                            );
-                          })
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                                <ArmorSetMultiSelectPanel
+                                  key={inventoryClass}
+                                  options={sortedSets}
+                                  values={setHashes}
+                                  onValuesChange={setSetHashes}
+                                  emptyCatalogMessage={armorSetEmptyCopy}
+                                  sharpCorners
+                                  pinnedHashes={pinnedHashes}
+                                  onTogglePin={togglePin}
+                                  autoFocusSearch
+                                  className="max-h-[min(70vh,22rem)]"
+                                />
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
 
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
-                          id="inv-filter-tertiary"
-                          aria-label="Tertiary stat filter"
-                          className={INVENTORY_TABLE_FILTER_TRIGGER}
-                        >
-                          <span
-                            className={cn(
-                              "min-w-0 flex-1 truncate",
-                              tertiaryStats.length === 0 &&
-                                "text-muted-foreground/80",
-                            )}
-                          >
-                            {tertiarySummary}
-                          </span>
-                          <CaretDown
-                            weight="duotone"
-                            className="h-4 w-4 shrink-0 opacity-60"
-                            aria-hidden
-                          />
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        align="start"
-                        className={cn(
-                          TABLE_FILTER_MENU_CONTENT,
-                          "min-w-[var(--radix-dropdown-menu-trigger-width)]",
-                        )}
-                      >
-                        {ARMOR_STAT_NAMES.map((stat) => (
-                          <DropdownMenuCheckboxItem
-                            key={stat}
-                            checked={tertiaryStats.includes(stat)}
-                            onSelect={(e) => e.preventDefault()}
-                            onCheckedChange={(c) => {
-                              setTertiaryStats((prev) =>
-                                c
-                                  ? [...prev, stat]
-                                  : prev.filter((s) => s !== stat),
-                              );
-                            }}
-                          >
-                            {stat}
-                          </DropdownMenuCheckboxItem>
-                        ))}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
-                          id="inv-filter-tuning"
-                          aria-label="Tuning stat filter"
-                          className={INVENTORY_TABLE_FILTER_TRIGGER}
-                        >
-                          <span
-                            className={cn(
-                              "min-w-0 flex-1 truncate",
-                              tuningHashes.length === 0 &&
-                                "text-muted-foreground/80",
-                            )}
-                          >
-                            {tuningSummary}
-                          </span>
-                          <CaretDown
-                            weight="duotone"
-                            className="h-4 w-4 shrink-0 opacity-60"
-                            aria-hidden
-                          />
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        align="start"
-                        className={cn(
-                          TABLE_FILTER_MENU_CONTENT,
-                          "min-w-[var(--radix-dropdown-menu-trigger-width)]",
-                        )}
-                      >
-                        {sortedTunings.length === 0 ? (
-                          <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
-                            No tunings — sync the manifest first.
-                          </div>
-                        ) : (
-                          sortedTunings.map((t) => {
-                            const id = String(t.hash);
-                            return (
-                              <DropdownMenuCheckboxItem
-                                key={t.hash}
-                                checked={tuningHashes.includes(id)}
-                                onSelect={(e) => e.preventDefault()}
-                                onCheckedChange={(c) => {
-                                  setTuningHashes((prev) =>
-                                    c
-                                      ? [...prev, id]
-                                      : prev.filter((h) => h !== id),
-                                  );
-                                }}
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger inset>
+                                Archetypes
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent
+                                className={cn(
+                                  TABLE_FILTER_MENU_CONTENT,
+                                  "min-w-64",
+                                )}
+                                collisionPadding={16}
                               >
-                                {t.name}
-                              </DropdownMenuCheckboxItem>
-                            );
-                          })
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
+                                {sortedArchetypes.length === 0 ?
+                                  <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
+                                    No archetypes — sync the manifest first.
+                                  </div>
+                                : sortedArchetypes.map((a) => {
+                                    const id = String(a.hash);
+                                    return (
+                                      <DropdownMenuCheckboxItem
+                                        key={a.hash}
+                                        checked={archetypeHashes.includes(id)}
+                                        onSelect={(e) => e.preventDefault()}
+                                        onCheckedChange={(c) => {
+                                          setArchetypeHashes((prev) =>
+                                            c
+                                              ? [...prev, id]
+                                              : prev.filter((h) => h !== id),
+                                          );
+                                        }}
+                                      >
+                                        {a.name}
+                                      </DropdownMenuCheckboxItem>
+                                    );
+                                  })
+                                }
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger inset>
+                                Tertiary stats
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent
+                                className={cn(
+                                  TABLE_FILTER_MENU_CONTENT,
+                                  "min-w-48",
+                                )}
+                                collisionPadding={16}
+                              >
+                                {ARMOR_STAT_NAMES.map((stat) => (
+                                  <DropdownMenuCheckboxItem
+                                    key={stat}
+                                    checked={tertiaryStats.includes(stat)}
+                                    onSelect={(e) => e.preventDefault()}
+                                    onCheckedChange={(c) => {
+                                      setTertiaryStats((prev) =>
+                                        c
+                                          ? [...prev, stat]
+                                          : prev.filter((s) => s !== stat),
+                                      );
+                                    }}
+                                  >
+                                    {stat}
+                                  </DropdownMenuCheckboxItem>
+                                ))}
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger inset>
+                                Tuning stats
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent
+                                className={cn(
+                                  TABLE_FILTER_MENU_CONTENT,
+                                  "min-w-56",
+                                )}
+                                collisionPadding={16}
+                              >
+                                {sortedTunings.length === 0 ?
+                                  <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
+                                    No tunings — sync the manifest first.
+                                  </div>
+                                : sortedTunings.map((t) => {
+                                    const id = String(t.hash);
+                                    return (
+                                      <DropdownMenuCheckboxItem
+                                        key={t.hash}
+                                        checked={tuningHashes.includes(id)}
+                                        onSelect={(e) => e.preventDefault()}
+                                        onCheckedChange={(c) => {
+                                          setTuningHashes((prev) =>
+                                            c
+                                              ? [...prev, id]
+                                              : prev.filter((h) => h !== id),
+                                          );
+                                        }}
+                                      >
+                                        {t.name}
+                                      </DropdownMenuCheckboxItem>
+                                    );
+                                  })
+                                }
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                          <p
+                            className="min-w-0 text-xs leading-snug text-muted-foreground/80"
+                            aria-live="polite"
+                          >
+                            Showing {filteredRows.length} piece
+                            {filteredRows.length === 1 ? "" : "s"} for{" "}
+                            {CLASS_NAMES[inventoryClass] ?? "class"}.
+                          </p>
+                        </div>
+
+                        <div className="min-w-0 justify-self-end">
+                          {searchExpanded ?
+                            <div
+                              role="search"
+                              className="relative min-h-[52px] min-w-0 lg:max-w-xs"
+                            >
+                              <MagnifyingGlass
+                                weight="regular"
+                                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                                aria-hidden
+                              />
+                              <input
+                                ref={searchInputRef}
+                                id="inv-filter-search"
+                                type="search"
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                placeholder="Search armor"
+                                aria-label="Search armor"
+                                onBlur={() => {
+                                  if (!search.trim()) setSearchUiOpen(false);
+                                }}
+                                onKeyDown={(e) => {
+                                  if (e.key !== "Escape") return;
+                                  if (search.trim()) {
+                                    setSearch("");
+                                  } else {
+                                    setSearchUiOpen(false);
+                                    e.currentTarget.blur();
+                                  }
+                                }}
+                                className="h-[52px] w-full min-w-0 border-0 border-b border-white bg-transparent py-0 ps-9 pe-9 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/80 focus-visible:border-b focus-visible:border-white focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-search-cancel-button]:hidden"
+                              />
+                              {search ?
+                                <button
+                                  type="button"
+                                  aria-label="Clear search"
+                                  onPointerDown={(e) => e.preventDefault()}
+                                  onClick={() => setSearch("")}
+                                  className="absolute right-2 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                >
+                                  <X
+                                    weight="bold"
+                                    className="h-3.5 w-3.5"
+                                    aria-hidden
+                                  />
+                                </button>
+                              : null}
+                            </div>
+                          : <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              aria-label="Search armor"
+                              aria-expanded={searchExpanded}
+                              className="size-9 shrink-0 self-center rounded-none border-0 shadow-none hover:bg-accent/50"
+                              onClick={openSearchField}
+                            >
+                              <MagnifyingGlass
+                                weight="regular"
+                                aria-hidden
+                                className="size-4"
+                              />
+                            </Button>
+                          }
+                        </div>
+                      </div>
+                    </TableHead>
+                  </TableRow>
+                  <TableRow className="border-b-0 border-border hover:bg-transparent [&:hover]:bg-transparent">
+                    <TableHead
+                      className="w-px border-b border-border bg-table-header pe-2 text-table-header-foreground"
+                      aria-label="Icon"
+                    />
+                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                      Armor set
+                    </TableHead>
+                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                      Archetype
+                    </TableHead>
+                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                      Tertiary
+                    </TableHead>
+                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                      Tuning
+                    </TableHead>
+                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                      Location
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                  </Table>
                 </div>
-              </div>
-
-              <p className="shrink-0 text-xs text-muted-foreground/80">
-                Showing {filteredRows.length} piece
-                {filteredRows.length === 1 ? "" : "s"} for{" "}
-                {CLASS_NAMES[inventoryClass] ?? "class"}.
-              </p>
-
-              <div className="min-w-0 rounded-none border border-border bg-card">
-                <Table containerClassName="overflow-visible">
-                  <TableHeader className="[&_tr]:border-b-0">
+                <div className="menu-scrollbar max-h-[calc(100dvh-13rem)] min-h-0 min-w-0 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]">
+                  <Table
+                    className="w-full table-fixed border-separate border-spacing-0"
+                    containerClassName="overflow-visible"
+                  >
+                    {INVENTORY_TABLE_COLGROUP}
+                <TableBody>
+                  {filteredRows.length === 0 ?
                     <TableRow className="border-border hover:bg-transparent">
-                      <TableHead
-                        className="sticky top-0 z-10 w-px border-b border-border bg-card pe-2 text-muted-foreground"
-                        aria-label="Icon"
-                      />
-                      <TableHead className="sticky top-0 z-10 border-b border-border bg-card text-muted-foreground">
-                        Armor set
-                      </TableHead>
-                      <TableHead className="sticky top-0 z-10 border-b border-border bg-card text-muted-foreground">
-                        Archetype
-                      </TableHead>
-                      <TableHead className="sticky top-0 z-10 border-b border-border bg-card text-muted-foreground">
-                        Tertiary
-                      </TableHead>
-                      <TableHead className="sticky top-0 z-10 border-b border-border bg-card text-muted-foreground">
-                        Tuning
-                      </TableHead>
-                      <TableHead className="sticky top-0 z-10 border-b border-border bg-card text-muted-foreground">
-                        Location
-                      </TableHead>
+                      <TableCell
+                        colSpan={6}
+                        className="py-8 text-center text-sm text-muted-foreground/80"
+                      >
+                        No armor matches these filters.
+                      </TableCell>
                     </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filteredRows.length === 0 ? (
-                      <TableRow className="border-border hover:bg-transparent">
-                        <TableCell
-                          colSpan={6}
-                          className="py-8 text-center text-sm text-muted-foreground/80"
-                        >
-                          No armor matches these filters.
+                  : filteredRows.map((piece) => (
+                      <TableRow
+                        key={piece.itemInstanceId}
+                        className="border-border hover:bg-accent/60"
+                      >
+                        <TableCell className="w-px whitespace-nowrap py-1 pe-2 align-middle">
+                          {piece.iconPath ?
+                            <span className="inline-flex rounded-none border border-border bg-accent leading-none">
+                              {/* eslint-disable-next-line @next/next/no-img-element -- Bungie CDN thumbnails; avoid bloating the bundle with next/image remotePatterns. */}
+                              <img
+                                src={bungieIconUrl(piece.iconPath)}
+                                alt={`${SLOT_LABELS[piece.slot]} — ${piece.setName ?? "armor"}`}
+                                className="block h-auto max-h-7 max-w-9 w-auto"
+                                loading="lazy"
+                              />
+                            </span>
+                          : <div
+                              role="img"
+                              aria-label={`${SLOT_LABELS[piece.slot]} — no artwork`}
+                              className="inline-block size-7 rounded-none border border-border bg-accent/60"
+                            />
+                          }
+                        </TableCell>
+                        <TableCell className="py-1.5 text-foreground/90">
+                          {piece.setName ?? "—"}
+                        </TableCell>
+                        <TableCell className="py-1.5 text-foreground/90">
+                          {piece.archetypeName ?? "—"}
+                        </TableCell>
+                        <TableCell className="py-1.5 text-foreground/80">
+                          {piece.tertiaryStat ?? "—"}
+                        </TableCell>
+                        <TableCell className="py-1.5 text-foreground/90">
+                          {piece.tuningName ?? "—"}
+                        </TableCell>
+                        <TableCell className="py-1.5 text-muted-foreground">
+                          {formatLocation(piece)}
                         </TableCell>
                       </TableRow>
-                    ) : (
-                      filteredRows.map((piece) => (
-                        <TableRow
-                          key={piece.itemInstanceId}
-                          className="border-border hover:bg-accent/60"
-                        >
-                          <TableCell className="w-px whitespace-nowrap py-1 pe-2 align-middle">
-                            {piece.iconPath ? (
-                              <span className="inline-flex rounded-none border border-border bg-accent leading-none">
-                                {/* eslint-disable-next-line @next/next/no-img-element -- Bungie CDN thumbnails; avoid bloating the bundle with next/image remotePatterns. */}
-                                <img
-                                  src={bungieIconUrl(piece.iconPath)}
-                                  alt={`${SLOT_LABELS[piece.slot]} — ${piece.setName ?? "armor"}`}
-                                  className="block max-h-7 max-w-9 h-auto w-auto"
-                                  loading="lazy"
-                                />
-                              </span>
-                            ) : (
-                              <div
-                                role="img"
-                                aria-label={`${SLOT_LABELS[piece.slot]} — no artwork`}
-                                className="inline-block size-7 rounded-none border border-border bg-accent/60"
-                              />
-                            )}
-                          </TableCell>
-                          <TableCell className="py-1.5 text-foreground/90">
-                            {piece.setName ?? "—"}
-                          </TableCell>
-                          <TableCell className="py-1.5 text-foreground/90">
-                            {piece.archetypeName ?? "—"}
-                          </TableCell>
-                          <TableCell className="py-1.5 text-foreground/80">
-                            {piece.tertiaryStat ?? "—"}
-                          </TableCell>
-                          <TableCell className="py-1.5 text-foreground/90">
-                            {piece.tuningName ?? "—"}
-                          </TableCell>
-                          <TableCell className="py-1.5 text-muted-foreground">
-                            {formatLocation(piece)}
-                          </TableCell>
-                        </TableRow>
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
+                    ))
+                  }
+                </TableBody>
+                  </Table>
+                </div>
               </div>
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/views/armor-set-combobox.tsx
+++ b/src/components/views/armor-set-combobox.tsx
@@ -499,6 +499,244 @@ export interface ArmorSetMultiComboboxProps {
   "aria-label"?: string;
 }
 
+export interface ArmorSetMultiSelectPanelProps {
+  /** When provided, used as the listbox element `id` (e.g. combobox `aria-controls`). */
+  listboxDomId?: string;
+  options: TrackerOptionItem[];
+  values: string[];
+  onValuesChange: (hashes: string[]) => void;
+  emptyCatalogMessage?: string;
+  sharpCorners?: boolean;
+  pinnedHashes?: readonly string[];
+  onTogglePin?: (hash: string) => void;
+  /** Outer wrapper (`flex` column + max-height). */
+  className?: string;
+  /**
+   * Focus the armor-set search field after mount (e.g. popover or submenu
+   * opened). Pass the parent `open` flag so focusing runs when it becomes true.
+   */
+  autoFocusSearch?: boolean;
+}
+
+/**
+ * List + search shell shared by {@link ArmorSetMultiCombobox} and nested filter
+ * UIs (e.g. dashboard inventory mega-menu).
+ */
+export function ArmorSetMultiSelectPanel({
+  listboxDomId,
+  options,
+  values,
+  onValuesChange,
+  emptyCatalogMessage = "No sets available — sync the manifest first.",
+  sharpCorners = false,
+  pinnedHashes,
+  onTogglePin,
+  className,
+  autoFocusSearch = false,
+}: ArmorSetMultiSelectPanelProps) {
+  const autoListboxId = useId();
+  const listboxId = listboxDomId ?? autoListboxId;
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [highlightIndex, setHighlightIndex] = useState(0);
+
+  const valueSet = useMemo(() => new Set(values), [values]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q.length) return options;
+    return options.filter((o) => o.name.toLowerCase().includes(q));
+  }, [options, query]);
+
+  const { pinned, unpinned, sectioned } = useMemo(
+    () => partitionByPin(filtered, pinnedHashes, query),
+    [filtered, pinnedHashes, query],
+  );
+  const displayedOptions = useMemo(
+    () => [...pinned, ...unpinned],
+    [pinned, unpinned],
+  );
+
+  const pinnedSet = useMemo(
+    () => new Set(pinnedHashes ?? []),
+    [pinnedHashes],
+  );
+
+  useLayoutEffect(() => {
+    if (!autoFocusSearch) return;
+    queueMicrotask(() => searchRef.current?.focus({ preventScroll: true }));
+  }, [autoFocusSearch]);
+
+  function toggle(hashStr: string) {
+    const next = valueSet.has(hashStr)
+      ? values.filter((h) => h !== hashStr)
+      : [...values, hashStr];
+    onValuesChange(next);
+  }
+
+  const focusedIndex =
+    displayedOptions.length === 0
+      ? 0
+      : Math.min(Math.max(0, highlightIndex), displayedOptions.length - 1);
+
+  return (
+    <div
+      className={cn(
+        "flex max-h-[min(90vh,26rem)] flex-col overflow-hidden",
+        className,
+      )}
+    >
+      <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 pb-2 pt-1.5">
+        <MagnifyingGlass
+          weight="regular"
+          className="pointer-events-none h-4 w-4 shrink-0 text-muted-foreground"
+          aria-hidden
+        />
+        <input
+          ref={searchRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setHighlightIndex(0);
+          }}
+          placeholder="Search armor sets..."
+          aria-label="Search armor sets"
+          className={cn(
+            "h-8 w-full min-w-0 bg-transparent px-2 py-0 text-sm text-foreground caret-foreground outline-none placeholder:text-muted-foreground",
+            "border-0 border-transparent shadow-none ring-0 focus:border-transparent focus-visible:ring-0 focus:ring-0",
+            sharpCorners ? "rounded-none" : "rounded-md",
+          )}
+          onKeyDown={(e) => {
+            if (!displayedOptions.length) return;
+            if (e.key === "ArrowDown") {
+              e.preventDefault();
+              setHighlightIndex((i) =>
+                Math.min(i + 1, displayedOptions.length - 1),
+              );
+            }
+            if (e.key === "ArrowUp") {
+              e.preventDefault();
+              setHighlightIndex((i) => Math.max(i - 1, 0));
+            }
+            if (e.key === "Enter") {
+              e.preventDefault();
+              const picked = displayedOptions[focusedIndex];
+              if (picked) toggle(String(picked.hash));
+            }
+            if (e.key === "Home") {
+              e.preventDefault();
+              setHighlightIndex(0);
+            }
+            if (e.key === "End") {
+              e.preventDefault();
+              setHighlightIndex(displayedOptions.length - 1);
+            }
+          }}
+        />
+        {query.length > 0 ? (
+          <SearchClearButton
+            onClear={() => {
+              setQuery("");
+              setHighlightIndex(0);
+              searchRef.current?.focus({ preventScroll: true });
+            }}
+          />
+        ) : null}
+      </div>
+      <ul
+        id={listboxId}
+        role="listbox"
+        aria-multiselectable
+        data-skip-canvas-wheel=""
+        className="menu-scrollbar max-h-72 min-h-0 touch-pan-y overflow-y-auto overscroll-contain px-0 py-1 motion-reduce:scroll-auto"
+      >
+        {displayedOptions.length === 0 ? (
+          <li className="px-2 py-2.5 text-sm text-muted-foreground">
+            {options.length === 0 ? emptyCatalogMessage : "No matches."}
+          </li>
+        ) : (
+          <>
+            {sectioned ? <PinnedSectionLabel /> : null}
+            {pinned.map((opt, pinIdx) => {
+              const idx = pinIdx;
+              const sel = valueSet.has(String(opt.hash));
+              const active = idx === focusedIndex;
+              const isPinned = pinnedSet.has(String(opt.hash));
+              return (
+                <li
+                  key={opt.hash}
+                  id={`${listboxId}-${opt.hash}`}
+                  role="option"
+                  aria-selected={sel}
+                  className={cn(
+                    "group relative flex w-full cursor-pointer select-none items-center rounded-none py-1.5 pl-8 pr-9 text-sm text-popover-foreground outline-none transition-colors",
+                    active && "bg-accent text-accent-foreground",
+                  )}
+                  onMouseEnter={() => setHighlightIndex(idx)}
+                  onClick={() => toggle(String(opt.hash))}
+                >
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute left-2 top-1/2 flex h-4 w-4 -translate-y-1/2 shrink-0 items-center justify-center border border-current/40"
+                  >
+                    {sel ? <Check weight="bold" className="h-3 w-3" /> : null}
+                  </span>
+                  <span className="truncate">{opt.name}</span>
+                  {onTogglePin ? (
+                    <PinButton
+                      pinned={isPinned}
+                      name={opt.name}
+                      onToggle={() => onTogglePin(String(opt.hash))}
+                    />
+                  ) : null}
+                </li>
+              );
+            })}
+            {sectioned ? <PinnedSectionDivider /> : null}
+            {unpinned.map((opt, unpinnedIdx) => {
+              const idx = pinned.length + unpinnedIdx;
+              const sel = valueSet.has(String(opt.hash));
+              const active = idx === focusedIndex;
+              const isPinned = pinnedSet.has(String(opt.hash));
+              return (
+                <li
+                  key={opt.hash}
+                  id={`${listboxId}-${opt.hash}`}
+                  role="option"
+                  aria-selected={sel}
+                  className={cn(
+                    "group relative flex w-full cursor-pointer select-none items-center rounded-none py-1.5 pl-8 text-sm text-popover-foreground outline-none transition-colors",
+                    onTogglePin ? "pr-9" : "pr-2",
+                    active && "bg-accent text-accent-foreground",
+                  )}
+                  onMouseEnter={() => setHighlightIndex(idx)}
+                  onClick={() => toggle(String(opt.hash))}
+                >
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute left-2 top-1/2 flex h-4 w-4 -translate-y-1/2 shrink-0 items-center justify-center border border-current/40"
+                  >
+                    {sel ? <Check weight="bold" className="h-3 w-3" /> : null}
+                  </span>
+                  <span className="truncate">{opt.name}</span>
+                  {onTogglePin ? (
+                    <PinButton
+                      pinned={isPinned}
+                      name={opt.name}
+                      onToggle={() => onTogglePin(String(opt.hash))}
+                    />
+                  ) : null}
+                </li>
+              );
+            })}
+          </>
+        )}
+      </ul>
+    </div>
+  );
+}
+
 function armorSetMultiSummary(
   values: string[],
   options: TrackerOptionItem[],
@@ -531,35 +769,10 @@ export function ArmorSetMultiCombobox({
   onTogglePin,
   "aria-label": ariaLabel,
 }: ArmorSetMultiComboboxProps) {
-  const listboxId = useId();
-  const searchRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxStableId = useId();
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
   const [panelWidth, setPanelWidth] = useState<number | undefined>();
-  const [highlightIndex, setHighlightIndex] = useState(0);
-
-  const valueSet = useMemo(() => new Set(values), [values]);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q.length) return options;
-    return options.filter((o) => o.name.toLowerCase().includes(q));
-  }, [options, query]);
-
-  const { pinned, unpinned, sectioned } = useMemo(
-    () => partitionByPin(filtered, pinnedHashes, query),
-    [filtered, pinnedHashes, query],
-  );
-  const displayedOptions = useMemo(
-    () => [...pinned, ...unpinned],
-    [pinned, unpinned],
-  );
-
-  const pinnedSet = useMemo(
-    () => new Set(pinnedHashes ?? []),
-    [pinnedHashes],
-  );
 
   const summary = armorSetMultiSummary(values, options, placeholder);
 
@@ -570,23 +783,7 @@ export function ArmorSetMultiCombobox({
 
   function closeAndReset(nextOpen: boolean) {
     setOpen(nextOpen);
-    if (!nextOpen) {
-      setQuery("");
-      setHighlightIndex(0);
-    }
   }
-
-  function toggle(hashStr: string) {
-    const next = valueSet.has(hashStr)
-      ? values.filter((h) => h !== hashStr)
-      : [...values, hashStr];
-    onValuesChange(next);
-  }
-
-  const focusedIndex =
-    displayedOptions.length === 0
-      ? 0
-      : Math.min(Math.max(0, highlightIndex), displayedOptions.length - 1);
 
   return (
     <Popover open={open} onOpenChange={closeAndReset}>
@@ -598,7 +795,7 @@ export function ArmorSetMultiCombobox({
           role="combobox"
           aria-expanded={open}
           aria-haspopup="listbox"
-          aria-controls={open ? listboxId : undefined}
+          aria-controls={open ? listboxStableId : undefined}
           aria-label={ariaLabel}
           disabled={disabled}
           className={
@@ -641,158 +838,20 @@ export function ArmorSetMultiCombobox({
         style={panelWidth ? { width: panelWidth } : undefined}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
-          queueMicrotask(() => searchRef.current?.focus({ preventScroll: true }));
+          /* Search focus is delegated to ArmorSetMultiSelectPanel. */
         }}
       >
-        <div className="flex max-h-[min(90vh,26rem)] flex-col overflow-hidden">
-          <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2 pb-2 pt-1.5">
-            <MagnifyingGlass
-              weight="regular"
-              className="pointer-events-none h-4 w-4 shrink-0 text-muted-foreground"
-              aria-hidden
-            />
-            <input
-              ref={searchRef}
-              type="text"
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setHighlightIndex(0);
-              }}
-              placeholder="Search armor sets..."
-              aria-label="Search armor sets"
-              className={cn(
-                "h-8 w-full min-w-0 bg-transparent px-2 py-0 text-sm text-foreground caret-foreground outline-none placeholder:text-muted-foreground",
-                "border-0 border-transparent shadow-none ring-0 focus:border-transparent focus-visible:ring-0 focus:ring-0",
-                sharpCorners ? "rounded-none" : "rounded-md",
-              )}
-              onKeyDown={(e) => {
-                if (!displayedOptions.length) return;
-                if (e.key === "ArrowDown") {
-                  e.preventDefault();
-                  setHighlightIndex((i) =>
-                    Math.min(i + 1, displayedOptions.length - 1),
-                  );
-                }
-                if (e.key === "ArrowUp") {
-                  e.preventDefault();
-                  setHighlightIndex((i) => Math.max(i - 1, 0));
-                }
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  const picked = displayedOptions[focusedIndex];
-                  if (picked) toggle(String(picked.hash));
-                }
-                if (e.key === "Home") {
-                  e.preventDefault();
-                  setHighlightIndex(0);
-                }
-                if (e.key === "End") {
-                  e.preventDefault();
-                  setHighlightIndex(displayedOptions.length - 1);
-                }
-              }}
-            />
-            {query.length > 0 ? (
-              <SearchClearButton
-                onClear={() => {
-                  setQuery("");
-                  setHighlightIndex(0);
-                  searchRef.current?.focus({ preventScroll: true });
-                }}
-              />
-            ) : null}
-          </div>
-          <ul
-            id={listboxId}
-            role="listbox"
-            aria-multiselectable
-            data-skip-canvas-wheel=""
-            className="menu-scrollbar max-h-72 min-h-0 touch-pan-y overflow-y-auto overscroll-contain px-0 py-1 motion-reduce:scroll-auto"
-          >
-            {displayedOptions.length === 0 ? (
-              <li className="px-2 py-2.5 text-sm text-muted-foreground">
-                {options.length === 0 ? emptyCatalogMessage : "No matches."}
-              </li>
-            ) : (
-              <>
-                {sectioned ? <PinnedSectionLabel /> : null}
-                {pinned.map((opt, pinIdx) => {
-                  const idx = pinIdx;
-                  const sel = valueSet.has(String(opt.hash));
-                  const active = idx === focusedIndex;
-                  const isPinned = pinnedSet.has(String(opt.hash));
-                  return (
-                    <li
-                      key={opt.hash}
-                      id={`${listboxId}-${opt.hash}`}
-                      role="option"
-                      aria-selected={sel}
-                      className={cn(
-                        "group relative flex w-full cursor-pointer select-none items-center rounded-none py-1.5 pl-8 pr-9 text-sm text-popover-foreground outline-none transition-colors",
-                        active && "bg-accent text-accent-foreground",
-                      )}
-                      onMouseEnter={() => setHighlightIndex(idx)}
-                      onClick={() => toggle(String(opt.hash))}
-                    >
-                      <span
-                        aria-hidden
-                        className="pointer-events-none absolute left-2 top-1/2 flex h-4 w-4 -translate-y-1/2 shrink-0 items-center justify-center border border-current/40"
-                      >
-                        {sel ? <Check weight="bold" className="h-3 w-3" /> : null}
-                      </span>
-                      <span className="truncate">{opt.name}</span>
-                      {onTogglePin ? (
-                        <PinButton
-                          pinned={isPinned}
-                          name={opt.name}
-                          onToggle={() => onTogglePin(String(opt.hash))}
-                        />
-                      ) : null}
-                    </li>
-                  );
-                })}
-                {sectioned ? <PinnedSectionDivider /> : null}
-                {unpinned.map((opt, unpinnedIdx) => {
-                  const idx = pinned.length + unpinnedIdx;
-                  const sel = valueSet.has(String(opt.hash));
-                  const active = idx === focusedIndex;
-                  const isPinned = pinnedSet.has(String(opt.hash));
-                  return (
-                    <li
-                      key={opt.hash}
-                      id={`${listboxId}-${opt.hash}`}
-                      role="option"
-                      aria-selected={sel}
-                      className={cn(
-                        "group relative flex w-full cursor-pointer select-none items-center rounded-none py-1.5 pl-8 text-sm text-popover-foreground outline-none transition-colors",
-                        onTogglePin ? "pr-9" : "pr-2",
-                        active && "bg-accent text-accent-foreground",
-                      )}
-                      onMouseEnter={() => setHighlightIndex(idx)}
-                      onClick={() => toggle(String(opt.hash))}
-                    >
-                      <span
-                        aria-hidden
-                        className="pointer-events-none absolute left-2 top-1/2 flex h-4 w-4 -translate-y-1/2 shrink-0 items-center justify-center border border-current/40"
-                      >
-                        {sel ? <Check weight="bold" className="h-3 w-3" /> : null}
-                      </span>
-                      <span className="truncate">{opt.name}</span>
-                      {onTogglePin ? (
-                        <PinButton
-                          pinned={isPinned}
-                          name={opt.name}
-                          onToggle={() => onTogglePin(String(opt.hash))}
-                        />
-                      ) : null}
-                    </li>
-                  );
-                })}
-              </>
-            )}
-          </ul>
-        </div>
+        <ArmorSetMultiSelectPanel
+          listboxDomId={listboxStableId}
+          options={options}
+          values={values}
+          onValuesChange={onValuesChange}
+          emptyCatalogMessage={emptyCatalogMessage}
+          sharpCorners={sharpCorners}
+          pinnedHashes={pinnedHashes}
+          onTogglePin={onTogglePin}
+          autoFocusSearch={open}
+        />
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
## Summary

- Reworks the dashboard **inventory table** layout: shrink-wrapped card height, scroll cap, and row count beside **Filters** (nested filter mega-menu).
- Extracts **`ArmorSetMultiSelectPanel`** from the armor-set combobox for reuse in filter submenus.
- Adds **`--table-header`** / **`--table-header-foreground`** tokens and wires **Storybook** wrappers with a flex column shell; **`DashboardWorkspace`** uses a full-height flex column so table mode fills the viewport correctly.

## Test plan

- [ ] `/dashboard` → **Table** mode: class tabs, Filters submenu (sets / archetypes / tertiary / tuning), search, inventory rows render and counts update when filters change.
- [ ] Long inventory: body scrolls; short inventory: card height hugs content (no large empty band).
- [ ] `npm run build`
- [ ] (Optional) `npm run storybook` → **Dashboard / InventoryTableView** stories


Made with [Cursor](https://cursor.com)