### PR TITLE
feat(dashboard): tracker grid workspace, persisted filters, and table mode

### DIFF
--- a/.storybook/mocks/grid-filters.ts
+++ b/.storybook/mocks/grid-filters.ts
@@ -1,0 +1,16 @@
+import {
+  defaultGridFilters,
+  type GridFiltersJson,
+} from "@/lib/workspace/grid-filters-schema";
+
+export const MOCK_GRID_FILTERS_EMPTY: GridFiltersJson = defaultGridFilters();
+
+export const MOCK_GRID_FILTERS_POPULATED: GridFiltersJson = {
+  version: 1,
+  class: 0,
+  setHashes: [1001],
+  archetypeHashes: [2005],
+  tuningHashes: [],
+  tertiaryStats: ["Health"],
+  search: "",
+};

--- a/.storybook/mocks/grid-lookup.ts
+++ b/.storybook/mocks/grid-lookup.ts
@@ -1,0 +1,44 @@
+import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
+import {
+  MOCK_ARCHETYPES,
+  MOCK_ARMOR_SETS,
+  MOCK_TUNINGS,
+} from "./manifest-lookups";
+
+/** Lightweight lookup payload for grid stories — names only, no icons. */
+export const MOCK_GRID_LOOKUP_PAYLOAD: GridLookupPayload = {
+  setNameByHash: Object.fromEntries(
+    MOCK_ARMOR_SETS.map((s) => [String(s.set_hash), s.name]),
+  ),
+  archetypeNameByHash: Object.fromEntries(
+    MOCK_ARCHETYPES.map((a) => [String(a.archetype_hash), a.name]),
+  ),
+  tuningNameByHash: Object.fromEntries(
+    MOCK_TUNINGS.map((t) => [String(t.tuning_hash), t.name]),
+  ),
+  armorSlotIconByKey: {},
+  slotFallbackIconByName: {},
+  archetypeStatPair: {
+    [String(MOCK_ARCHETYPES[0].archetype_hash)]: {
+      primary: "Weapons",
+      secondary: "Health",
+    },
+    [String(MOCK_ARCHETYPES[1].archetype_hash)]: {
+      primary: "Health",
+      secondary: "Class",
+    },
+    [String(MOCK_ARCHETYPES[2].archetype_hash)]: {
+      primary: "Grenade",
+      secondary: "Melee",
+    },
+    [String(MOCK_ARCHETYPES[3].archetype_hash)]: {
+      primary: "Super",
+      secondary: "Weapons",
+    },
+    [String(MOCK_ARCHETYPES[4].archetype_hash)]: {
+      primary: "Weapons",
+      secondary: "Grenade",
+    },
+  },
+  statIconByName: {},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.105.1",
+        "@tanstack/react-virtual": "^3.13.24",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "jose": "^6.2.3",
@@ -1186,9 +1187,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1204,9 +1202,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1224,9 +1219,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1242,9 +1234,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1262,9 +1251,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1280,9 +1266,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1300,9 +1283,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1319,9 +1299,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1337,9 +1314,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1363,9 +1337,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1387,9 +1358,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1413,9 +1381,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1437,9 +1402,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1463,9 +1425,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1488,9 +1447,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1512,9 +1468,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1770,9 +1723,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,9 +1738,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1808,9 +1755,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1826,9 +1770,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3017,9 +2958,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3037,9 +2975,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3057,9 +2992,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3077,9 +3009,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3097,9 +3026,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3117,9 +3043,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3854,9 +3777,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3874,9 +3794,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3894,9 +3811,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3914,9 +3828,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4002,6 +3913,33 @@
         "@tailwindcss/oxide": "4.2.4",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4708,9 +4646,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4725,9 +4660,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4742,9 +4674,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4759,9 +4688,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4776,9 +4702,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4793,9 +4716,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4810,9 +4730,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4827,9 +4744,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8321,9 +8235,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8345,9 +8256,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8369,9 +8277,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8393,9 +8298,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.105.1",
+    "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "jose": "^6.2.3",

--- a/src/app/api/me/workspace/route.ts
+++ b/src/app/api/me/workspace/route.ts
@@ -3,12 +3,18 @@ import { z } from "zod";
 import { crossSiteOriginBlockResponse } from "@/lib/auth/api-origin-check";
 import { getSessionFromRequest } from "@/lib/auth/session";
 import { getServiceRoleClient } from "@/lib/db/server";
-import type { Json } from "@/lib/db/types";
+import type { Json, TablesUpdate } from "@/lib/db/types";
 import { workspaceCameraSchema } from "@/lib/workspace/workspace-schema";
+import { gridFiltersSchema } from "@/lib/workspace/grid-filters-schema";
 
-const patchSchema = z.object({
-  camera: workspaceCameraSchema,
-});
+const patchSchema = z
+  .object({
+    camera: workspaceCameraSchema.optional(),
+    gridFilters: gridFiltersSchema.optional(),
+  })
+  .refine((d) => d.camera !== undefined || d.gridFilters !== undefined, {
+    message: "Must include camera or gridFilters",
+  });
 
 export async function PATCH(req: NextRequest) {
   const blocked = crossSiteOriginBlockResponse(req);
@@ -34,13 +40,20 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
+  const update: TablesUpdate<"users"> = {
+    updated_at: new Date().toISOString(),
+  };
+  if (parsed.data.camera !== undefined) {
+    update.workspace_camera = parsed.data.camera as Json;
+  }
+  if (parsed.data.gridFilters !== undefined) {
+    update.grid_filters = parsed.data.gridFilters as Json;
+  }
+
   const sb = getServiceRoleClient();
   const { error } = await sb
     .from("users")
-    .update({
-      workspace_camera: parsed.data.camera as Json,
-      updated_at: new Date().toISOString(),
-    })
+    .update(update)
     .eq("id", session.userId);
 
   if (error) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,37 +7,25 @@ import {
   syncUserInventory,
   InventoryNotReady,
 } from "@/lib/inventory/sync";
-import { listViewsForUser } from "@/lib/views/queries";
 import { getManifestLookups } from "@/lib/manifest/lookups";
 import { checkManifestVersion } from "@/lib/manifest/version-check";
 import { SyncManifestButton } from "@/components/dashboard/sync-manifest-button";
-import { buildSerializableTrackerPayload } from "@/lib/workspace/build-tracker-payload";
 import { DashboardWorkspace } from "@/components/dashboard/dashboard-workspace";
 import { manifestSelectorsFromLookups } from "@/lib/views/manifest-selectors-from-lookup";
-import { parseWorkspaceCamera } from "@/lib/workspace/workspace-schema";
+import { buildGridLookupPayload } from "@/lib/views/grid-lookup-payload.server";
+import { parseGridFilters } from "@/lib/workspace/grid-filters-schema";
 import { bungieIconUrl } from "@/lib/bungie/constants";
 
 export const dynamic = "force-dynamic";
 
-interface DashboardPageProps {
-  searchParams: Promise<{ tracker?: string }>;
-}
-
-export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+export default async function DashboardPage() {
   const session = await getSession();
   if (!session) redirect("/");
-
-  const sp = await searchParams;
-  const rawTracker = typeof sp?.tracker === "string" ? sp.tracker.trim() : "";
-  const focusTrackerId =
-    rawTracker.length > 0 && /^[\da-f-]{36}$/i.test(rawTracker)
-      ? rawTracker
-      : null;
 
   const sb = getServiceRoleClient();
   const { data: userRow } = await sb
     .from("users")
-    .select("display_name, workspace_camera, profile_picture_path")
+    .select("display_name, profile_picture_path, grid_filters")
     .eq("id", session.userId)
     .maybeSingle();
   const displayName = userRow?.display_name ?? session.displayName;
@@ -46,7 +34,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
     userRow.profile_picture_path.trim().length > 0
       ? bungieIconUrl(userRow.profile_picture_path.trim())
       : null;
-  const initialCamera = parseWorkspaceCamera(userRow?.workspace_camera ?? null);
+  const initialGridFilters = parseGridFilters(userRow?.grid_filters ?? null);
 
   let syncWarning: string | null = null;
   try {
@@ -66,8 +54,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
     }
   }
 
-  const [views, cached, lookups, versionCheck] = await Promise.all([
-    listViewsForUser(session.userId),
+  const [cached, lookups, versionCheck] = await Promise.all([
     getCachedInventoryWithSyncedAt(session.userId),
     getManifestLookups(),
     checkManifestVersion(),
@@ -75,11 +62,8 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
 
   const inventory = cached?.items ?? [];
 
-  const trackerPayloads = views.map((view) =>
-    buildSerializableTrackerPayload(view, lookups, inventory),
-  );
-
   const selectors = manifestSelectorsFromLookups(lookups);
+  const lookupPayload = buildGridLookupPayload(lookups);
 
   const banners = (
     <>
@@ -148,13 +132,12 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       displayName={displayName}
       profilePictureUrl={profilePictureUrl}
       banners={banners}
-      initialTrackers={trackerPayloads}
-      initialCamera={initialCamera}
-      focusTrackerId={focusTrackerId}
       syncWarning={syncWarning}
       hasInventory={cached !== null}
       selectors={selectors}
       inventory={inventory}
+      lookupPayload={lookupPayload}
+      initialGridFilters={initialGridFilters}
     />
   );
 }

--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
 import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
+import { useGridFiltersPersistence } from "@/lib/workspace/use-grid-filters-persistence";
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
 import { AppHeader } from "@/components/app-header";
 import { GridWorkspace } from "@/components/workspace/grid-workspace";
@@ -39,6 +40,8 @@ export function DashboardWorkspace({
 }: DashboardWorkspaceProps) {
   const [mode, setMode] = useState<WorkspaceViewMode>("grid");
   const tabs = <WorkspaceViewModeTabs mode={mode} onModeChange={setMode} />;
+  const { filters, onFiltersChange } =
+    useGridFiltersPersistence(initialGridFilters);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -54,6 +57,8 @@ export function DashboardWorkspace({
           hasInventory={hasInventory}
           inventory={inventory}
           selectors={selectors}
+          filters={filters}
+          onFiltersChange={onFiltersChange}
         />
       ) : (
         <GridWorkspace
@@ -63,7 +68,8 @@ export function DashboardWorkspace({
           selectors={selectors}
           inventory={inventory}
           lookupPayload={lookupPayload}
-          initialFilters={initialGridFilters}
+          filters={filters}
+          onFiltersChange={onFiltersChange}
         />
       )}
     </div>

--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -3,11 +3,11 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
-import type { SerializableTrackerPayload } from "@/lib/workspace/types";
-import type { WorkspaceCameraJson } from "@/lib/workspace/workspace-schema";
+import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
+import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
 import { AppHeader } from "@/components/app-header";
-import { CanvasWorkspace } from "@/components/workspace/canvas-workspace";
+import { GridWorkspace } from "@/components/workspace/grid-workspace";
 import { InventoryTableView } from "@/components/dashboard/inventory-table-view";
 import {
   WorkspaceViewModeTabs,
@@ -18,28 +18,26 @@ export interface DashboardWorkspaceProps {
   displayName: string;
   profilePictureUrl: string | null;
   banners: ReactNode;
-  initialTrackers: SerializableTrackerPayload[];
-  initialCamera: WorkspaceCameraJson;
-  focusTrackerId: string | null;
   syncWarning: string | null;
   hasInventory: boolean;
   selectors: TrackerFormSelectors;
   inventory: DerivedArmorPieceJson[];
+  lookupPayload: GridLookupPayload;
+  initialGridFilters: GridFiltersJson;
 }
 
 export function DashboardWorkspace({
   displayName,
   profilePictureUrl,
   banners,
-  initialTrackers,
-  initialCamera,
-  focusTrackerId,
   syncWarning,
   hasInventory,
   selectors,
   inventory,
+  lookupPayload,
+  initialGridFilters,
 }: DashboardWorkspaceProps) {
-  const [mode, setMode] = useState<WorkspaceViewMode>("canvas");
+  const [mode, setMode] = useState<WorkspaceViewMode>("grid");
   const tabs = <WorkspaceViewModeTabs mode={mode} onModeChange={setMode} />;
 
   return (
@@ -58,14 +56,14 @@ export function DashboardWorkspace({
           selectors={selectors}
         />
       ) : (
-        <CanvasWorkspace
+        <GridWorkspace
           banners={banners}
-          initialTrackers={initialTrackers}
-          initialCamera={initialCamera}
-          focusTrackerId={focusTrackerId}
           syncWarning={syncWarning}
           hasInventory={hasInventory}
           selectors={selectors}
+          inventory={inventory}
+          lookupPayload={lookupPayload}
+          initialFilters={initialGridFilters}
         />
       )}
     </div>

--- a/src/components/dashboard/inventory-table-view.stories.tsx
+++ b/src/components/dashboard/inventory-table-view.stories.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import {
   EMPTY_INVENTORY,
   MOCK_INVENTORY,
 } from "../../../.storybook/mocks/armor-pieces";
+import { MOCK_GRID_FILTERS_EMPTY } from "../../../.storybook/mocks/grid-filters";
 import { MOCK_TRACKER_FORM_SELECTORS } from "../../../.storybook/mocks/tracker-options";
 
 import { InventoryTableView } from "./inventory-table-view";
@@ -17,41 +19,62 @@ export default meta;
 
 type Story = StoryObj<typeof InventoryTableView>;
 
-export const Loaded: Story = {
-  render: () => (
+function LoadedShell() {
+  const [filters, setFilters] = useState(MOCK_GRID_FILTERS_EMPTY);
+  return (
     <div className="flex h-[80vh] flex-col bg-background">
       <InventoryTableView
         hasInventory
         inventory={MOCK_INVENTORY}
         selectors={MOCK_TRACKER_FORM_SELECTORS}
         syncWarning={null}
+        filters={filters}
+        onFiltersChange={setFilters}
       />
     </div>
-  ),
-};
+  );
+}
 
-export const NoInventory: Story = {
-  render: () => (
+function NoInventoryShell() {
+  const [filters, setFilters] = useState(MOCK_GRID_FILTERS_EMPTY);
+  return (
     <div className="flex h-[80vh] flex-col bg-background">
       <InventoryTableView
         hasInventory={false}
         inventory={EMPTY_INVENTORY}
         selectors={MOCK_TRACKER_FORM_SELECTORS}
         syncWarning={null}
+        filters={filters}
+        onFiltersChange={setFilters}
       />
     </div>
-  ),
-};
+  );
+}
 
-export const SyncWarning: Story = {
-  render: () => (
+function SyncWarningShell() {
+  const [filters, setFilters] = useState(MOCK_GRID_FILTERS_EMPTY);
+  return (
     <div className="flex h-[80vh] flex-col bg-background">
       <InventoryTableView
         hasInventory
         inventory={MOCK_INVENTORY}
         selectors={MOCK_TRACKER_FORM_SELECTORS}
         syncWarning="Bungie returned only equipped items. Re-grant the inventory scope."
+        filters={filters}
+        onFiltersChange={setFilters}
       />
     </div>
-  ),
+  );
+}
+
+export const Loaded: Story = {
+  render: LoadedShell,
+};
+
+export const NoInventory: Story = {
+  render: NoInventoryShell,
+};
+
+export const SyncWarning: Story = {
+  render: SyncWarningShell,
 };

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -1,26 +1,14 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { ARMOR_STAT_NAMES, type DerivedArmorPieceJson } from "@/lib/db/types";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import {
-  CLASS_NAMES,
   SLOT_LABELS,
   SLOT_ORDER,
   bungieIconUrl,
   type ArmorSlot,
 } from "@/lib/bungie/constants";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -29,13 +17,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ArmorSetMultiSelectPanel } from "@/components/views/armor-set-combobox";
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
-import { MagnifyingGlass, SlidersHorizontal, X } from "@phosphor-icons/react/dist/ssr";
 import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
-
-const TABLE_FILTER_MENU_CONTENT =
-  "max-h-[min(60vh,20rem)] min-w-56 overflow-y-auto rounded-none py-2 shadow-xl";
+import { TrackerFilterBar } from "@/components/workspace/tracker-filter-bar";
+import {
+  defaultGridFilters,
+  type GridFiltersJson,
+} from "@/lib/workspace/grid-filters-schema";
 
 /** Shared by header + body tables so columns line up (`table-fixed`). */
 const INVENTORY_TABLE_COLGROUP = (
@@ -60,14 +48,6 @@ function formatLocation(piece: DerivedArmorPieceJson): string {
   return "Inventory";
 }
 
-type InventoryClass = 0 | 1 | 2;
-
-const CLASS_TABS: Array<{ value: InventoryClass; label: string }> = [
-  { value: 0, label: "Titan" },
-  { value: 1, label: "Hunter" },
-  { value: 2, label: "Warlock" },
-];
-
 interface InventoryTableViewProps {
   className?: string;
   banners?: ReactNode;
@@ -85,67 +65,36 @@ export function InventoryTableView({
   inventory,
   selectors,
 }: InventoryTableViewProps) {
-  const [inventoryClass, setInventoryClass] = useState<InventoryClass>(0);
-  const [setHashes, setSetHashes] = useState<string[]>([]);
-  const [archetypeHashes, setArchetypeHashes] = useState<string[]>([]);
-  const [tuningHashes, setTuningHashes] = useState<string[]>([]);
-  const [tertiaryStats, setTertiaryStats] = useState<string[]>([]);
-  const [search, setSearch] = useState("");
-  const [searchUiOpen, setSearchUiOpen] = useState(false);
-  const searchExpanded = searchUiOpen || search.trim().length > 0;
-  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [filters, setFilters] = useState<GridFiltersJson>(() =>
+    defaultGridFilters(),
+  );
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
 
-  const sortedSets = useMemo(
-    () => selectors.setsByClass[inventoryClass],
-    [selectors.setsByClass, inventoryClass],
-  );
-
-  const sortedArchetypes = useMemo(
-    () => [...selectors.archetypes].sort((a, b) => a.name.localeCompare(b.name)),
-    [selectors.archetypes],
-  );
-  const sortedTunings = useMemo(
-    () => [...selectors.tunings].sort((a, b) => a.name.localeCompare(b.name)),
-    [selectors.tunings],
-  );
-
-  const activeFilterDimCount = useMemo(() => {
-    let n = 0;
-    if (setHashes.length > 0) n += 1;
-    if (archetypeHashes.length > 0) n += 1;
-    if (tuningHashes.length > 0) n += 1;
-    if (tertiaryStats.length > 0) n += 1;
-    return n;
-  }, [setHashes, archetypeHashes, tuningHashes, tertiaryStats]);
-
   const filteredRows = useMemo(() => {
-    let rows = inventory.filter((p) => p.classType === inventoryClass);
-    if (setHashes.length > 0) {
-      const allowed = new Set(setHashes.map(Number));
-      rows = rows.filter(
-        (p) => p.setHash != null && allowed.has(p.setHash),
-      );
+    let rows = inventory.filter((p) => p.classType === filters.class);
+    if (filters.setHashes.length > 0) {
+      const allowed = new Set(filters.setHashes);
+      rows = rows.filter((p) => p.setHash != null && allowed.has(p.setHash));
     }
-    if (archetypeHashes.length > 0) {
-      const allowed = new Set(archetypeHashes.map(Number));
+    if (filters.archetypeHashes.length > 0) {
+      const allowed = new Set(filters.archetypeHashes);
       rows = rows.filter(
         (p) => p.archetypeHash != null && allowed.has(p.archetypeHash),
       );
     }
-    if (tuningHashes.length > 0) {
-      const allowed = new Set(tuningHashes.map(Number));
+    if (filters.tuningHashes.length > 0) {
+      const allowed = new Set(filters.tuningHashes);
       rows = rows.filter(
         (p) => p.tuningHash != null && allowed.has(p.tuningHash),
       );
     }
-    if (tertiaryStats.length > 0) {
-      const allowed = new Set(tertiaryStats);
+    if (filters.tertiaryStats.length > 0) {
+      const allowed = new Set(filters.tertiaryStats);
       rows = rows.filter(
         (p) => p.tertiaryStat != null && allowed.has(p.tertiaryStat),
       );
     }
-    const trimmedSearch = search.trim().toLowerCase();
+    const trimmedSearch = filters.search.trim().toLowerCase();
     if (trimmedSearch) {
       rows = rows.filter((p) => {
         const haystack = [
@@ -169,28 +118,9 @@ export function InventoryTableView({
       return a.itemHash - b.itemHash;
     });
     return rows;
-  }, [
-    inventory,
-    inventoryClass,
-    setHashes,
-    archetypeHashes,
-    tuningHashes,
-    tertiaryStats,
-    search,
-  ]);
-
-  const armorSetEmptyCopy = selectors.manifestEmpty
-    ? "Sync the manifest first."
-    : "No sets for this class.";
+  }, [inventory, filters]);
 
   const hasTopMessage = Boolean(banners) || Boolean(syncWarning);
-
-  function openSearchField() {
-    setSearchUiOpen(true);
-    queueMicrotask(() =>
-      searchInputRef.current?.focus({ preventScroll: true }),
-    );
-  }
 
   return (
     <div className={`flex min-h-0 flex-1 flex-col ${className}`}>
@@ -227,299 +157,49 @@ export function InventoryTableView({
                     containerClassName="overflow-visible"
                   >
                     {INVENTORY_TABLE_COLGROUP}
-                <TableHeader className="[&_tr]:border-b-0">
-                  <TableRow className="border-b-0 border-border hover:bg-transparent [&:hover]:bg-transparent">
-                    <TableHead
-                      colSpan={6}
-                      className="h-auto border-b-0 bg-table-header px-3 py-0 text-left align-middle font-medium text-muted-foreground shadow-[inset_0_-1px_0_0_var(--border)] [&:has([role=checkbox])]:pr-0"
-                    >
-                      <div className="grid min-h-[52px] min-w-0 grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-2">
-                        <div className="flex min-w-0 shrink-0 overflow-hidden rounded-none bg-card">
-                          {CLASS_TABS.map((tab) => (
-                            <button
-                              key={tab.value}
-                              type="button"
-                              className={cn(
-                                "flex h-9 shrink-0 items-center border border-transparent px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                                inventoryClass === tab.value &&
-                                  "border-border bg-accent text-foreground",
-                              )}
-                              onClick={() => {
-                                setInventoryClass(tab.value);
-                                setSetHashes((prev) =>
-                                  prev.filter((h) =>
-                                    selectors.setsByClass[tab.value].some(
-                                      (s) => String(s.hash) === h,
-                                    ),
-                                  ),
-                                );
-                              }}
-                            >
-                              {tab.label}
-                            </button>
-                          ))}
-                        </div>
-
-                        <div className="flex min-w-0 shrink-0 items-center gap-2 self-center sm:gap-3">
-                          <DropdownMenu modal={false}>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              aria-label="Armor filters"
-                              className="relative h-9 shrink-0 gap-1.5 rounded-none px-3 text-xs"
-                            >
-                              <SlidersHorizontal
-                                weight="duotone"
-                                aria-hidden
-                                className="size-4"
-                              />
-                              <span className="hidden sm:inline">Filters</span>
-                              {activeFilterDimCount > 0 ?
-                                <span
-                                  className="flex h-4 min-w-4 items-center justify-center rounded-none bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"
-                                  aria-hidden
-                                >
-                                  {activeFilterDimCount}
-                                </span>
-                              : null}
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            align="start"
-                            className="min-w-48 rounded-none py-1"
-                          >
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger inset>
-                                Armor sets
-                              </DropdownMenuSubTrigger>
-                              <DropdownMenuSubContent
-                                className="w-[min(90vw,22rem)] min-w-[18rem] rounded-none border-border p-0 shadow-xl"
-                                collisionPadding={16}
-                              >
-                                <ArmorSetMultiSelectPanel
-                                  key={inventoryClass}
-                                  options={sortedSets}
-                                  values={setHashes}
-                                  onValuesChange={setSetHashes}
-                                  emptyCatalogMessage={armorSetEmptyCopy}
-                                  sharpCorners
-                                  pinnedHashes={pinnedHashes}
-                                  onTogglePin={togglePin}
-                                  autoFocusSearch
-                                  className="max-h-[min(70vh,22rem)]"
-                                />
-                              </DropdownMenuSubContent>
-                            </DropdownMenuSub>
-
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger inset>
-                                Archetypes
-                              </DropdownMenuSubTrigger>
-                              <DropdownMenuSubContent
-                                className={cn(
-                                  TABLE_FILTER_MENU_CONTENT,
-                                  "min-w-64",
-                                )}
-                                collisionPadding={16}
-                              >
-                                {sortedArchetypes.length === 0 ?
-                                  <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
-                                    No archetypes — sync the manifest first.
-                                  </div>
-                                : sortedArchetypes.map((a) => {
-                                    const id = String(a.hash);
-                                    return (
-                                      <DropdownMenuCheckboxItem
-                                        key={a.hash}
-                                        checked={archetypeHashes.includes(id)}
-                                        onSelect={(e) => e.preventDefault()}
-                                        onCheckedChange={(c) => {
-                                          setArchetypeHashes((prev) =>
-                                            c
-                                              ? [...prev, id]
-                                              : prev.filter((h) => h !== id),
-                                          );
-                                        }}
-                                      >
-                                        {a.name}
-                                      </DropdownMenuCheckboxItem>
-                                    );
-                                  })
-                                }
-                              </DropdownMenuSubContent>
-                            </DropdownMenuSub>
-
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger inset>
-                                Tertiary stats
-                              </DropdownMenuSubTrigger>
-                              <DropdownMenuSubContent
-                                className={cn(
-                                  TABLE_FILTER_MENU_CONTENT,
-                                  "min-w-48",
-                                )}
-                                collisionPadding={16}
-                              >
-                                {ARMOR_STAT_NAMES.map((stat) => (
-                                  <DropdownMenuCheckboxItem
-                                    key={stat}
-                                    checked={tertiaryStats.includes(stat)}
-                                    onSelect={(e) => e.preventDefault()}
-                                    onCheckedChange={(c) => {
-                                      setTertiaryStats((prev) =>
-                                        c
-                                          ? [...prev, stat]
-                                          : prev.filter((s) => s !== stat),
-                                      );
-                                    }}
-                                  >
-                                    {stat}
-                                  </DropdownMenuCheckboxItem>
-                                ))}
-                              </DropdownMenuSubContent>
-                            </DropdownMenuSub>
-
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger inset>
-                                Tuning stats
-                              </DropdownMenuSubTrigger>
-                              <DropdownMenuSubContent
-                                className={cn(
-                                  TABLE_FILTER_MENU_CONTENT,
-                                  "min-w-56",
-                                )}
-                                collisionPadding={16}
-                              >
-                                {sortedTunings.length === 0 ?
-                                  <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
-                                    No tunings — sync the manifest first.
-                                  </div>
-                                : sortedTunings.map((t) => {
-                                    const id = String(t.hash);
-                                    return (
-                                      <DropdownMenuCheckboxItem
-                                        key={t.hash}
-                                        checked={tuningHashes.includes(id)}
-                                        onSelect={(e) => e.preventDefault()}
-                                        onCheckedChange={(c) => {
-                                          setTuningHashes((prev) =>
-                                            c
-                                              ? [...prev, id]
-                                              : prev.filter((h) => h !== id),
-                                          );
-                                        }}
-                                      >
-                                        {t.name}
-                                      </DropdownMenuCheckboxItem>
-                                    );
-                                  })
-                                }
-                              </DropdownMenuSubContent>
-                            </DropdownMenuSub>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                          <p
-                            className="min-w-0 text-xs leading-snug text-muted-foreground/80"
-                            aria-live="polite"
-                          >
-                            Showing {filteredRows.length} piece
-                            {filteredRows.length === 1 ? "" : "s"} for{" "}
-                            {CLASS_NAMES[inventoryClass] ?? "class"}.
-                          </p>
-                        </div>
-
-                        <div className="min-w-0 justify-self-end">
-                          {searchExpanded ?
-                            <div
-                              role="search"
-                              className="relative min-h-[52px] min-w-0 lg:max-w-xs"
-                            >
-                              <MagnifyingGlass
-                                weight="regular"
-                                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                                aria-hidden
-                              />
-                              <input
-                                ref={searchInputRef}
-                                id="inv-filter-search"
-                                type="search"
-                                value={search}
-                                onChange={(e) => setSearch(e.target.value)}
-                                placeholder="Search armor"
-                                aria-label="Search armor"
-                                onBlur={() => {
-                                  if (!search.trim()) setSearchUiOpen(false);
-                                }}
-                                onKeyDown={(e) => {
-                                  if (e.key !== "Escape") return;
-                                  if (search.trim()) {
-                                    setSearch("");
-                                  } else {
-                                    setSearchUiOpen(false);
-                                    e.currentTarget.blur();
-                                  }
-                                }}
-                                className="h-[52px] w-full min-w-0 border-0 border-b border-white bg-transparent py-0 ps-9 pe-9 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/80 focus-visible:border-b focus-visible:border-white focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-search-cancel-button]:hidden"
-                              />
-                              {search ?
-                                <button
-                                  type="button"
-                                  aria-label="Clear search"
-                                  onPointerDown={(e) => e.preventDefault()}
-                                  onClick={() => setSearch("")}
-                                  className="absolute right-2 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                                >
-                                  <X
-                                    weight="bold"
-                                    className="h-3.5 w-3.5"
-                                    aria-hidden
-                                  />
-                                </button>
-                              : null}
-                            </div>
-                          : <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              aria-label="Search armor"
-                              aria-expanded={searchExpanded}
-                              className="size-9 shrink-0 self-center rounded-none border-0 shadow-none hover:bg-accent/50"
-                              onClick={openSearchField}
-                            >
-                              <MagnifyingGlass
-                                weight="regular"
-                                aria-hidden
-                                className="size-4"
-                              />
-                            </Button>
-                          }
-                        </div>
-                      </div>
-                    </TableHead>
-                  </TableRow>
-                  <TableRow className="border-b-0 border-border hover:bg-transparent [&:hover]:bg-transparent">
-                    <TableHead
-                      className="w-px border-b border-border bg-table-header pe-2 text-table-header-foreground"
-                      aria-label="Icon"
-                    />
-                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
-                      Armor set
-                    </TableHead>
-                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
-                      Archetype
-                    </TableHead>
-                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
-                      Tertiary
-                    </TableHead>
-                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
-                      Tuning
-                    </TableHead>
-                    <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
-                      Location
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
+                    <TableHeader className="[&_tr]:border-b-0">
+                      <TableRow className="border-b-0 border-border hover:bg-transparent [&:hover]:bg-transparent">
+                        <TableHead
+                          colSpan={6}
+                          className="h-auto border-b-0 bg-table-header px-3 py-0 text-left align-middle font-medium text-muted-foreground shadow-[inset_0_-1px_0_0_var(--border)] [&:has([role=checkbox])]:pr-0"
+                        >
+                          <TrackerFilterBar
+                            selectors={selectors}
+                            value={filters}
+                            onChange={setFilters}
+                            pinnedHashes={pinnedHashes}
+                            onTogglePin={togglePin}
+                            resultCount={filteredRows.length}
+                            resultNoun={{
+                              singular: "piece",
+                              plural: "pieces",
+                            }}
+                            variant="table-header"
+                          />
+                        </TableHead>
+                      </TableRow>
+                      <TableRow className="border-b-0 border-border hover:bg-transparent [&:hover]:bg-transparent">
+                        <TableHead
+                          className="w-px border-b border-border bg-table-header pe-2 text-table-header-foreground"
+                          aria-label="Icon"
+                        />
+                        <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                          Armor set
+                        </TableHead>
+                        <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                          Archetype
+                        </TableHead>
+                        <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                          Tertiary
+                        </TableHead>
+                        <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                          Tuning
+                        </TableHead>
+                        <TableHead className="border-b border-border bg-table-header text-table-header-foreground">
+                          Location
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
                   </Table>
                 </div>
                 <div className="menu-scrollbar max-h-[calc(100dvh-13rem)] min-h-0 min-w-0 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]">
@@ -528,58 +208,60 @@ export function InventoryTableView({
                     containerClassName="overflow-visible"
                   >
                     {INVENTORY_TABLE_COLGROUP}
-                <TableBody>
-                  {filteredRows.length === 0 ?
-                    <TableRow className="border-border hover:bg-transparent">
-                      <TableCell
-                        colSpan={6}
-                        className="py-8 text-center text-sm text-muted-foreground/80"
-                      >
-                        No armor matches these filters.
-                      </TableCell>
-                    </TableRow>
-                  : filteredRows.map((piece) => (
-                      <TableRow
-                        key={piece.itemInstanceId}
-                        className="border-border hover:bg-accent/60"
-                      >
-                        <TableCell className="w-px whitespace-nowrap py-1 pe-2 align-middle">
-                          {piece.iconPath ?
-                            <span className="inline-flex rounded-none border border-border bg-accent leading-none">
-                              {/* eslint-disable-next-line @next/next/no-img-element -- Bungie CDN thumbnails; avoid bloating the bundle with next/image remotePatterns. */}
-                              <img
-                                src={bungieIconUrl(piece.iconPath)}
-                                alt={`${SLOT_LABELS[piece.slot]} — ${piece.setName ?? "armor"}`}
-                                className="block h-auto max-h-7 max-w-9 w-auto"
-                                loading="lazy"
-                              />
-                            </span>
-                          : <div
-                              role="img"
-                              aria-label={`${SLOT_LABELS[piece.slot]} — no artwork`}
-                              className="inline-block size-7 rounded-none border border-border bg-accent/60"
-                            />
-                          }
-                        </TableCell>
-                        <TableCell className="py-1.5 text-foreground/90">
-                          {piece.setName ?? "—"}
-                        </TableCell>
-                        <TableCell className="py-1.5 text-foreground/90">
-                          {piece.archetypeName ?? "—"}
-                        </TableCell>
-                        <TableCell className="py-1.5 text-foreground/80">
-                          {piece.tertiaryStat ?? "—"}
-                        </TableCell>
-                        <TableCell className="py-1.5 text-foreground/90">
-                          {piece.tuningName ?? "—"}
-                        </TableCell>
-                        <TableCell className="py-1.5 text-muted-foreground">
-                          {formatLocation(piece)}
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  }
-                </TableBody>
+                    <TableBody>
+                      {filteredRows.length === 0 ? (
+                        <TableRow className="border-border hover:bg-transparent">
+                          <TableCell
+                            colSpan={6}
+                            className="py-8 text-center text-sm text-muted-foreground/80"
+                          >
+                            No armor matches these filters.
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        filteredRows.map((piece) => (
+                          <TableRow
+                            key={piece.itemInstanceId}
+                            className="border-border hover:bg-accent/60"
+                          >
+                            <TableCell className="w-px whitespace-nowrap py-1 pe-2 align-middle">
+                              {piece.iconPath ? (
+                                <span className="inline-flex rounded-none border border-border bg-accent leading-none">
+                                  {/* eslint-disable-next-line @next/next/no-img-element -- Bungie CDN thumbnails; avoid bloating the bundle with next/image remotePatterns. */}
+                                  <img
+                                    src={bungieIconUrl(piece.iconPath)}
+                                    alt={`${SLOT_LABELS[piece.slot]} — ${piece.setName ?? "armor"}`}
+                                    className="block h-auto max-h-7 max-w-9 w-auto"
+                                    loading="lazy"
+                                  />
+                                </span>
+                              ) : (
+                                <div
+                                  role="img"
+                                  aria-label={`${SLOT_LABELS[piece.slot]} — no artwork`}
+                                  className="inline-block size-7 rounded-none border border-border bg-accent/60"
+                                />
+                              )}
+                            </TableCell>
+                            <TableCell className="py-1.5 text-foreground/90">
+                              {piece.setName ?? "—"}
+                            </TableCell>
+                            <TableCell className="py-1.5 text-foreground/90">
+                              {piece.archetypeName ?? "—"}
+                            </TableCell>
+                            <TableCell className="py-1.5 text-foreground/80">
+                              {piece.tertiaryStat ?? "—"}
+                            </TableCell>
+                            <TableCell className="py-1.5 text-foreground/90">
+                              {piece.tuningName ?? "—"}
+                            </TableCell>
+                            <TableCell className="py-1.5 text-muted-foreground">
+                              {formatLocation(piece)}
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
                   </Table>
                 </div>
               </div>

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { ReactNode } from "react";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import {
@@ -20,10 +20,7 @@ import {
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
 import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
 import { TrackerFilterBar } from "@/components/workspace/tracker-filter-bar";
-import {
-  defaultGridFilters,
-  type GridFiltersJson,
-} from "@/lib/workspace/grid-filters-schema";
+import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
 
 /** Shared by header + body tables so columns line up (`table-fixed`). */
 const INVENTORY_TABLE_COLGROUP = (
@@ -55,6 +52,8 @@ interface InventoryTableViewProps {
   hasInventory: boolean;
   inventory: DerivedArmorPieceJson[];
   selectors: TrackerFormSelectors;
+  filters: GridFiltersJson;
+  onFiltersChange: (next: GridFiltersJson) => void;
 }
 
 export function InventoryTableView({
@@ -64,10 +63,9 @@ export function InventoryTableView({
   hasInventory,
   inventory,
   selectors,
+  filters,
+  onFiltersChange,
 }: InventoryTableViewProps) {
-  const [filters, setFilters] = useState<GridFiltersJson>(() =>
-    defaultGridFilters(),
-  );
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
 
   const filteredRows = useMemo(() => {
@@ -166,7 +164,7 @@ export function InventoryTableView({
                           <TrackerFilterBar
                             selectors={selectors}
                             value={filters}
-                            onChange={setFilters}
+                            onChange={onFiltersChange}
                             pinnedHashes={pinnedHashes}
                             onTogglePin={togglePin}
                             resultCount={filteredRows.length}

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -208,7 +208,7 @@ export function InventoryTableView({
                     {INVENTORY_TABLE_COLGROUP}
                     <TableBody>
                       {filteredRows.length === 0 ? (
-                        <TableRow className="border-border hover:bg-transparent">
+                        <TableRow className="border-b-0 border-border hover:bg-transparent shadow-[inset_0_-1px_0_0_var(--border)]">
                           <TableCell
                             colSpan={6}
                             className="py-8 text-center text-sm text-muted-foreground/80"
@@ -220,7 +220,7 @@ export function InventoryTableView({
                         filteredRows.map((piece) => (
                           <TableRow
                             key={piece.itemInstanceId}
-                            className="border-border hover:bg-accent/60"
+                            className="border-b-0 shadow-[inset_0_-1px_0_0_var(--border)] hover:bg-accent/60"
                           >
                             <TableCell className="w-px whitespace-nowrap py-1 pe-2 align-middle">
                               {piece.iconPath ? (

--- a/src/components/dashboard/workspace-view-mode-tabs.stories.tsx
+++ b/src/components/dashboard/workspace-view-mode-tabs.stories.tsx
@@ -15,9 +15,9 @@ export default meta;
 
 type Story = StoryObj<typeof WorkspaceViewModeTabs>;
 
-export const CanvasSelected: Story = {
+export const GridSelected: Story = {
   render: function Render() {
-    const [mode, setMode] = useState<WorkspaceViewMode>("canvas");
+    const [mode, setMode] = useState<WorkspaceViewMode>("grid");
     return <WorkspaceViewModeTabs mode={mode} onModeChange={setMode} />;
   },
 };

--- a/src/components/dashboard/workspace-view-mode-tabs.tsx
+++ b/src/components/dashboard/workspace-view-mode-tabs.tsx
@@ -4,7 +4,7 @@ import { SquaresFour, Table } from "@phosphor-icons/react/dist/ssr";
 import { cn } from "@/lib/utils";
 import { chromeToolbarShellClass } from "@/components/ui/chrome-square-icon-button";
 
-export type WorkspaceViewMode = "canvas" | "table";
+export type WorkspaceViewMode = "grid" | "table";
 
 interface WorkspaceViewModeTabsProps {
   mode: WorkspaceViewMode;
@@ -27,15 +27,15 @@ export function WorkspaceViewModeTabs({
       <button
         type="button"
         role="tab"
-        aria-selected={mode === "canvas"}
+        aria-selected={mode === "grid"}
         className={cn(
           segmentBtn,
-          mode === "canvas" && "bg-accent text-foreground",
+          mode === "grid" && "bg-accent text-foreground",
         )}
-        onClick={() => onModeChange("canvas")}
+        onClick={() => onModeChange("grid")}
       >
         <SquaresFour className="h-4 w-4" weight="duotone" aria-hidden />
-        Canvas
+        Tracker
       </button>
       <button
         type="button"

--- a/src/components/workspace/compare-dialog.stories.tsx
+++ b/src/components/workspace/compare-dialog.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+import {
+  CompareDialog,
+  type CompareTrackerDescriptor,
+} from "./compare-dialog";
+import { Button } from "@/components/ui/button";
+import { MOCK_GRID_LOOKUP_PAYLOAD } from "../../../.storybook/mocks/grid-lookup";
+import {
+  MOCK_ARCHETYPES,
+  MOCK_ARMOR_SETS,
+  MOCK_TUNINGS,
+} from "../../../.storybook/mocks/manifest-lookups";
+
+const meta: Meta<typeof CompareDialog> = {
+  title: "Workspace/CompareDialog",
+  component: CompareDialog,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof CompareDialog>;
+
+function buildPool(): CompareTrackerDescriptor[] {
+  const pool: CompareTrackerDescriptor[] = [];
+  for (const s of MOCK_ARMOR_SETS) {
+    for (const a of MOCK_ARCHETYPES) {
+      for (const t of MOCK_TUNINGS) {
+        pool.push({
+          setHash: s.set_hash,
+          archetypeHash: a.archetype_hash,
+          tuningHash: t.tuning_hash,
+          classType: 0,
+          setName: s.name,
+          archetypeName: a.name,
+          tuningName: t.name,
+        });
+      }
+    }
+  }
+  return pool;
+}
+
+const POOL = buildPool();
+const ANCHOR = POOL[0]!;
+
+export const PartnerNotYetPicked: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open compare dialog</Button>
+        <CompareDialog
+          open={open}
+          onOpenChange={setOpen}
+          anchor={ANCHOR}
+          candidatePool={POOL}
+          lookupPayload={MOCK_GRID_LOOKUP_PAYLOAD}
+          inventory={[]}
+          hasInventory={false}
+        />
+      </>
+    );
+  },
+};

--- a/src/components/workspace/compare-dialog.tsx
+++ b/src/components/workspace/compare-dialog.tsx
@@ -108,7 +108,12 @@ export function CompareDialog({
             <TrackerIdentBadges
               setName={anchor.setName}
               archetypeName={anchor.archetypeName}
-              tuning={<TuningHeaderGlyph tuningName={anchor.tuningName} iconPath={null} />}
+              tuning={
+                <TuningHeaderGlyph
+                  tuningName={anchor.tuningName}
+                  iconPath={anchorPayload?.tuningStatIconPath ?? null}
+                />
+              }
             />
           </div>
         ) : null}
@@ -123,7 +128,10 @@ export function CompareDialog({
                 setName={partner.setName}
                 archetypeName={partner.archetypeName}
                 tuning={
-                  <TuningHeaderGlyph tuningName={partner.tuningName} iconPath={null} />
+                  <TuningHeaderGlyph
+                    tuningName={partner.tuningName}
+                    iconPath={partnerPayload?.tuningStatIconPath ?? null}
+                  />
                 }
               />
             </div>

--- a/src/components/workspace/compare-dialog.tsx
+++ b/src/components/workspace/compare-dialog.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { MagnifyingGlass } from "@phosphor-icons/react/dist/ssr";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { MergedCompareGrid } from "@/components/views/merged-compare-grid";
+import { TrackerIdentBadges } from "@/components/workspace/tracker-ident-badges";
+import { TuningHeaderGlyph } from "@/components/views/tuning-header-glyph";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
+import {
+  buildEphemeralTrackerPayload,
+  ephemeralTrackerId,
+} from "@/lib/workspace/build-tracker-payload-core";
+
+export interface CompareTrackerDescriptor {
+  setHash: number;
+  archetypeHash: number;
+  tuningHash: number;
+  classType: number;
+  setName: string;
+  archetypeName: string;
+  tuningName: string;
+}
+
+interface CompareDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  anchor: CompareTrackerDescriptor | null;
+  /** Tiles available as partner choices — same class as the anchor by construction. */
+  candidatePool: CompareTrackerDescriptor[];
+  lookupPayload: GridLookupPayload;
+  inventory: DerivedArmorPieceJson[];
+  hasInventory: boolean;
+}
+
+/**
+ * Modal compare flow. Anchor tile is pre-selected; user picks a partner from a
+ * filterable list of same-class tiles; we render the existing
+ * `MergedCompareGrid` for the chosen pair.
+ */
+export function CompareDialog({
+  open,
+  onOpenChange,
+  anchor,
+  candidatePool,
+  lookupPayload,
+  inventory,
+  hasInventory,
+}: CompareDialogProps) {
+  const [partnerId, setPartnerId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  const filteredCandidates = useMemo(() => {
+    if (!anchor) return [] as CompareTrackerDescriptor[];
+    const trimmed = query.trim().toLowerCase();
+    const aId = ephemeralTrackerId(anchor);
+    let rows = candidatePool.filter((c) => ephemeralTrackerId(c) !== aId);
+    if (trimmed) {
+      rows = rows.filter((c) =>
+        `${c.setName} ${c.archetypeName} ${c.tuningName}`
+          .toLowerCase()
+          .includes(trimmed),
+      );
+    }
+    return rows;
+  }, [anchor, candidatePool, query]);
+
+  const partner = useMemo(() => {
+    if (partnerId === null) return null;
+    return candidatePool.find((c) => ephemeralTrackerId(c) === partnerId) ?? null;
+  }, [candidatePool, partnerId]);
+
+  const anchorPayload = useMemo(() => {
+    if (!anchor) return null;
+    return buildEphemeralTrackerPayload(anchor, inventory, lookupPayload);
+  }, [anchor, inventory, lookupPayload]);
+
+  const partnerPayload = useMemo(() => {
+    if (!partner) return null;
+    return buildEphemeralTrackerPayload(partner, inventory, lookupPayload);
+  }, [partner, inventory, lookupPayload]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl gap-4">
+        <DialogHeader>
+          <DialogTitle>Compare trackers</DialogTitle>
+          <DialogDescription>
+            {anchor
+              ? `Pick a second tracker to compare against ${anchor.setName} · ${anchor.archetypeName}.`
+              : "Pick a tracker to compare."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {anchor ? (
+          <div className="flex shrink-0 items-center gap-3 border border-border bg-card px-3 py-2">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              A
+            </span>
+            <TrackerIdentBadges
+              setName={anchor.setName}
+              archetypeName={anchor.archetypeName}
+              tuning={<TuningHeaderGlyph tuningName={anchor.tuningName} iconPath={null} />}
+            />
+          </div>
+        ) : null}
+
+        {partner ? (
+          <div className="flex items-center justify-between gap-3 border border-border bg-card px-3 py-2">
+            <div className="flex items-center gap-3">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                B
+              </span>
+              <TrackerIdentBadges
+                setName={partner.setName}
+                archetypeName={partner.archetypeName}
+                tuning={
+                  <TuningHeaderGlyph tuningName={partner.tuningName} iconPath={null} />
+                }
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setPartnerId(null)}
+            >
+              Change
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="relative">
+              <MagnifyingGlass
+                weight="regular"
+                aria-hidden
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search trackers"
+                aria-label="Search compare candidates"
+                className="h-9 w-full min-w-0 rounded-none border border-border bg-card py-0 ps-9 pe-3 text-sm text-foreground outline-none placeholder:text-muted-foreground/80 focus-visible:border-foreground focus-visible:ring-0"
+              />
+            </div>
+            <div className="max-h-72 min-h-0 overflow-y-auto border border-border bg-card">
+              {filteredCandidates.length === 0 ? (
+                <p className="px-3 py-4 text-sm text-muted-foreground">
+                  No other trackers in view match.
+                </p>
+              ) : (
+                <ul role="listbox" aria-label="Compare candidates">
+                  {filteredCandidates.map((c) => {
+                    const id = ephemeralTrackerId(c);
+                    return (
+                      <li key={id}>
+                        <button
+                          type="button"
+                          role="option"
+                          aria-selected={false}
+                          onClick={() => setPartnerId(id)}
+                          className="flex w-full items-center justify-between gap-3 border-b border-border px-3 py-2 text-left text-sm text-foreground/90 transition-colors last:border-b-0 hover:bg-accent focus-visible:outline-none focus-visible:bg-accent"
+                        >
+                          <span className="truncate">
+                            {c.setName} · {c.archetypeName}
+                          </span>
+                          <span className="shrink-0 text-xs text-muted-foreground">
+                            {c.tuningName}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+
+        {anchorPayload && partnerPayload ? (
+          <div className="overflow-y-auto border border-border bg-card p-4">
+            <MergedCompareGrid
+              anchorPayload={anchorPayload}
+              partnerPayload={partnerPayload}
+              hasInventory={hasInventory}
+            />
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/workspace/grid-workspace.stories.tsx
+++ b/src/components/workspace/grid-workspace.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { GridWorkspace } from "./grid-workspace";
 import { MOCK_TRACKER_FORM_SELECTORS } from "../../../.storybook/mocks/tracker-options";
@@ -16,8 +17,9 @@ export default meta;
 
 type Story = StoryObj<typeof GridWorkspace>;
 
-export const EmptyState: Story = {
-  render: () => (
+function EmptyStory() {
+  const [filters, setFilters] = useState(MOCK_GRID_FILTERS_EMPTY);
+  return (
     <div style={{ height: "100vh" }}>
       <GridWorkspace
         banners={null}
@@ -26,24 +28,35 @@ export const EmptyState: Story = {
         selectors={MOCK_TRACKER_FORM_SELECTORS}
         inventory={[]}
         lookupPayload={MOCK_GRID_LOOKUP_PAYLOAD}
-        initialFilters={MOCK_GRID_FILTERS_EMPTY}
+        filters={filters}
+        onFiltersChange={setFilters}
       />
     </div>
-  ),
+  );
+}
+
+function PopulatedStory() {
+  const [filters, setFilters] = useState(MOCK_GRID_FILTERS_POPULATED);
+  return (
+    <div style={{ height: "100vh" }}>
+      <GridWorkspace
+        banners={null}
+        syncWarning={null}
+        hasInventory={false}
+        selectors={MOCK_TRACKER_FORM_SELECTORS}
+        inventory={[]}
+        lookupPayload={MOCK_GRID_LOOKUP_PAYLOAD}
+        filters={filters}
+        onFiltersChange={setFilters}
+      />
+    </div>
+  );
+}
+
+export const EmptyState: Story = {
+  render: EmptyStory,
 };
 
 export const PopulatedFilters: Story = {
-  render: () => (
-    <div style={{ height: "100vh" }}>
-      <GridWorkspace
-        banners={null}
-        syncWarning={null}
-        hasInventory={false}
-        selectors={MOCK_TRACKER_FORM_SELECTORS}
-        inventory={[]}
-        lookupPayload={MOCK_GRID_LOOKUP_PAYLOAD}
-        initialFilters={MOCK_GRID_FILTERS_POPULATED}
-      />
-    </div>
-  ),
+  render: PopulatedStory,
 };

--- a/src/components/workspace/grid-workspace.stories.tsx
+++ b/src/components/workspace/grid-workspace.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { GridWorkspace } from "./grid-workspace";
+import { MOCK_TRACKER_FORM_SELECTORS } from "../../../.storybook/mocks/tracker-options";
+import { MOCK_GRID_LOOKUP_PAYLOAD } from "../../../.storybook/mocks/grid-lookup";
+import {
+  MOCK_GRID_FILTERS_EMPTY,
+  MOCK_GRID_FILTERS_POPULATED,
+} from "../../../.storybook/mocks/grid-filters";
+
+const meta: Meta<typeof GridWorkspace> = {
+  title: "Workspace/GridWorkspace",
+  component: GridWorkspace,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof GridWorkspace>;
+
+export const EmptyState: Story = {
+  render: () => (
+    <div style={{ height: "100vh" }}>
+      <GridWorkspace
+        banners={null}
+        syncWarning={null}
+        hasInventory={false}
+        selectors={MOCK_TRACKER_FORM_SELECTORS}
+        inventory={[]}
+        lookupPayload={MOCK_GRID_LOOKUP_PAYLOAD}
+        initialFilters={MOCK_GRID_FILTERS_EMPTY}
+      />
+    </div>
+  ),
+};
+
+export const PopulatedFilters: Story = {
+  render: () => (
+    <div style={{ height: "100vh" }}>
+      <GridWorkspace
+        banners={null}
+        syncWarning={null}
+        hasInventory={false}
+        selectors={MOCK_TRACKER_FORM_SELECTORS}
+        inventory={[]}
+        lookupPayload={MOCK_GRID_LOOKUP_PAYLOAD}
+        initialFilters={MOCK_GRID_FILTERS_POPULATED}
+      />
+    </div>
+  ),
+};

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -278,7 +278,7 @@ export function GridWorkspace({
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
         <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-[4.75rem] sm:px-6">
-          <div className="shrink-0 rounded-none border border-border bg-card px-3">
+          <div className="shrink-0 rounded-none border border-border bg-table-header px-3 shadow-[inset_0_-1px_0_0_var(--border)]">
             <TrackerFilterBar
               selectors={selectors}
               value={filters}

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -32,7 +32,6 @@ import {
   TRACKER_GRID_VISUAL_SCALE,
   TRACKER_WIDTH,
 } from "@/lib/workspace/workspace-constants";
-import { tertiaryStatsForArchetype } from "@/lib/views/progress";
 import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
 
 const ROW_GAP_PX = 16;
@@ -105,10 +104,6 @@ export function GridWorkspace({
       filters.tuningHashes.length > 0
         ? new Set(filters.tuningHashes)
         : null;
-    const tertiarySet =
-      filters.tertiaryStats.length > 0
-        ? new Set(filters.tertiaryStats)
-        : null;
     const searchTerm = filters.search.trim().toLowerCase();
 
     const sets = setOptions.filter((s) => (setIds ? setIds.has(s.hash) : true));
@@ -122,11 +117,6 @@ export function GridWorkspace({
     const out: TrackerDescriptor[] = [];
     for (const set of sets) {
       for (const arch of archetypes) {
-        if (tertiarySet) {
-          const pair = lookupPayload.archetypeStatPair[String(arch.hash)];
-          const stats = tertiaryStatsForArchetype(pair);
-          if (!stats.some((s) => tertiarySet.has(s))) continue;
-        }
         for (const tun of tunings) {
           if (searchTerm) {
             const haystack =
@@ -163,12 +153,10 @@ export function GridWorkspace({
     filters.setHashes,
     filters.archetypeHashes,
     filters.tuningHashes,
-    filters.tertiaryStats,
     filters.search,
     selectors.setsByClass,
     selectors.archetypes,
     selectors.tunings,
-    lookupPayload.archetypeStatPair,
   ]);
 
   const scrollerRef = useRef<HTMLDivElement | null>(null);
@@ -241,6 +229,7 @@ export function GridWorkspace({
               onTogglePin={togglePin}
               resultCount={visibleTrackers.length}
               resultNoun={{ singular: "tracker", plural: "trackers" }}
+              showTertiaryStatFilter={false}
             />
           </div>
 

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import {
-  useCallback,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -10,7 +8,6 @@ import {
   type ReactNode,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { toast } from "sonner";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
 import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
@@ -38,7 +35,6 @@ import {
 import { tertiaryStatsForArchetype } from "@/lib/views/progress";
 import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
 
-const PERSIST_DEBOUNCE_MS = 500;
 const ROW_GAP_PX = 16;
 /** Virtual row height for scaled tiles + vertical gap. */
 const ROW_PITCH_PX = TRACKER_GRID_TILE_DISPLAY_HEIGHT_PX + ROW_GAP_PX;
@@ -59,7 +55,8 @@ interface GridWorkspaceProps {
   selectors: TrackerFormSelectors;
   inventory: DerivedArmorPieceJson[];
   lookupPayload: GridLookupPayload;
-  initialFilters: GridFiltersJson;
+  filters: GridFiltersJson;
+  onFiltersChange: (next: GridFiltersJson) => void;
 }
 
 type TrackerDescriptor = CompareTrackerDescriptor;
@@ -71,9 +68,9 @@ export function GridWorkspace({
   selectors,
   inventory,
   lookupPayload,
-  initialFilters,
+  filters,
+  onFiltersChange,
 }: GridWorkspaceProps) {
-  const [filters, setFilters] = useState<GridFiltersJson>(initialFilters);
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
 
   // Class-bucketed inventory; cheap to re-compute when `inventory` changes.
@@ -88,49 +85,6 @@ export function GridWorkspace({
   }, [inventory]);
 
   const inventoryForClass = inventoryByClass[filters.class] ?? [];
-
-  // ---- Debounced persistence ----
-  const pendingFiltersRef = useRef<GridFiltersJson | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const flush = useCallback(async () => {
-    if (timerRef.current !== null) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-    const next = pendingFiltersRef.current;
-    if (next === null) return;
-    pendingFiltersRef.current = null;
-    try {
-      const res = await fetch("/api/me/workspace", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ gridFilters: next }),
-      });
-      if (!res.ok) {
-        toast.error("Could not save filter selections.");
-      }
-    } catch {
-      toast.error("Could not save filter selections.");
-    }
-  }, []);
-  useEffect(() => {
-    return () => {
-      if (pendingFiltersRef.current !== null) {
-        // Best-effort flush on unmount.
-        void flush();
-      }
-    };
-  }, [flush]);
-
-  const handleFiltersChange = useCallback(
-    (next: GridFiltersJson) => {
-      setFilters(next);
-      pendingFiltersRef.current = next;
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => void flush(), PERSIST_DEBOUNCE_MS);
-    },
-    [flush],
-  );
 
   // ---- Visible trackers (enumerate filtered cross-product) ----
   const unblocked = gridFiltersHaveUnblockingSelection(filters);
@@ -278,11 +232,11 @@ export function GridWorkspace({
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
         <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-[4.75rem] sm:px-6">
-          <div className="shrink-0 rounded-none border border-border bg-table-header px-3 shadow-[inset_0_-1px_0_0_var(--border)]">
+          <div className="shrink-0 rounded-none border border-border bg-table-header px-3">
             <TrackerFilterBar
               selectors={selectors}
               value={filters}
-              onChange={handleFiltersChange}
+              onChange={onFiltersChange}
               pinnedHashes={pinnedHashes}
               onTogglePin={togglePin}
               resultCount={visibleTrackers.length}

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { toast } from "sonner";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
+import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
+import {
+  buildEphemeralTrackerPayload,
+  ephemeralTrackerId,
+} from "@/lib/workspace/build-tracker-payload-core";
+import {
+  gridFiltersHaveUnblockingSelection,
+  type GridFiltersJson,
+} from "@/lib/workspace/grid-filters-schema";
+import { TrackerFilterBar } from "@/components/workspace/tracker-filter-bar";
+import { TrackerGridContent } from "@/components/workspace/tracker-grid-content";
+import {
+  CompareDialog,
+  type CompareTrackerDescriptor,
+} from "@/components/workspace/compare-dialog";
+import {
+  TRACKER_DEFAULT_HEIGHT,
+  TRACKER_WIDTH,
+} from "@/lib/workspace/workspace-constants";
+import { tertiaryStatsForArchetype } from "@/lib/views/progress";
+import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
+
+const PERSIST_DEBOUNCE_MS = 500;
+const ROW_GAP_PX = 16;
+/** Visual row height including the configured gap. */
+const ROW_PITCH_PX = TRACKER_DEFAULT_HEIGHT + ROW_GAP_PX;
+
+interface GridWorkspaceProps {
+  banners: ReactNode;
+  syncWarning: string | null;
+  hasInventory: boolean;
+  selectors: TrackerFormSelectors;
+  inventory: DerivedArmorPieceJson[];
+  lookupPayload: GridLookupPayload;
+  initialFilters: GridFiltersJson;
+}
+
+type TrackerDescriptor = CompareTrackerDescriptor;
+
+export function GridWorkspace({
+  banners,
+  syncWarning,
+  hasInventory,
+  selectors,
+  inventory,
+  lookupPayload,
+  initialFilters,
+}: GridWorkspaceProps) {
+  const [filters, setFilters] = useState<GridFiltersJson>(initialFilters);
+  const { pinnedHashes, togglePin } = usePinnedArmorSets();
+
+  // Class-bucketed inventory; cheap to re-compute when `inventory` changes.
+  const inventoryByClass = useMemo(() => {
+    const out: Record<number, DerivedArmorPieceJson[]> = { 0: [], 1: [], 2: [] };
+    for (const p of inventory) {
+      if (p.classType === 0 || p.classType === 1 || p.classType === 2) {
+        out[p.classType].push(p);
+      }
+    }
+    return out;
+  }, [inventory]);
+
+  const inventoryForClass = inventoryByClass[filters.class] ?? [];
+
+  // ---- Debounced persistence ----
+  const pendingFiltersRef = useRef<GridFiltersJson | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flush = useCallback(async () => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const next = pendingFiltersRef.current;
+    if (next === null) return;
+    pendingFiltersRef.current = null;
+    try {
+      const res = await fetch("/api/me/workspace", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gridFilters: next }),
+      });
+      if (!res.ok) {
+        toast.error("Could not save filter selections.");
+      }
+    } catch {
+      toast.error("Could not save filter selections.");
+    }
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (pendingFiltersRef.current !== null) {
+        // Best-effort flush on unmount.
+        void flush();
+      }
+    };
+  }, [flush]);
+
+  const handleFiltersChange = useCallback(
+    (next: GridFiltersJson) => {
+      setFilters(next);
+      pendingFiltersRef.current = next;
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => void flush(), PERSIST_DEBOUNCE_MS);
+    },
+    [flush],
+  );
+
+  // ---- Visible trackers (enumerate filtered cross-product) ----
+  const unblocked = gridFiltersHaveUnblockingSelection(filters);
+
+  const visibleTrackers = useMemo<TrackerDescriptor[]>(() => {
+    if (!unblocked) return [];
+
+    const setOptions = selectors.setsByClass[filters.class];
+    const setIds =
+      filters.setHashes.length > 0
+        ? new Set(filters.setHashes)
+        : null;
+    const archetypeIds =
+      filters.archetypeHashes.length > 0
+        ? new Set(filters.archetypeHashes)
+        : null;
+    const tuningIds =
+      filters.tuningHashes.length > 0
+        ? new Set(filters.tuningHashes)
+        : null;
+    const tertiarySet =
+      filters.tertiaryStats.length > 0
+        ? new Set(filters.tertiaryStats)
+        : null;
+    const searchTerm = filters.search.trim().toLowerCase();
+
+    const sets = setOptions.filter((s) => (setIds ? setIds.has(s.hash) : true));
+    const archetypes = selectors.archetypes.filter((a) =>
+      archetypeIds ? archetypeIds.has(a.hash) : true,
+    );
+    const tunings = selectors.tunings.filter((t) =>
+      tuningIds ? tuningIds.has(t.hash) : true,
+    );
+
+    const out: TrackerDescriptor[] = [];
+    for (const set of sets) {
+      for (const arch of archetypes) {
+        if (tertiarySet) {
+          const pair = lookupPayload.archetypeStatPair[String(arch.hash)];
+          const stats = tertiaryStatsForArchetype(pair);
+          if (!stats.some((s) => tertiarySet.has(s))) continue;
+        }
+        for (const tun of tunings) {
+          if (searchTerm) {
+            const haystack =
+              `${set.name} ${arch.name} ${tun.name}`.toLowerCase();
+            if (!haystack.includes(searchTerm)) continue;
+          }
+          out.push({
+            setHash: set.hash,
+            archetypeHash: arch.hash,
+            tuningHash: tun.hash,
+            classType: filters.class,
+            setName: set.name,
+            archetypeName: arch.name,
+            tuningName: tun.name,
+          });
+        }
+      }
+    }
+
+    out.sort((a, b) => {
+      const s = a.setName.localeCompare(b.setName);
+      if (s !== 0) return s;
+      const ar = a.archetypeName.localeCompare(b.archetypeName);
+      if (ar !== 0) return ar;
+      const tu = a.tuningName.localeCompare(b.tuningName);
+      if (tu !== 0) return tu;
+      return a.setHash - b.setHash;
+    });
+
+    return out;
+  }, [
+    unblocked,
+    filters.class,
+    filters.setHashes,
+    filters.archetypeHashes,
+    filters.tuningHashes,
+    filters.tertiaryStats,
+    filters.search,
+    selectors.setsByClass,
+    selectors.archetypes,
+    selectors.tunings,
+    lookupPayload.archetypeStatPair,
+  ]);
+
+  // ---- Responsive column count via ResizeObserver ----
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const [columnCount, setColumnCount] = useState(1);
+
+  useLayoutEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const tick = () => {
+      const width = el.clientWidth;
+      const cols = Math.max(1, Math.floor((width + ROW_GAP_PX) / (TRACKER_WIDTH + ROW_GAP_PX)));
+      setColumnCount((prev) => (prev === cols ? prev : cols));
+    };
+    tick();
+    const ro = new ResizeObserver(tick);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const rows = useMemo<TrackerDescriptor[][]>(() => {
+    if (visibleTrackers.length === 0 || columnCount < 1) return [];
+    const out: TrackerDescriptor[][] = [];
+    for (let i = 0; i < visibleTrackers.length; i += columnCount) {
+      out.push(visibleTrackers.slice(i, i + columnCount));
+    }
+    return out;
+  }, [visibleTrackers, columnCount]);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollerRef.current,
+    estimateSize: () => ROW_PITCH_PX,
+    overscan: 2,
+  });
+
+  // ---- Compare dialog state ----
+  const [compareAnchor, setCompareAnchor] =
+    useState<TrackerDescriptor | null>(null);
+  const compareOpen = compareAnchor !== null;
+
+  const hasTopMessage = Boolean(banners) || Boolean(syncWarning);
+  const totalSize = virtualizer.getTotalSize();
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {hasTopMessage ? (
+        <div className="shrink-0 pt-[76px]">
+          {banners ? (
+            <div className="space-y-2 border-b border-border bg-background px-4 py-3 sm:px-6">
+              {banners}
+            </div>
+          ) : null}
+          {syncWarning ? (
+            <div className="border-b border-destructive/20 bg-destructive/10 px-4 py-2 sm:px-6">
+              <p role="alert" className="text-sm text-destructive">
+                {syncWarning}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-[4.75rem] sm:px-6">
+          <div className="shrink-0 rounded-none border border-border bg-card px-3">
+            <TrackerFilterBar
+              selectors={selectors}
+              value={filters}
+              onChange={handleFiltersChange}
+              pinnedHashes={pinnedHashes}
+              onTogglePin={togglePin}
+              resultCount={visibleTrackers.length}
+              resultNoun={{ singular: "tracker", plural: "trackers" }}
+            />
+          </div>
+
+          {!unblocked ? (
+            <div className="flex flex-1 items-center justify-center">
+              <div className="max-w-md text-center text-sm text-muted-foreground">
+                <p className="text-base font-medium text-foreground">
+                  Pick a set, archetype, or tuning to see trackers.
+                </p>
+                <p className="mt-2">
+                  Use the Filters menu above to narrow down to the combinations
+                  you care about.
+                </p>
+              </div>
+            </div>
+          ) : visibleTrackers.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center">
+              <p className="text-sm text-muted-foreground">
+                No trackers match these filters.
+              </p>
+            </div>
+          ) : (
+            <div
+              ref={scrollerRef}
+              className="menu-scrollbar relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden"
+            >
+              <div
+                style={{ height: totalSize, width: "100%", position: "relative" }}
+              >
+                {virtualizer.getVirtualItems().map((vRow) => {
+                  const rowItems = rows[vRow.index] ?? [];
+                  return (
+                    <div
+                      key={vRow.key}
+                      data-row-index={vRow.index}
+                      style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        width: "100%",
+                        transform: `translateY(${vRow.start}px)`,
+                        height: ROW_PITCH_PX,
+                        paddingBottom: ROW_GAP_PX,
+                      }}
+                    >
+                      <div
+                        className="grid h-full gap-4"
+                        style={{
+                          gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+                        }}
+                      >
+                        {rowItems.map((d) => (
+                          <GridTile
+                            key={ephemeralTrackerId(d)}
+                            descriptor={d}
+                            inventory={inventoryForClass}
+                            lookupPayload={lookupPayload}
+                            hasInventory={hasInventory}
+                            onCompareClick={() => setCompareAnchor(d)}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <CompareDialog
+        key={compareAnchor ? ephemeralTrackerId(compareAnchor) : "no-anchor"}
+        open={compareOpen}
+        onOpenChange={(o) => {
+          if (!o) setCompareAnchor(null);
+        }}
+        anchor={compareAnchor}
+        candidatePool={visibleTrackers}
+        lookupPayload={lookupPayload}
+        inventory={inventoryForClass}
+        hasInventory={hasInventory}
+      />
+    </div>
+  );
+}
+
+interface GridTileProps {
+  descriptor: TrackerDescriptor;
+  inventory: DerivedArmorPieceJson[];
+  lookupPayload: GridLookupPayload;
+  hasInventory: boolean;
+  onCompareClick: () => void;
+}
+
+function GridTile({
+  descriptor,
+  inventory,
+  lookupPayload,
+  hasInventory,
+  onCompareClick,
+}: GridTileProps) {
+  const payload = useMemo(
+    () => buildEphemeralTrackerPayload(descriptor, inventory, lookupPayload),
+    [descriptor, inventory, lookupPayload],
+  );
+  return (
+    <TrackerGridContent
+      payload={payload}
+      hasInventory={hasInventory}
+      onCompareClick={onCompareClick}
+    />
+  );
+}

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -29,7 +29,10 @@ import {
   type CompareTrackerDescriptor,
 } from "@/components/workspace/compare-dialog";
 import {
-  TRACKER_DEFAULT_HEIGHT,
+  TRACKER_GRID_TILE_DISPLAY_HEIGHT_PX,
+  TRACKER_GRID_TILE_DISPLAY_WIDTH_PX,
+  TRACKER_GRID_TILE_HEIGHT,
+  TRACKER_GRID_VISUAL_SCALE,
   TRACKER_WIDTH,
 } from "@/lib/workspace/workspace-constants";
 import { tertiaryStatsForArchetype } from "@/lib/views/progress";
@@ -37,8 +40,17 @@ import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
 
 const PERSIST_DEBOUNCE_MS = 500;
 const ROW_GAP_PX = 16;
-/** Visual row height including the configured gap. */
-const ROW_PITCH_PX = TRACKER_DEFAULT_HEIGHT + ROW_GAP_PX;
+/** Virtual row height for scaled tiles + vertical gap. */
+const ROW_PITCH_PX = TRACKER_GRID_TILE_DISPLAY_HEIGHT_PX + ROW_GAP_PX;
+const GRID_MAX_COLUMNS = 3;
+
+function trackerGridColumnCountForWidth(scrollerClientWidth: number): number {
+  const tile = TRACKER_GRID_TILE_DISPLAY_WIDTH_PX;
+  const raw = Math.floor(
+    (scrollerClientWidth + ROW_GAP_PX) / (tile + ROW_GAP_PX),
+  );
+  return Math.min(GRID_MAX_COLUMNS, Math.max(1, raw));
+}
 
 interface GridWorkspaceProps {
   banners: ReactNode;
@@ -205,17 +217,15 @@ export function GridWorkspace({
     lookupPayload.archetypeStatPair,
   ]);
 
-  // ---- Responsive column count via ResizeObserver ----
   const scrollerRef = useRef<HTMLDivElement | null>(null);
-  const [columnCount, setColumnCount] = useState(1);
+  const [columnCount, setColumnCount] = useState(GRID_MAX_COLUMNS);
 
   useLayoutEffect(() => {
     const el = scrollerRef.current;
     if (!el) return;
     const tick = () => {
-      const width = el.clientWidth;
-      const cols = Math.max(1, Math.floor((width + ROW_GAP_PX) / (TRACKER_WIDTH + ROW_GAP_PX)));
-      setColumnCount((prev) => (prev === cols ? prev : cols));
+      const next = trackerGridColumnCountForWidth(el.clientWidth);
+      setColumnCount((prev) => (prev === next ? prev : next));
     };
     tick();
     const ro = new ResizeObserver(tick);
@@ -323,9 +333,9 @@ export function GridWorkspace({
                       }}
                     >
                       <div
-                        className="grid h-full gap-4"
+                        className="grid h-full w-max max-w-none justify-start gap-4"
                         style={{
-                          gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+                          gridTemplateColumns: `repeat(${columnCount}, ${TRACKER_GRID_TILE_DISPLAY_WIDTH_PX}px)`,
                         }}
                       >
                         {rowItems.map((d) => (
@@ -384,10 +394,27 @@ function GridTile({
     [descriptor, inventory, lookupPayload],
   );
   return (
-    <TrackerGridContent
-      payload={payload}
-      hasInventory={hasInventory}
-      onCompareClick={onCompareClick}
-    />
+    <div
+      className="shrink-0 overflow-hidden"
+      style={{
+        width: TRACKER_GRID_TILE_DISPLAY_WIDTH_PX,
+        height: TRACKER_GRID_TILE_DISPLAY_HEIGHT_PX,
+      }}
+    >
+      <div
+        style={{
+          width: TRACKER_WIDTH,
+          height: TRACKER_GRID_TILE_HEIGHT,
+          transform: `scale(${TRACKER_GRID_VISUAL_SCALE})`,
+          transformOrigin: "top left",
+        }}
+      >
+        <TrackerGridContent
+          payload={payload}
+          hasInventory={hasInventory}
+          onCompareClick={onCompareClick}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/components/workspace/tracker-filter-bar.stories.tsx
+++ b/src/components/workspace/tracker-filter-bar.stories.tsx
@@ -17,7 +17,13 @@ export default meta;
 
 type Story = StoryObj<typeof TrackerFilterBar>;
 
-function Render({ initial }: { initial: GridFiltersJson }) {
+function Render({
+  initial,
+  showTertiaryStatFilter = true,
+}: {
+  initial: GridFiltersJson;
+  showTertiaryStatFilter?: boolean;
+}) {
   const [value, setValue] = useState<GridFiltersJson>(initial);
   return (
     <div className="border border-border bg-card px-3" style={{ width: 960 }}>
@@ -29,6 +35,7 @@ function Render({ initial }: { initial: GridFiltersJson }) {
         onTogglePin={() => {}}
         resultCount={42}
         resultNoun={{ singular: "tracker", plural: "trackers" }}
+        showTertiaryStatFilter={showTertiaryStatFilter}
       />
     </div>
   );
@@ -40,4 +47,10 @@ export const EmptyFilters: Story = {
 
 export const PopulatedFilters: Story = {
   render: () => <Render initial={MOCK_GRID_FILTERS_POPULATED} />,
+};
+
+export const TrackerGridNoTertiaryMenu: Story = {
+  render: () => (
+    <Render initial={MOCK_GRID_FILTERS_POPULATED} showTertiaryStatFilter={false} />
+  ),
 };

--- a/src/components/workspace/tracker-filter-bar.stories.tsx
+++ b/src/components/workspace/tracker-filter-bar.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+import { TrackerFilterBar } from "./tracker-filter-bar";
+import { MOCK_TRACKER_FORM_SELECTORS } from "../../../.storybook/mocks/tracker-options";
+import {
+  MOCK_GRID_FILTERS_EMPTY,
+  MOCK_GRID_FILTERS_POPULATED,
+} from "../../../.storybook/mocks/grid-filters";
+import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
+
+const meta: Meta<typeof TrackerFilterBar> = {
+  title: "Workspace/TrackerFilterBar",
+  component: TrackerFilterBar,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof TrackerFilterBar>;
+
+function Render({ initial }: { initial: GridFiltersJson }) {
+  const [value, setValue] = useState<GridFiltersJson>(initial);
+  return (
+    <div className="border border-border bg-card px-3" style={{ width: 960 }}>
+      <TrackerFilterBar
+        selectors={MOCK_TRACKER_FORM_SELECTORS}
+        value={value}
+        onChange={setValue}
+        pinnedHashes={[]}
+        onTogglePin={() => {}}
+        resultCount={42}
+        resultNoun={{ singular: "tracker", plural: "trackers" }}
+      />
+    </div>
+  );
+}
+
+export const EmptyFilters: Story = {
+  render: () => <Render initial={MOCK_GRID_FILTERS_EMPTY} />,
+};
+
+export const PopulatedFilters: Story = {
+  render: () => <Render initial={MOCK_GRID_FILTERS_POPULATED} />,
+};

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -31,6 +31,35 @@ const CLASS_TABS: Array<{ value: GridFilterClass; label: string }> = [
   { value: 2, label: "Warlock" },
 ];
 
+/** Per-dimension badge on submenu rows — mirrors the aggregate count on Filters. */
+function FilterDimensionSubTrigger({
+  label,
+  selectionCount,
+}: {
+  label: string;
+  selectionCount: number;
+}) {
+  const active = selectionCount > 0;
+  return (
+    <DropdownMenuSubTrigger
+      inset
+      className={cn(active && "font-medium text-foreground")}
+    >
+      <span className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {active ? (
+          <span
+            className="flex h-4 min-w-4 shrink-0 items-center justify-center rounded-none bg-primary px-1 text-[10px] font-semibold leading-none tabular-nums text-primary-foreground"
+            title={`${selectionCount} selected`}
+          >
+            {selectionCount}
+          </span>
+        ) : null}
+      </span>
+    </DropdownMenuSubTrigger>
+  );
+}
+
 interface ResultNoun {
   singular: string;
   plural: string;
@@ -220,7 +249,10 @@ export function TrackerFilterBar({
             className="min-w-48 rounded-none py-1"
           >
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger inset>Armor sets</DropdownMenuSubTrigger>
+              <FilterDimensionSubTrigger
+                label="Armor sets"
+                selectionCount={value.setHashes.length}
+              />
               <DropdownMenuSubContent
                 className="w-[min(90vw,22rem)] min-w-[18rem] rounded-none border-border p-0 shadow-xl"
                 collisionPadding={16}
@@ -241,7 +273,10 @@ export function TrackerFilterBar({
             </DropdownMenuSub>
 
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger inset>Archetypes</DropdownMenuSubTrigger>
+              <FilterDimensionSubTrigger
+                label="Archetypes"
+                selectionCount={value.archetypeHashes.length}
+              />
               <DropdownMenuSubContent
                 className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-64")}
                 collisionPadding={16}
@@ -269,7 +304,10 @@ export function TrackerFilterBar({
             </DropdownMenuSub>
 
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger inset>Tertiary stats</DropdownMenuSubTrigger>
+              <FilterDimensionSubTrigger
+                label="Tertiary stats"
+                selectionCount={value.tertiaryStats.length}
+              />
               <DropdownMenuSubContent
                 className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-48")}
                 collisionPadding={16}
@@ -288,7 +326,10 @@ export function TrackerFilterBar({
             </DropdownMenuSub>
 
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger inset>Tuning stats</DropdownMenuSubTrigger>
+              <FilterDimensionSubTrigger
+                label="Tuning stats"
+                selectionCount={value.tuningHashes.length}
+              />
               <DropdownMenuSubContent
                 className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-56")}
                 collisionPadding={16}

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { MagnifyingGlass, SlidersHorizontal, X } from "@phosphor-icons/react/dist/ssr";
+import { CLASS_NAMES } from "@/lib/bungie/constants";
+import { ARMOR_STAT_NAMES, type ArmorStatName } from "@/lib/db/types";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ArmorSetMultiSelectPanel } from "@/components/views/armor-set-combobox";
+import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
+import {
+  type GridFilterClass,
+  type GridFiltersJson,
+} from "@/lib/workspace/grid-filters-schema";
+
+const FILTER_MENU_CONTENT_CLASS =
+  "max-h-[min(60vh,20rem)] min-w-56 overflow-y-auto rounded-none py-2 shadow-xl";
+
+const CLASS_TABS: Array<{ value: GridFilterClass; label: string }> = [
+  { value: 0, label: "Titan" },
+  { value: 1, label: "Hunter" },
+  { value: 2, label: "Warlock" },
+];
+
+interface ResultNoun {
+  singular: string;
+  plural: string;
+}
+
+interface TrackerFilterBarProps {
+  selectors: TrackerFormSelectors;
+  value: GridFiltersJson;
+  onChange: (next: GridFiltersJson) => void;
+  pinnedHashes: readonly string[];
+  onTogglePin: (hash: string) => void;
+  resultCount: number;
+  resultNoun: ResultNoun;
+  /** Render inside the table-view header (uses TableHead container styles). */
+  variant?: "standalone" | "table-header";
+  className?: string;
+}
+
+/**
+ * Filter + class-tab + search bar shared between the Tracker grid view and the
+ * Table view. Mirrors the table view's prior inline filter dropdown — class
+ * change prunes set selections to class-valid options.
+ */
+export function TrackerFilterBar({
+  selectors,
+  value,
+  onChange,
+  pinnedHashes,
+  onTogglePin,
+  resultCount,
+  resultNoun,
+  variant = "standalone",
+  className,
+}: TrackerFilterBarProps) {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [searchUiOpen, setSearchUiOpen] = useState(false);
+  const searchExpanded = searchUiOpen || value.search.trim().length > 0;
+
+  const sortedSets = useMemo(
+    () => selectors.setsByClass[value.class],
+    [selectors.setsByClass, value.class],
+  );
+
+  const sortedArchetypes = useMemo(
+    () => [...selectors.archetypes].sort((a, b) => a.name.localeCompare(b.name)),
+    [selectors.archetypes],
+  );
+  const sortedTunings = useMemo(
+    () => [...selectors.tunings].sort((a, b) => a.name.localeCompare(b.name)),
+    [selectors.tunings],
+  );
+
+  const activeFilterDimCount = useMemo(() => {
+    let n = 0;
+    if (value.setHashes.length > 0) n += 1;
+    if (value.archetypeHashes.length > 0) n += 1;
+    if (value.tuningHashes.length > 0) n += 1;
+    if (value.tertiaryStats.length > 0) n += 1;
+    return n;
+  }, [value]);
+
+  const setHashesAsStrings = useMemo(
+    () => value.setHashes.map(String),
+    [value.setHashes],
+  );
+  const archetypeHashesAsStrings = useMemo(
+    () => value.archetypeHashes.map(String),
+    [value.archetypeHashes],
+  );
+  const tuningHashesAsStrings = useMemo(
+    () => value.tuningHashes.map(String),
+    [value.tuningHashes],
+  );
+
+  const armorSetEmptyCopy = selectors.manifestEmpty
+    ? "Sync the manifest first."
+    : "No sets for this class.";
+
+  function setSetHashesFromStrings(next: string[]) {
+    onChange({
+      ...value,
+      setHashes: next.map(Number).filter((n) => Number.isFinite(n)),
+    });
+  }
+
+  function toggleArchetype(id: string, checked: boolean) {
+    const idNum = Number(id);
+    const has = value.archetypeHashes.includes(idNum);
+    if (checked && !has) {
+      onChange({ ...value, archetypeHashes: [...value.archetypeHashes, idNum] });
+    } else if (!checked && has) {
+      onChange({
+        ...value,
+        archetypeHashes: value.archetypeHashes.filter((h) => h !== idNum),
+      });
+    }
+  }
+
+  function toggleTuning(id: string, checked: boolean) {
+    const idNum = Number(id);
+    const has = value.tuningHashes.includes(idNum);
+    if (checked && !has) {
+      onChange({ ...value, tuningHashes: [...value.tuningHashes, idNum] });
+    } else if (!checked && has) {
+      onChange({
+        ...value,
+        tuningHashes: value.tuningHashes.filter((h) => h !== idNum),
+      });
+    }
+  }
+
+  function toggleStat(stat: ArmorStatName, checked: boolean) {
+    const has = value.tertiaryStats.includes(stat);
+    if (checked && !has) {
+      onChange({ ...value, tertiaryStats: [...value.tertiaryStats, stat] });
+    } else if (!checked && has) {
+      onChange({
+        ...value,
+        tertiaryStats: value.tertiaryStats.filter((s) => s !== stat),
+      });
+    }
+  }
+
+  function switchClass(next: GridFilterClass) {
+    if (next === value.class) return;
+    const allowed = new Set(
+      selectors.setsByClass[next].map((s) => s.hash),
+    );
+    onChange({
+      ...value,
+      class: next,
+      setHashes: value.setHashes.filter((h) => allowed.has(h)),
+    });
+  }
+
+  const wrapperClass =
+    variant === "table-header"
+      ? "grid min-h-[52px] min-w-0 grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-2"
+      : "flex min-w-0 items-center gap-2 sm:gap-3";
+
+  return (
+    <div className={cn(wrapperClass, className)}>
+      <div className="flex min-w-0 shrink-0 overflow-hidden rounded-none bg-card">
+        {CLASS_TABS.map((tab) => (
+          <button
+            key={tab.value}
+            type="button"
+            className={cn(
+              "flex h-9 shrink-0 items-center border border-transparent px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+              value.class === tab.value &&
+                "border-border bg-accent text-foreground",
+            )}
+            onClick={() => switchClass(tab.value)}
+            aria-pressed={value.class === tab.value}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex min-w-0 shrink-0 items-center gap-2 self-center sm:gap-3">
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              aria-label="Armor filters"
+              className="relative h-9 shrink-0 gap-1.5 rounded-none px-3 text-xs"
+            >
+              <SlidersHorizontal weight="duotone" aria-hidden className="size-4" />
+              <span className="hidden sm:inline">Filters</span>
+              {activeFilterDimCount > 0 ? (
+                <span
+                  className="flex h-4 min-w-4 items-center justify-center rounded-none bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"
+                  aria-hidden
+                >
+                  {activeFilterDimCount}
+                </span>
+              ) : null}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="min-w-48 rounded-none py-1"
+          >
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger inset>Armor sets</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent
+                className="w-[min(90vw,22rem)] min-w-[18rem] rounded-none border-border p-0 shadow-xl"
+                collisionPadding={16}
+              >
+                <ArmorSetMultiSelectPanel
+                  key={value.class}
+                  options={sortedSets}
+                  values={setHashesAsStrings}
+                  onValuesChange={setSetHashesFromStrings}
+                  emptyCatalogMessage={armorSetEmptyCopy}
+                  sharpCorners
+                  pinnedHashes={pinnedHashes}
+                  onTogglePin={onTogglePin}
+                  autoFocusSearch
+                  className="max-h-[min(70vh,22rem)]"
+                />
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger inset>Archetypes</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent
+                className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-64")}
+                collisionPadding={16}
+              >
+                {sortedArchetypes.length === 0 ? (
+                  <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
+                    No archetypes — sync the manifest first.
+                  </div>
+                ) : (
+                  sortedArchetypes.map((a) => {
+                    const id = String(a.hash);
+                    return (
+                      <DropdownMenuCheckboxItem
+                        key={a.hash}
+                        checked={archetypeHashesAsStrings.includes(id)}
+                        onSelect={(e) => e.preventDefault()}
+                        onCheckedChange={(c) => toggleArchetype(id, c)}
+                      >
+                        {a.name}
+                      </DropdownMenuCheckboxItem>
+                    );
+                  })
+                )}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger inset>Tertiary stats</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent
+                className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-48")}
+                collisionPadding={16}
+              >
+                {ARMOR_STAT_NAMES.map((stat) => (
+                  <DropdownMenuCheckboxItem
+                    key={stat}
+                    checked={value.tertiaryStats.includes(stat)}
+                    onSelect={(e) => e.preventDefault()}
+                    onCheckedChange={(c) => toggleStat(stat, c)}
+                  >
+                    {stat}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger inset>Tuning stats</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent
+                className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-56")}
+                collisionPadding={16}
+              >
+                {sortedTunings.length === 0 ? (
+                  <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
+                    No tunings — sync the manifest first.
+                  </div>
+                ) : (
+                  sortedTunings.map((t) => {
+                    const id = String(t.hash);
+                    return (
+                      <DropdownMenuCheckboxItem
+                        key={t.hash}
+                        checked={tuningHashesAsStrings.includes(id)}
+                        onSelect={(e) => e.preventDefault()}
+                        onCheckedChange={(c) => toggleTuning(id, c)}
+                      >
+                        {t.name}
+                      </DropdownMenuCheckboxItem>
+                    );
+                  })
+                )}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <p
+          className="min-w-0 text-xs leading-snug text-muted-foreground/80"
+          aria-live="polite"
+        >
+          Showing {resultCount}{" "}
+          {resultCount === 1 ? resultNoun.singular : resultNoun.plural} for{" "}
+          {CLASS_NAMES[value.class] ?? "class"}.
+        </p>
+      </div>
+
+      <div className="min-w-0 justify-self-end">
+        {searchExpanded ? (
+          <div
+            role="search"
+            className="relative min-h-[52px] min-w-0 lg:max-w-xs"
+          >
+            <MagnifyingGlass
+              weight="regular"
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden
+            />
+            <input
+              ref={searchInputRef}
+              type="search"
+              value={value.search}
+              onChange={(e) => onChange({ ...value, search: e.target.value })}
+              placeholder="Search armor"
+              aria-label="Search armor"
+              onBlur={() => {
+                if (!value.search.trim()) setSearchUiOpen(false);
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== "Escape") return;
+                if (value.search.trim()) {
+                  onChange({ ...value, search: "" });
+                } else {
+                  setSearchUiOpen(false);
+                  e.currentTarget.blur();
+                }
+              }}
+              className="h-[52px] w-full min-w-0 border-0 border-b border-white bg-transparent py-0 ps-9 pe-9 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/80 focus-visible:border-b focus-visible:border-white focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-search-cancel-button]:hidden"
+            />
+            {value.search ? (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onPointerDown={(e) => e.preventDefault()}
+                onClick={() => onChange({ ...value, search: "" })}
+                className="absolute right-2 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <X weight="bold" className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Search armor"
+            aria-expanded={searchExpanded}
+            className="size-9 shrink-0 self-center rounded-none border-0 shadow-none hover:bg-accent/50"
+            onClick={() => {
+              setSearchUiOpen(true);
+              queueMicrotask(() =>
+                searchInputRef.current?.focus({ preventScroll: true }),
+              );
+            }}
+          >
+            <MagnifyingGlass weight="regular" aria-hidden className="size-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -75,13 +75,15 @@ interface TrackerFilterBarProps {
   resultNoun: ResultNoun;
   /** Render inside the table-view header (uses TableHead container styles). */
   variant?: "standalone" | "table-header";
+  /** Tracker grid hides tertiary filtering; inventory table keeps it enabled. */
+  showTertiaryStatFilter?: boolean;
   className?: string;
 }
 
 /**
  * Filter + class-tab + search bar shared between the Tracker grid view and the
- * Table view. Mirrors the table view's prior inline filter dropdown — class
- * change prunes set selections to class-valid options.
+ * Table view (`showTertiaryStatFilter`). Mirrors the table view's prior inline
+ * filter dropdown — class change prunes set selections to class-valid options.
  */
 export function TrackerFilterBar({
   selectors,
@@ -92,6 +94,7 @@ export function TrackerFilterBar({
   resultCount,
   resultNoun,
   variant = "standalone",
+  showTertiaryStatFilter = true,
   className,
 }: TrackerFilterBarProps) {
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -117,9 +120,9 @@ export function TrackerFilterBar({
     if (value.setHashes.length > 0) n += 1;
     if (value.archetypeHashes.length > 0) n += 1;
     if (value.tuningHashes.length > 0) n += 1;
-    if (value.tertiaryStats.length > 0) n += 1;
+    if (showTertiaryStatFilter && value.tertiaryStats.length > 0) n += 1;
     return n;
-  }, [value]);
+  }, [value, showTertiaryStatFilter]);
 
   const setHashesAsStrings = useMemo(
     () => value.setHashes.map(String),
@@ -303,27 +306,29 @@ export function TrackerFilterBar({
               </DropdownMenuSubContent>
             </DropdownMenuSub>
 
-            <DropdownMenuSub>
-              <FilterDimensionSubTrigger
-                label="Tertiary stats"
-                selectionCount={value.tertiaryStats.length}
-              />
-              <DropdownMenuSubContent
-                className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-48")}
-                collisionPadding={16}
-              >
-                {ARMOR_STAT_NAMES.map((stat) => (
-                  <DropdownMenuCheckboxItem
-                    key={stat}
-                    checked={value.tertiaryStats.includes(stat)}
-                    onSelect={(e) => e.preventDefault()}
-                    onCheckedChange={(c) => toggleStat(stat, c)}
-                  >
-                    {stat}
-                  </DropdownMenuCheckboxItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
+            {showTertiaryStatFilter ? (
+              <DropdownMenuSub>
+                <FilterDimensionSubTrigger
+                  label="Tertiary stats"
+                  selectionCount={value.tertiaryStats.length}
+                />
+                <DropdownMenuSubContent
+                  className={cn(FILTER_MENU_CONTENT_CLASS, "min-w-48")}
+                  collisionPadding={16}
+                >
+                  {ARMOR_STAT_NAMES.map((stat) => (
+                    <DropdownMenuCheckboxItem
+                      key={stat}
+                      checked={value.tertiaryStats.includes(stat)}
+                      onSelect={(e) => e.preventDefault()}
+                      onCheckedChange={(c) => toggleStat(stat, c)}
+                    >
+                      {stat}
+                    </DropdownMenuCheckboxItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            ) : null}
 
             <DropdownMenuSub>
               <FilterDimensionSubTrigger

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -166,10 +166,13 @@ export function TrackerFilterBar({
     });
   }
 
+  /** Match expanded search (`h-[52px]` input rail) so the bar height stays fixed when collapsed. */
+  const barMinH = "min-h-[52px]";
+
   const wrapperClass =
     variant === "table-header"
-      ? "grid min-h-[52px] min-w-0 grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-2"
-      : "flex min-w-0 items-center gap-2 sm:gap-3";
+      ? cn("grid min-w-0 grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-2", barMinH)
+      : cn("flex min-w-0 items-center gap-2 sm:gap-3", barMinH);
 
   return (
     <div className={cn(wrapperClass, className)}>

--- a/src/components/workspace/tracker-grid-content.stories.tsx
+++ b/src/components/workspace/tracker-grid-content.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { TrackerGridContent } from "./tracker-grid-content";
+import {
+  MOCK_PAYLOAD_HUNTER_EMPTY,
+  MOCK_PAYLOAD_TITAN_COMPLETE,
+  MOCK_PAYLOAD_TITAN_PARTIAL,
+} from "../../../.storybook/mocks/tracker-payload";
+
+const meta: Meta<typeof TrackerGridContent> = {
+  title: "Workspace/TrackerGridContent",
+  component: TrackerGridContent,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof TrackerGridContent>;
+
+export const PartialProgress: Story = {
+  render: () => (
+    <div style={{ width: 566, height: 384 }}>
+      <TrackerGridContent
+        payload={MOCK_PAYLOAD_TITAN_PARTIAL}
+        hasInventory
+        onCompareClick={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const CompleteCoverage: Story = {
+  render: () => (
+    <div style={{ width: 566, height: 384 }}>
+      <TrackerGridContent
+        payload={MOCK_PAYLOAD_TITAN_COMPLETE}
+        hasInventory
+        onCompareClick={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const NoInventory: Story = {
+  render: () => (
+    <div style={{ width: 566, height: 384 }}>
+      <TrackerGridContent
+        payload={MOCK_PAYLOAD_HUNTER_EMPTY}
+        hasInventory={false}
+        onCompareClick={() => {}}
+      />
+    </div>
+  ),
+};

--- a/src/components/workspace/tracker-grid-content.tsx
+++ b/src/components/workspace/tracker-grid-content.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMemo } from "react";
+import { SquareSplitHorizontal } from "@phosphor-icons/react/dist/ssr";
+import { TuningHeaderGlyph } from "@/components/views/tuning-header-glyph";
+import { ViewGrid } from "@/components/views/view-grid";
+import type { ArmorStatName } from "@/lib/db/types";
+import type { ViewProgress } from "@/lib/views/progress";
+import { TrackerIdentBadges } from "@/components/workspace/tracker-ident-badges";
+import type { SerializableTrackerPayload } from "@/lib/workspace/types";
+import { cn } from "@/lib/utils";
+
+interface TrackerGridContentProps {
+  payload: SerializableTrackerPayload;
+  hasInventory: boolean;
+  onCompareClick?: () => void;
+  className?: string;
+}
+
+/** Class glyph assets (static; manifest does not ship class icons). */
+const CLASS_GLYPH_SRC: Record<number, string> = {
+  0: "/class-icons/titan.svg",
+  1: "/class-icons/hunter.svg",
+  2: "/class-icons/warlock.svg",
+};
+
+function ClassGlyph({
+  classType,
+  className,
+}: {
+  classType: number;
+  className?: string;
+}) {
+  const src = CLASS_GLYPH_SRC[classType];
+  if (src) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element -- static asset; plain img keeps currentColor + sizing simple
+      <img src={src} alt="" aria-hidden className={className} />
+    );
+  }
+  return (
+    <svg
+      width="30"
+      height="15"
+      viewBox="0 0 30 15"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      className={className}
+    >
+      <path d="M0 15 L7.5 0 L15 15 Z" fill="currentColor" />
+      <path d="M15 15 L22.5 0 L30 15 Z" fill="currentColor" />
+    </svg>
+  );
+}
+
+const TRACKER_BODY_GLASS_BORDER =
+  "bg-[linear-gradient(170deg,rgba(255,255,255,0.5)_0%,rgba(255,255,255,0.24)_18%,rgba(255,255,255,0.24)_52%,rgba(255,255,255,0.36)_100%)]";
+
+const TRACKER_HEADER_CONTENT_DIVIDER =
+  "h-px w-full shrink-0 bg-gradient-to-r from-white/[0.06] via-white/[0.32] to-white/[0.06]";
+
+/**
+ * Inline tracker tile (no Rnd / merge chrome). Same inner layout as the
+ * canvas `TrackerPanel`'s solo branch — header + ViewGrid + a Compare action.
+ */
+export function TrackerGridContent({
+  payload,
+  hasInventory,
+  onCompareClick,
+  className,
+}: TrackerGridContentProps) {
+  const { view } = payload;
+
+  const viewProgressForGrid = useMemo(
+    (): ViewProgress => ({
+      ...payload.progress,
+      cells: payload.progress.cells as ViewProgress["cells"],
+    }),
+    [payload.progress],
+  );
+
+  const tertiaryPaths = payload.tertiaryStatIconPaths as Partial<
+    Record<ArmorStatName, string>
+  >;
+
+  const glyphClass =
+    Number(view.class_type) < 0
+      ? "block h-[15px] w-[30px] shrink-0 text-foreground"
+      : Number(view.class_type) === 2
+        ? "block h-3.5 w-auto shrink-0 object-contain"
+        : "block h-7 w-auto shrink-0 object-contain";
+
+  const ariaRegionLabel = `Tracker ${payload.setName} · ${payload.archetypeName}`;
+
+  return (
+    <div
+      role="region"
+      aria-label={ariaRegionLabel}
+      className={cn(
+        "flex h-full min-h-0 w-full overflow-hidden rounded-none p-px shadow-lg",
+        TRACKER_BODY_GLASS_BORDER,
+        className,
+      )}
+    >
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-card">
+        <header className="flex shrink-0 select-none items-center gap-4 p-4">
+          <ClassGlyph
+            classType={Number(view.class_type)}
+            className={glyphClass}
+          />
+          <TrackerIdentBadges
+            setName={payload.setName}
+            archetypeName={payload.archetypeName}
+            tuning={
+              <TuningHeaderGlyph
+                tuningName={payload.tuningName}
+                iconPath={payload.tuningStatIconPath}
+              />
+            }
+          />
+        </header>
+
+        <div className={TRACKER_HEADER_CONTENT_DIVIDER} aria-hidden />
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden px-4 pt-4 pb-2">
+          {payload.needsClass ? (
+            <div
+              role="alert"
+              className="rounded-none border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200"
+            >
+              <p className="font-medium">No class assigned</p>
+              <p className="text-muted-foreground">
+                Created before class scoping. Delete and remake to filter by
+                class.
+              </p>
+            </div>
+          ) : null}
+
+          <ViewGrid
+            progress={viewProgressForGrid}
+            hasInventory={hasInventory}
+            tertiaryStatIconPaths={tertiaryPaths}
+            armorSlotIconPaths={payload.armorSlotIconPaths}
+          />
+
+          {onCompareClick ? (
+            <div className="mt-auto flex shrink-0 justify-end pt-1">
+              <button
+                type="button"
+                onClick={onCompareClick}
+                className="inline-flex h-7 items-center gap-1.5 rounded-none border border-border bg-card px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <SquareSplitHorizontal
+                  weight="duotone"
+                  aria-hidden
+                  className="h-3.5 w-3.5"
+                />
+                Compare
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/tracker-grid-content.tsx
+++ b/src/components/workspace/tracker-grid-content.tsx
@@ -62,7 +62,7 @@ const TRACKER_HEADER_CONTENT_DIVIDER =
 
 /**
  * Inline tracker tile (no Rnd / merge chrome). Same inner layout as the
- * canvas `TrackerPanel`'s solo branch — header + ViewGrid + a Compare action.
+ * canvas `TrackerPanel`'s solo branch — header + ViewGrid; Compare sits top-right in the header when enabled.
  */
 export function TrackerGridContent({
   payload,
@@ -105,20 +105,36 @@ export function TrackerGridContent({
     >
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-card">
         <header className="flex shrink-0 select-none items-center gap-4 p-4">
-          <ClassGlyph
-            classType={Number(view.class_type)}
-            className={glyphClass}
-          />
-          <TrackerIdentBadges
-            setName={payload.setName}
-            archetypeName={payload.archetypeName}
-            tuning={
-              <TuningHeaderGlyph
-                tuningName={payload.tuningName}
-                iconPath={payload.tuningStatIconPath}
+          <div className="flex min-w-0 flex-1 items-center gap-4">
+            <ClassGlyph
+              classType={Number(view.class_type)}
+              className={glyphClass}
+            />
+            <TrackerIdentBadges
+              setName={payload.setName}
+              archetypeName={payload.archetypeName}
+              tuning={
+                <TuningHeaderGlyph
+                  tuningName={payload.tuningName}
+                  iconPath={payload.tuningStatIconPath}
+                />
+              }
+            />
+          </div>
+          {onCompareClick ? (
+            <button
+              type="button"
+              onClick={onCompareClick}
+              className="inline-flex h-8 shrink-0 items-center gap-2 rounded-none border border-border bg-card px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <SquareSplitHorizontal
+                weight="duotone"
+                aria-hidden
+                className="h-4 w-4 shrink-0"
               />
-            }
-          />
+              Compare
+            </button>
+          ) : null}
         </header>
 
         <div className={TRACKER_HEADER_CONTENT_DIVIDER} aria-hidden />
@@ -143,23 +159,6 @@ export function TrackerGridContent({
             tertiaryStatIconPaths={tertiaryPaths}
             armorSlotIconPaths={payload.armorSlotIconPaths}
           />
-
-          {onCompareClick ? (
-            <div className="mt-auto flex shrink-0 justify-end pt-1">
-              <button
-                type="button"
-                onClick={onCompareClick}
-                className="inline-flex h-7 items-center gap-1.5 rounded-none border border-border bg-card px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <SquareSplitHorizontal
-                  weight="duotone"
-                  aria-hidden
-                  className="h-3.5 w-3.5"
-                />
-                Compare
-              </button>
-            </div>
-          ) : null}
         </div>
       </div>
     </div>

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -22,6 +22,7 @@ export type Database = {
           created_at: string;
           updated_at: string;
           workspace_camera: Json;
+          grid_filters: Json;
         };
         Insert: {
           id?: string;
@@ -32,6 +33,7 @@ export type Database = {
           created_at?: string;
           updated_at?: string;
           workspace_camera?: Json;
+          grid_filters?: Json;
         };
         Update: {
           id?: string;
@@ -42,6 +44,7 @@ export type Database = {
           created_at?: string;
           updated_at?: string;
           workspace_camera?: Json;
+          grid_filters?: Json;
         };
         Relationships: [];
       };

--- a/src/lib/views/grid-lookup-payload.server.ts
+++ b/src/lib/views/grid-lookup-payload.server.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+import type { ManifestLookups } from "@/lib/manifest/lookups";
+import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
+
+/** Serialize the Map-based manifest lookups into a JSON-safe payload. */
+export function buildGridLookupPayload(
+  lookups: ManifestLookups,
+): GridLookupPayload {
+  const setNameByHash: Record<string, string> = {};
+  for (const [hash, name] of lookups.setNameByHash) {
+    setNameByHash[String(hash)] = name;
+  }
+
+  const archetypeNameByHash: Record<string, string> = {};
+  for (const [hash, name] of lookups.archetypeNameByHash) {
+    archetypeNameByHash[String(hash)] = name;
+  }
+
+  const tuningNameByHash: Record<string, string> = {};
+  for (const [hash, name] of lookups.tuningNameByHash) {
+    tuningNameByHash[String(hash)] = name;
+  }
+
+  const armorSlotIconByKey: Record<string, string> = {};
+  for (const [key, path] of lookups.armorSlotIconPathBySetClassSlot) {
+    armorSlotIconByKey[key] = path;
+  }
+
+  const slotFallbackIconByName: GridLookupPayload["slotFallbackIconByName"] = {};
+  for (const [slot, path] of lookups.slotFallbackIconPathBySlot) {
+    slotFallbackIconByName[slot] = path;
+  }
+
+  const archetypeStatPair: GridLookupPayload["archetypeStatPair"] = {};
+  for (const [hash, pair] of lookups.archetypeStatPair) {
+    archetypeStatPair[String(hash)] = pair;
+  }
+
+  const statIconByName: GridLookupPayload["statIconByName"] = {};
+  for (const [stat, path] of lookups.statIconByName) {
+    statIconByName[stat] = path;
+  }
+
+  return {
+    setNameByHash,
+    archetypeNameByHash,
+    tuningNameByHash,
+    armorSlotIconByKey,
+    slotFallbackIconByName,
+    archetypeStatPair,
+    statIconByName,
+  };
+}

--- a/src/lib/views/grid-lookup-payload.ts
+++ b/src/lib/views/grid-lookup-payload.ts
@@ -1,0 +1,62 @@
+import type { ArmorSlot } from "@/lib/bungie/constants";
+import { SLOT_ORDER } from "@/lib/bungie/constants";
+import type { ArmorStatName } from "@/lib/db/types";
+
+/**
+ * Plain-JSON subset of `ManifestLookups` safe to ship to the client. Used by
+ * the dashboard Tracker grid to build ephemeral tracker payloads on demand
+ * (without going through the `server-only` builder).
+ */
+export interface GridLookupPayload {
+  setNameByHash: Record<string, string>;
+  archetypeNameByHash: Record<string, string>;
+  tuningNameByHash: Record<string, string>;
+  /** `${setHash}:${classType}:${slot}` → relative icon path. */
+  armorSlotIconByKey: Record<string, string>;
+  /** Per-slot fallback icon when no exact set+class+slot row exists. */
+  slotFallbackIconByName: Partial<Record<ArmorSlot, string>>;
+  archetypeStatPair: Record<
+    string,
+    { primary: ArmorStatName; secondary: ArmorStatName }
+  >;
+  statIconByName: Partial<Record<ArmorStatName, string>>;
+}
+
+export function gridLookupArmorSlotIconKey(
+  setHash: number,
+  classType: number,
+  slot: ArmorSlot,
+): string {
+  return `${setHash}:${classType}:${slot}`;
+}
+
+/**
+ * Per-slot icon paths for a given set + class, picking the canonical exact
+ * match first, then the slot fallback. Mirrors `armorSlotIconPathsForView` in
+ * `src/lib/manifest/lookups.ts`, but reads from the client-safe payload.
+ */
+export function armorSlotIconPathsFromGridLookup(
+  lookup: GridLookupPayload,
+  setHash: number,
+  classType: number,
+): Partial<Record<ArmorSlot, string>> {
+  const out: Partial<Record<ArmorSlot, string>> = {};
+  for (const slot of SLOT_ORDER) {
+    let path: string | undefined;
+    if (classType >= 0) {
+      path = lookup.armorSlotIconByKey[
+        gridLookupArmorSlotIconKey(setHash, classType, slot)
+      ];
+    } else {
+      for (const cls of [0, 1, 2, 3] as const) {
+        path = lookup.armorSlotIconByKey[
+          gridLookupArmorSlotIconKey(setHash, cls, slot)
+        ];
+        if (path) break;
+      }
+    }
+    if (!path) path = lookup.slotFallbackIconByName[slot];
+    if (path) out[slot] = path;
+  }
+  return out;
+}

--- a/src/lib/workspace/build-tracker-payload-core.ts
+++ b/src/lib/workspace/build-tracker-payload-core.ts
@@ -1,0 +1,162 @@
+import { CLASS_NAMES, SLOT_ORDER } from "@/lib/bungie/constants";
+import type {
+  ArmorStatName,
+  DerivedArmorPieceJson,
+  ViewRow,
+} from "@/lib/db/types";
+import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
+import { armorSlotIconPathsFromGridLookup } from "@/lib/views/grid-lookup-payload";
+import type { ViewProgress } from "@/lib/views/progress";
+import {
+  computeViewProgress,
+  tertiaryStatsForArchetype,
+} from "@/lib/views/progress";
+import { tuningPositiveArmorStat } from "@/lib/views/tuning-positive-stat";
+import type {
+  SerializableTrackerPayload,
+  SerializableViewProgressCells,
+} from "@/lib/workspace/types";
+import {
+  defaultWorkspaceLayout,
+  type WorkspaceLayoutJson,
+} from "@/lib/workspace/workspace-schema";
+
+function cellsToSerializable(
+  cells: ViewProgress["cells"],
+): SerializableViewProgressCells {
+  const out: SerializableViewProgressCells = {};
+  for (const slot of SLOT_ORDER) {
+    out[slot] = {};
+    const row = cells[slot];
+    for (const statName of Object.keys(row)) {
+      const v = row[statName as ArmorStatName];
+      if (v !== undefined) {
+        out[slot]![statName] = v;
+      }
+    }
+  }
+  return out;
+}
+
+interface EphemeralDescriptor {
+  setHash: number;
+  archetypeHash: number;
+  tuningHash: number;
+  classType: number;
+}
+
+/**
+ * Pure tracker payload assembly. Reads only from {@link GridLookupPayload} so
+ * it runs on either side of the server/client boundary.
+ */
+export function assembleTrackerPayloadFromLookup(
+  view: ViewRow & { layout: WorkspaceLayoutJson },
+  resolvedSetHash: number,
+  inventory: DerivedArmorPieceJson[],
+  lookup: GridLookupPayload,
+): SerializableTrackerPayload {
+  const archetypePair = lookup.archetypeStatPair[String(view.archetype_hash)];
+  const tertiaryStats = tertiaryStatsForArchetype(archetypePair);
+
+  const viewForMatching: ViewRow = { ...view, set_hash: resolvedSetHash };
+  const progressFull = computeViewProgress(
+    viewForMatching,
+    inventory,
+    tertiaryStats,
+  );
+
+  const tertiaryStatIconPaths: Partial<Record<ArmorStatName, string>> = {};
+  for (const t of tertiaryStats) {
+    const path = lookup.statIconByName[t];
+    if (path) tertiaryStatIconPaths[t] = path;
+  }
+
+  const armorSlotIconPaths = armorSlotIconPathsFromGridLookup(
+    lookup,
+    resolvedSetHash,
+    Number(view.class_type),
+  );
+
+  const setName =
+    lookup.setNameByHash[String(resolvedSetHash)] ?? "Unknown set";
+  const archetypeName =
+    lookup.archetypeNameByHash[String(view.archetype_hash)] ??
+    "Unknown archetype";
+  const tuningName =
+    lookup.tuningNameByHash[String(view.tuning_hash)] ?? "Unknown tuning";
+  const tuningPositive = tuningPositiveArmorStat(tuningName);
+  const tuningStatIconPath =
+    tuningPositive !== null
+      ? (lookup.statIconByName[tuningPositive] ?? null)
+      : null;
+
+  const className =
+    Number(view.class_type) >= 0
+      ? CLASS_NAMES[Number(view.class_type)]
+      : null;
+
+  const progress = {
+    ...progressFull,
+    cells: cellsToSerializable(progressFull.cells),
+  };
+
+  return {
+    view,
+    progress,
+    setName,
+    archetypeName,
+    tuningName,
+    tuningStatIconPath,
+    className,
+    archetypePrimarySecondary: archetypePair
+      ? { primary: archetypePair.primary, secondary: archetypePair.secondary }
+      : null,
+    tertiaryStatIconPaths: tertiaryStatIconPaths as Record<string, string>,
+    armorSlotIconPaths: armorSlotIconPaths as Record<string, string>,
+    needsClass: Number(view.class_type) < 0,
+    resolvedSetHash,
+  };
+}
+
+/**
+ * Build a tracker payload for an ephemeral grid tile — no `views` row required.
+ * Synthetic `view.id` keeps `SerializableTrackerPayload` consumers (ViewGrid,
+ * MergedCompareGrid) happy without touching the database.
+ */
+export function buildEphemeralTrackerPayload(
+  descriptor: EphemeralDescriptor,
+  inventory: DerivedArmorPieceJson[],
+  lookup: GridLookupPayload,
+): SerializableTrackerPayload {
+  const { setHash, archetypeHash, tuningHash, classType } = descriptor;
+
+  const setName = lookup.setNameByHash[String(setHash)] ?? "Unknown set";
+  const archetypeName =
+    lookup.archetypeNameByHash[String(archetypeHash)] ?? "Unknown archetype";
+  const tuningName =
+    lookup.tuningNameByHash[String(tuningHash)] ?? "Unknown tuning";
+
+  const view: ViewRow & { layout: WorkspaceLayoutJson } = {
+    id: ephemeralTrackerId(descriptor),
+    user_id: "",
+    name: `${setName} · ${archetypeName} · ${tuningName}`,
+    set_hash: setHash,
+    archetype_hash: archetypeHash,
+    tuning_hash: tuningHash,
+    class_type: classType,
+    created_at: "1970-01-01T00:00:00.000Z",
+    updated_at: "1970-01-01T00:00:00.000Z",
+    layout: defaultWorkspaceLayout(),
+  };
+
+  return assembleTrackerPayloadFromLookup(
+    view,
+    setHash,
+    inventory,
+    lookup,
+  );
+}
+
+export function ephemeralTrackerId(d: EphemeralDescriptor): string {
+  return `eph:${d.classType}:${d.setHash}:${d.archetypeHash}:${d.tuningHash}`;
+}

--- a/src/lib/workspace/build-tracker-payload.ts
+++ b/src/lib/workspace/build-tracker-payload.ts
@@ -1,41 +1,12 @@
 import "server-only";
 
-import { CLASS_NAMES, SLOT_ORDER } from "@/lib/bungie/constants";
-import type { ArmorStatName } from "@/lib/db/types";
 import type { DerivedArmorPieceJson, ViewRow } from "@/lib/db/types";
 import type { ManifestLookups } from "@/lib/manifest/lookups";
-import {
-  armorSlotIconPathsForView,
-  resolveViewSetHash,
-} from "@/lib/manifest/lookups";
-import type { ViewProgress } from "@/lib/views/progress";
-import {
-  computeViewProgress,
-  tertiaryStatsForArchetype,
-} from "@/lib/views/progress";
-import { tuningPositiveArmorStat } from "@/lib/views/tuning-positive-stat";
-import type {
-  SerializableTrackerPayload,
-  SerializableViewProgressCells,
-} from "@/lib/workspace/types";
+import { resolveViewSetHash } from "@/lib/manifest/lookups";
+import { buildGridLookupPayload } from "@/lib/views/grid-lookup-payload.server";
+import { assembleTrackerPayloadFromLookup } from "@/lib/workspace/build-tracker-payload-core";
+import type { SerializableTrackerPayload } from "@/lib/workspace/types";
 import { parseWorkspaceLayout } from "@/lib/workspace/workspace-schema";
-
-function cellsToSerializable(
-  cells: ViewProgress["cells"],
-): SerializableViewProgressCells {
-  const out: SerializableViewProgressCells = {};
-  for (const slot of SLOT_ORDER) {
-    out[slot] = {};
-    const row = cells[slot];
-    for (const statName of Object.keys(row)) {
-      const v = row[statName as ArmorStatName];
-      if (v !== undefined) {
-        out[slot]![statName] = v;
-      }
-    }
-  }
-  return out;
-}
 
 /** Build one tracker card payload after DB view row + manifest + inventory snapshot. */
 export function buildSerializableTrackerPayload(
@@ -44,76 +15,12 @@ export function buildSerializableTrackerPayload(
   inventory: DerivedArmorPieceJson[],
 ): SerializableTrackerPayload {
   const resolvedSetHash = resolveViewSetHash(Number(viewRow.set_hash), lookups);
-  const viewForMatching = { ...viewRow, set_hash: resolvedSetHash };
+  const lookupPayload = buildGridLookupPayload(lookups);
 
-  const archetypePair = lookups.archetypeStatPair.get(
-    Number(viewRow.archetype_hash),
-  );
-  const tertiaryStats = tertiaryStatsForArchetype(archetypePair);
-  const progressFull = computeViewProgress(
-    viewForMatching,
+  return assembleTrackerPayloadFromLookup(
+    { ...viewRow, layout: parseWorkspaceLayout(viewRow.layout) },
+    resolvedSetHash,
     inventory,
-    tertiaryStats,
+    lookupPayload,
   );
-
-  const tertiaryStatIconPaths: Partial<Record<ArmorStatName, string>> = {};
-  for (const t of tertiaryStats) {
-    const path = lookups.statIconByName.get(t);
-    if (path) tertiaryStatIconPaths[t] = path;
-  }
-
-  const armorSlotIconPaths = armorSlotIconPathsForView(
-    lookups,
-    resolvedSetHash,
-    Number(viewRow.class_type),
-  );
-
-  const setName =
-    lookups.setNameByHash.get(resolvedSetHash) ?? "Unknown set";
-  const archetypeName =
-    lookups.archetypeNameByHash.get(Number(viewRow.archetype_hash)) ??
-    "Unknown archetype";
-  const tuningName =
-    lookups.tuningNameByHash.get(Number(viewRow.tuning_hash)) ?? "Unknown tuning";
-  const tuningPositive = tuningPositiveArmorStat(tuningName);
-  const tuningStatIconPath =
-    tuningPositive !== null
-      ? (lookups.statIconByName.get(tuningPositive) ?? null)
-      : null;
-
-  const className =
-    Number(viewRow.class_type) >= 0
-      ? CLASS_NAMES[Number(viewRow.class_type)]
-      : null;
-
-  const { cells, ...restProgress } = progressFull;
-  void cells;
-  const progress = {
-    ...restProgress,
-    cells: cellsToSerializable(progressFull.cells),
-  };
-
-  const needsClass = Number(viewRow.class_type) < 0;
-
-  const layout = parseWorkspaceLayout(viewRow.layout);
-
-  return {
-    view: {
-      ...viewRow,
-      layout,
-    },
-    progress,
-    setName,
-    archetypeName,
-    tuningName,
-    tuningStatIconPath,
-    className,
-    archetypePrimarySecondary: archetypePair
-      ? { primary: archetypePair.primary, secondary: archetypePair.secondary }
-      : null,
-    tertiaryStatIconPaths: tertiaryStatIconPaths as Record<string, string>,
-    armorSlotIconPaths: armorSlotIconPaths as Record<string, string>,
-    needsClass,
-    resolvedSetHash,
-  };
 }

--- a/src/lib/workspace/grid-filters-schema.ts
+++ b/src/lib/workspace/grid-filters-schema.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import { ARMOR_STAT_NAMES, type ArmorStatName } from "@/lib/db/types";
+
+/** Single-class scope: 0 = Titan, 1 = Hunter, 2 = Warlock. */
+export const GRID_FILTER_CLASS_VALUES = [0, 1, 2] as const;
+export type GridFilterClass = (typeof GRID_FILTER_CLASS_VALUES)[number];
+
+const HASH_LIST_MAX = 256;
+const SEARCH_MAX = 128;
+
+export const gridFiltersSchema = z.object({
+  version: z.literal(1),
+  class: z.union([z.literal(0), z.literal(1), z.literal(2)]),
+  setHashes: z.array(z.number().int().nonnegative()).max(HASH_LIST_MAX),
+  archetypeHashes: z.array(z.number().int().nonnegative()).max(HASH_LIST_MAX),
+  tuningHashes: z.array(z.number().int().nonnegative()).max(HASH_LIST_MAX),
+  tertiaryStats: z
+    .array(z.enum(ARMOR_STAT_NAMES as unknown as [ArmorStatName, ...ArmorStatName[]]))
+    .max(ARMOR_STAT_NAMES.length),
+  search: z.string().max(SEARCH_MAX),
+});
+
+export type GridFiltersJson = z.infer<typeof gridFiltersSchema>;
+
+export function defaultGridFilters(): GridFiltersJson {
+  return {
+    version: 1,
+    class: 0,
+    setHashes: [],
+    archetypeHashes: [],
+    tuningHashes: [],
+    tertiaryStats: [],
+    search: "",
+  };
+}
+
+/** Tolerant parser — returns defaults on any structural failure. */
+export function parseGridFilters(raw: unknown): GridFiltersJson {
+  if (raw === null || typeof raw !== "object") {
+    return defaultGridFilters();
+  }
+  const parsed = gridFiltersSchema.safeParse(raw);
+  if (parsed.success) return parsed.data;
+  return defaultGridFilters();
+}
+
+/**
+ * Does at least one of the unblocking filters (set / archetype / tuning) have a
+ * selection? Tertiary stats and search alone do NOT unblock — they narrow once
+ * a primary axis is picked.
+ */
+export function gridFiltersHaveUnblockingSelection(
+  filters: GridFiltersJson,
+): boolean {
+  return (
+    filters.setHashes.length > 0 ||
+    filters.archetypeHashes.length > 0 ||
+    filters.tuningHashes.length > 0
+  );
+}

--- a/src/lib/workspace/use-grid-filters-persistence.ts
+++ b/src/lib/workspace/use-grid-filters-persistence.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
+
+const PERSIST_DEBOUNCE_MS = 500;
+
+/**
+ * Hydrates dashboard filter state from the server blob and PATCHes `/api/me/workspace`
+ * on change (debounced), shared by grid and table dashboard modes.
+ */
+export function useGridFiltersPersistence(
+  initialFilters: GridFiltersJson,
+): {
+  filters: GridFiltersJson;
+  onFiltersChange: (next: GridFiltersJson) => void;
+} {
+  const [filters, setFilters] = useState(initialFilters);
+
+  const pendingFiltersRef = useRef<GridFiltersJson | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flush = useCallback(async () => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const next = pendingFiltersRef.current;
+    if (next === null) return;
+    pendingFiltersRef.current = null;
+    try {
+      const res = await fetch("/api/me/workspace", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gridFilters: next }),
+      });
+      if (!res.ok) {
+        toast.error("Could not save filter selections.");
+      }
+    } catch {
+      toast.error("Could not save filter selections.");
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (pendingFiltersRef.current !== null) {
+        void flush();
+      }
+    };
+  }, [flush]);
+
+  const onFiltersChange = useCallback(
+    (next: GridFiltersJson) => {
+      setFilters(next);
+      pendingFiltersRef.current = next;
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => void flush(), PERSIST_DEBOUNCE_MS);
+    },
+    [flush],
+  );
+
+  return { filters, onFiltersChange };
+}

--- a/src/lib/workspace/workspace-constants.ts
+++ b/src/lib/workspace/workspace-constants.ts
@@ -53,6 +53,28 @@ export const TRACKER_DEFAULT_HEIGHT = 384;
  */
 export const TRACKER_MERGED_DEFAULT_HEIGHT = 456;
 
+/**
+ * Tracker height for each tile in dashboard grid/list mode ({@link GridWorkspace}
+ * virtualization). Matches canvas {@link TRACKER_DEFAULT_HEIGHT}, plus {@link TrackerGridContent}'s
+ * Compare footer: `gap-4` below the stat grid (16px) + row padding `pt-1` (4px) + button `h-7` (28px).
+ */
+export const TRACKER_GRID_TILE_HEIGHT =
+  TRACKER_DEFAULT_HEIGHT + 16 + 4 + 28;
+
+/**
+ * Grid list renders the full-pixel tracker DOM, then scales for display (≈25% smaller).
+ * Virtual row pitch and breakpoints use display dimensions so the page need not scroll horizontally.
+ */
+export const TRACKER_GRID_VISUAL_SCALE = 0.75;
+
+export const TRACKER_GRID_TILE_DISPLAY_WIDTH_PX = Math.round(
+  TRACKER_WIDTH * TRACKER_GRID_VISUAL_SCALE,
+);
+
+export const TRACKER_GRID_TILE_DISPLAY_HEIGHT_PX = Math.round(
+  TRACKER_GRID_TILE_HEIGHT * TRACKER_GRID_VISUAL_SCALE,
+);
+
 /** Largest tracker shell height (used for arrange grid vertical pitch). */
 export const TRACKER_MAX_SHELL_HEIGHT_PX = Math.max(
   TRACKER_DEFAULT_HEIGHT,

--- a/src/lib/workspace/workspace-constants.ts
+++ b/src/lib/workspace/workspace-constants.ts
@@ -55,11 +55,9 @@ export const TRACKER_MERGED_DEFAULT_HEIGHT = 456;
 
 /**
  * Tracker height for each tile in dashboard grid/list mode ({@link GridWorkspace}
- * virtualization). Matches canvas {@link TRACKER_DEFAULT_HEIGHT}, plus {@link TrackerGridContent}'s
- * Compare footer: `gap-4` below the stat grid (16px) + row padding `pt-1` (4px) + button `h-7` (28px).
+ * virtualization). Matches canvas {@link TRACKER_DEFAULT_HEIGHT}; Compare lives in the header.
  */
-export const TRACKER_GRID_TILE_HEIGHT =
-  TRACKER_DEFAULT_HEIGHT + 16 + 4 + 28;
+export const TRACKER_GRID_TILE_HEIGHT = TRACKER_DEFAULT_HEIGHT;
 
 /**
  * Grid list renders the full-pixel tracker DOM, then scales for display (≈25% smaller).

--- a/supabase/migrations/0014_grid_filters.sql
+++ b/supabase/migrations/0014_grid_filters.sql
@@ -1,0 +1,5 @@
+-- Per-user persisted filter selections for the dashboard Tracker grid.
+
+alter table public.users
+  add column if not exists grid_filters jsonb not null
+  default '{"version":1,"class":0,"setHashes":[],"archetypeHashes":[],"tuningHashes":[],"tertiaryStats":[],"search":""}'::jsonb;


### PR DESCRIPTION
## Summary
- Swap the dashboard from the pannable canvas to a filtered **tracker grid**, with tabs to toggle an **armor inventory table** beside the grid experience.
- **Persist filter state** (`users.grid_filters`, migration + `PATCH /api/me/workspace`) with one shared hook so grid and inventory table respect the same class, set/archetype/tuning, search, and (table-only) tertiary selections.
- Add **tracker compare** (`CompareDialog` + `MergedCompareGrid`), header **Compare** on grid tiles with tuning glyphs in the modal, virtualization for the tracker grid, and supporting grid lookup/payload tooling.

## Test plan
- [ ] Dashboard loads signed-in; manifests/inventory prerequisites unchanged.
- [ ] **Tabs:** Grid ↔ table; switching modes keeps filters consistent (debounced saves land after edits).
- [ ] **Filters:** Armor sets archetypes tunings tertiary (table)/search behave; tertiary does not appear as a filter dimension on the **tracker grid** and does not prune grid tiles from saved tertiary selections.
- [ ] **Compare:** Pick two trackers when grid has trackers; anchors show tuning icons; merged grid renders.
- [ ] Inventory table lists rows with visible row dividers; filter bar behaves in table header.
- [ ] `npm run build` passes (no new regressions locally).

Made with [Cursor](https://cursor.com)