### PR TITLE
UI: header redesign and dashboard polish

### DIFF
--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -149,12 +149,12 @@ export default async function DebugPage({ searchParams }: DebugPageProps) {
     : [];
 
   return (
-    <>
+    <div className="flex h-full min-h-0 flex-col">
       <AppHeader
         displayName={headerDisplayName}
         profilePictureUrl={profilePictureUrl}
       />
-      <main className="mx-auto w-full max-w-5xl flex-1 px-4 pb-8 pt-[92px] sm:px-6">
+      <main className="mx-auto w-full max-w-5xl flex-1 overflow-auto px-4 pb-8 pt-6 sm:px-6">
         <h1 className="text-2xl font-semibold tracking-tight">Debug</h1>
 
         <h2 className="mt-6 text-lg font-semibold">Manifest table counts</h2>
@@ -257,7 +257,7 @@ export default async function DebugPage({ searchParams }: DebugPageProps) {
           </>
         ) : null}
       </main>
-    </>
+    </div>
   );
 }
 

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -31,11 +31,11 @@ export function AppHeader({
   leadingAccessory,
 }: AppHeaderProps) {
   return (
-    <header className="pointer-events-none fixed left-0 right-0 top-0 z-40 flex flex-col gap-3 px-3 pt-3 sm:flex-row sm:items-start sm:justify-between sm:gap-3 sm:px-4 sm:pt-4">
-      <div className="pointer-events-none flex min-w-0 flex-wrap items-center gap-2 sm:gap-3">
+    <header className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-border bg-background px-4 py-3 sm:h-14 sm:flex-nowrap sm:px-6 sm:py-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-3">
         <Link
           href="/dashboard"
-          className="pointer-events-auto flex h-9 items-center gap-2 rounded-none border border-border bg-card px-2.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex h-9 items-center gap-2 text-left transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {/* eslint-disable-next-line @next/next/no-img-element -- static brand asset */}
           <img
@@ -51,18 +51,16 @@ export function AppHeader({
           </span>
         </Link>
         {leadingAccessory ? (
-          <div className="pointer-events-auto flex shrink-0 items-center">
-            {leadingAccessory}
-          </div>
+          <div className="flex shrink-0 items-center">{leadingAccessory}</div>
         ) : null}
       </div>
 
-      <div className="pointer-events-auto flex flex-wrap items-center gap-2.5 sm:gap-3">
+      <div className="flex flex-wrap items-center gap-2.5 sm:gap-3">
         <FeedbackHeaderDialog />
         <RefreshButton variant="header-large" />
         <SyncManifestButton variant="header-large" />
 
-        <div className="flex min-w-0 max-w-[min(100vw-10rem,20rem)] items-center gap-2 rounded-none border border-border bg-card px-2 py-1 sm:max-w-none sm:gap-2.5 sm:px-2.5">
+        <div className="flex min-w-0 max-w-[min(100vw-10rem,20rem)] items-center gap-2 sm:max-w-none sm:gap-2.5">
           <BungieProfileAvatar
             displayName={displayName}
             profilePictureUrl={profilePictureUrl}

--- a/src/components/bungie-profile-avatar.tsx
+++ b/src/components/bungie-profile-avatar.tsx
@@ -36,7 +36,7 @@ export function BungieProfileAvatar({
       <span
         aria-hidden
         className={cn(
-          "flex shrink-0 items-center justify-center rounded-full bg-accent font-semibold text-foreground",
+          "flex shrink-0 items-center justify-center rounded-full font-semibold text-muted-foreground",
           s.box,
         )}
       >

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -123,7 +123,7 @@ export function InventoryTableView({
   return (
     <div className={`flex min-h-0 flex-1 flex-col ${className}`}>
       {hasTopMessage ? (
-        <div className="shrink-0 pt-[76px]">
+        <div className="shrink-0">
           {banners ? (
             <div className="space-y-2 border-b border-border bg-background px-4 py-3 sm:px-6">
               {banners}
@@ -140,7 +140,7 @@ export function InventoryTableView({
       ) : null}
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-[4.75rem] sm:px-6">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-4 sm:px-6">
           {!hasInventory ? (
             <p className="text-sm text-muted-foreground">
               No armor inventory loaded yet. Use Refresh in the header after

--- a/src/components/views/armor-set-combobox.tsx
+++ b/src/components/views/armor-set-combobox.tsx
@@ -13,6 +13,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  checkboxBoxClassName,
+  checkboxIconClassName,
+} from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import type { TrackerOptionItem } from "@/lib/views/tracker-option";
 
@@ -107,6 +111,25 @@ function PinnedSectionDivider() {
       aria-hidden
       className="mx-2 mb-1 mt-1 border-t border-border"
     />
+  );
+}
+
+/** Matches {@link DropdownMenuCheckboxItem} indicator styling in filter menus. */
+function ListboxCheckboxIndicator({ checked }: { checked: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        checkboxBoxClassName,
+        "pointer-events-none absolute left-2 top-1/2 -translate-y-1/2",
+        checked &&
+          "border-primary bg-primary text-primary-foreground",
+      )}
+    >
+      {checked ? (
+        <Check weight="bold" className={checkboxIconClassName} />
+      ) : null}
+    </span>
   );
 }
 
@@ -676,12 +699,7 @@ export function ArmorSetMultiSelectPanel({
                   onMouseEnter={() => setHighlightIndex(idx)}
                   onClick={() => toggle(String(opt.hash))}
                 >
-                  <span
-                    aria-hidden
-                    className="pointer-events-none absolute left-2 top-1/2 flex h-4 w-4 -translate-y-1/2 shrink-0 items-center justify-center border border-current/40"
-                  >
-                    {sel ? <Check weight="bold" className="h-3 w-3" /> : null}
-                  </span>
+                  <ListboxCheckboxIndicator checked={sel} />
                   <span className="truncate">{opt.name}</span>
                   {onTogglePin ? (
                     <PinButton
@@ -713,12 +731,7 @@ export function ArmorSetMultiSelectPanel({
                   onMouseEnter={() => setHighlightIndex(idx)}
                   onClick={() => toggle(String(opt.hash))}
                 >
-                  <span
-                    aria-hidden
-                    className="pointer-events-none absolute left-2 top-1/2 flex h-4 w-4 -translate-y-1/2 shrink-0 items-center justify-center border border-current/40"
-                  >
-                    {sel ? <Check weight="bold" className="h-3 w-3" /> : null}
-                  </span>
+                  <ListboxCheckboxIndicator checked={sel} />
                   <span className="truncate">{opt.name}</span>
                   {onTogglePin ? (
                     <PinButton

--- a/src/components/workspace/canvas-workspace.tsx
+++ b/src/components/workspace/canvas-workspace.tsx
@@ -1222,7 +1222,7 @@ export function CanvasWorkspace({
   return (
     <div className={`flex min-h-0 flex-1 flex-col ${className}`}>
       {hasTopMessage ? (
-        <div className="shrink-0 pt-[76px]">
+        <div className="shrink-0">
           {banners ? (
             <div className="space-y-2 border-b border-border bg-background px-4 py-3 sm:px-6">
               {banners}

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -37,14 +37,12 @@ import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
 const ROW_GAP_PX = 16;
 /** Virtual row height for scaled tiles + vertical gap. */
 const ROW_PITCH_PX = TRACKER_GRID_TILE_DISPLAY_HEIGHT_PX + ROW_GAP_PX;
-const GRID_MAX_COLUMNS = 3;
-
 function trackerGridColumnCountForWidth(scrollerClientWidth: number): number {
   const tile = TRACKER_GRID_TILE_DISPLAY_WIDTH_PX;
   const raw = Math.floor(
     (scrollerClientWidth + ROW_GAP_PX) / (tile + ROW_GAP_PX),
   );
-  return Math.min(GRID_MAX_COLUMNS, Math.max(1, raw));
+  return Math.max(1, raw);
 }
 
 interface GridWorkspaceProps {
@@ -160,7 +158,7 @@ export function GridWorkspace({
   ]);
 
   const scrollerRef = useRef<HTMLDivElement | null>(null);
-  const [columnCount, setColumnCount] = useState(GRID_MAX_COLUMNS);
+  const [columnCount, setColumnCount] = useState(1);
 
   useLayoutEffect(() => {
     const el = scrollerRef.current;
@@ -202,7 +200,7 @@ export function GridWorkspace({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {hasTopMessage ? (
-        <div className="shrink-0 pt-[76px]">
+        <div className="shrink-0">
           {banners ? (
             <div className="space-y-2 border-b border-border bg-background px-4 py-3 sm:px-6">
               {banners}
@@ -219,7 +217,7 @@ export function GridWorkspace({
       ) : null}
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-[4.75rem] sm:px-6">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4 pb-4 pt-4 sm:px-6">
           <div className="shrink-0 rounded-none border border-border bg-table-header px-3">
             <TrackerFilterBar
               selectors={selectors}


### PR DESCRIPTION
## Summary
- Replace the fixed floating header with an in-flow top bar separated from content by a bottom border; flatten the brand link and profile cluster (no card chrome)
- Remove header clearance padding hacks from grid/table workspace and debug page
- Allow the tracker grid to use more columns on wide screens (drops the 3-column cap)
- Align armor set filter menu checkboxes with `DropdownMenuCheckboxItem` styling

## Test plan
- [ ] Open `/dashboard` — header is a full-width bar with divider; content starts below without overlap
- [ ] Verify brand + profile have no border/fill; Tracker/Table tabs unchanged
- [ ] Grid view on a wide monitor shows 4+ tracker columns when space allows
- [ ] Armor sets filter checkboxes match archetype/tuning filters (green fill when checked)
- [ ] Table view and `/debug` layout look correct


Made with [Cursor](https://cursor.com)