### PR TITLE
Compare dialog UX and primary green alignment

### DIFF
--- a/src/components/ui/badge.stories.tsx
+++ b/src/components/ui/badge.stories.tsx
@@ -40,7 +40,7 @@ export const TrackerPill: Story = {
   render: () => (
     <Badge
       variant="outline"
-      className="border-[#00FF85] bg-[#00FF85]/14 px-3 py-1.5 text-sm font-medium text-foreground shadow-none"
+      className="border-primary bg-primary/14 px-3 py-1.5 text-sm font-medium text-foreground shadow-none"
     >
       Iron Will Suit
     </Badge>

--- a/src/components/views/tuning-header-glyph.tsx
+++ b/src/components/views/tuning-header-glyph.tsx
@@ -10,7 +10,7 @@ import {
 
 /** Same border, fill, type scale as set/archetype badges on the tracker header. */
 const tuningBadgeClass =
-  "inline-flex shrink-0 cursor-default items-center gap-2 rounded-none border border-[#00FF85] bg-[#00FF85]/14 px-3 py-1.5 text-sm font-medium leading-snug text-foreground shadow-none";
+  "inline-flex shrink-0 cursor-default items-center gap-2 rounded-none border border-primary bg-primary/14 px-3 py-1.5 text-sm font-medium leading-snug text-foreground shadow-none";
 
 interface TuningHeaderGlyphProps {
   tuningName: string;

--- a/src/components/workspace/compare-dialog.tsx
+++ b/src/components/workspace/compare-dialog.tsx
@@ -15,10 +15,24 @@ import { TrackerIdentBadges } from "@/components/workspace/tracker-ident-badges"
 import { TuningHeaderGlyph } from "@/components/views/tuning-header-glyph";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
+import { tuningPositiveArmorStat } from "@/lib/views/tuning-positive-stat";
 import {
   buildEphemeralTrackerPayload,
   ephemeralTrackerId,
 } from "@/lib/workspace/build-tracker-payload-core";
+
+function tuningStatIconPathFromLookup(
+  tuningName: string,
+  lookup: GridLookupPayload,
+): string | null {
+  const positive = tuningPositiveArmorStat(tuningName);
+  return positive !== null
+    ? (lookup.statIconByName[positive] ?? null)
+    : null;
+}
+
+const compareTrackerRowShellClass =
+  "flex items-center gap-3 border border-border bg-card px-3 py-2";
 
 export interface CompareTrackerDescriptor {
   setHash: number;
@@ -101,7 +115,7 @@ export function CompareDialog({
         </DialogHeader>
 
         {anchor ? (
-          <div className="flex shrink-0 items-center gap-3 border border-border bg-card px-3 py-2">
+          <div className={`${compareTrackerRowShellClass} shrink-0`}>
             <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
               A
             </span>
@@ -119,7 +133,9 @@ export function CompareDialog({
         ) : null}
 
         {partner ? (
-          <div className="flex items-center justify-between gap-3 border border-border bg-card px-3 py-2">
+          <div
+            className={`${compareTrackerRowShellClass} justify-between`}
+          >
             <div className="flex items-center gap-3">
               <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                 B
@@ -161,13 +177,19 @@ export function CompareDialog({
                 className="h-9 w-full min-w-0 rounded-none border border-border bg-card py-0 ps-9 pe-3 text-sm text-foreground outline-none placeholder:text-muted-foreground/80 focus-visible:border-foreground focus-visible:ring-0"
               />
             </div>
-            <div className="max-h-72 min-h-0 overflow-y-auto border border-border bg-card">
+            <div className="max-h-72 min-h-0 overflow-y-auto">
               {filteredCandidates.length === 0 ? (
-                <p className="px-3 py-4 text-sm text-muted-foreground">
+                <p
+                  className={`${compareTrackerRowShellClass} text-sm text-muted-foreground`}
+                >
                   No other trackers in view match.
                 </p>
               ) : (
-                <ul role="listbox" aria-label="Compare candidates">
+                <ul
+                  role="listbox"
+                  aria-label="Compare candidates"
+                  className="flex flex-col gap-2"
+                >
                   {filteredCandidates.map((c) => {
                     const id = ephemeralTrackerId(c);
                     return (
@@ -177,14 +199,21 @@ export function CompareDialog({
                           role="option"
                           aria-selected={false}
                           onClick={() => setPartnerId(id)}
-                          className="flex w-full items-center justify-between gap-3 border-b border-border px-3 py-2 text-left text-sm text-foreground/90 transition-colors last:border-b-0 hover:bg-accent focus-visible:outline-none focus-visible:bg-accent"
+                          className={`${compareTrackerRowShellClass} w-full text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:bg-accent`}
                         >
-                          <span className="truncate">
-                            {c.setName} · {c.archetypeName}
-                          </span>
-                          <span className="shrink-0 text-xs text-muted-foreground">
-                            {c.tuningName}
-                          </span>
+                          <TrackerIdentBadges
+                            setName={c.setName}
+                            archetypeName={c.archetypeName}
+                            tuning={
+                              <TuningHeaderGlyph
+                                tuningName={c.tuningName}
+                                iconPath={tuningStatIconPathFromLookup(
+                                  c.tuningName,
+                                  lookupPayload,
+                                )}
+                              />
+                            }
+                          />
                         </button>
                       </li>
                     );

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -41,8 +41,8 @@ import {
 const FILTER_MENU_CONTENT_CLASS =
   "max-h-[min(60vh,20rem)] min-w-56 overflow-y-auto rounded-none py-2 shadow-xl";
 
-const INLINE_TRIGGER_CLASS =
-  "group/inline-trigger h-9 shrink-0 gap-1.5 rounded-none px-3 text-xs data-[state=open]:bg-accent data-[state=open]:text-accent-foreground";
+const INLINE_TRIGGER_BASE_CLASS =
+  "group/inline-trigger h-9 shrink-0 gap-1.5 rounded-none px-3 text-xs";
 
 /** Wraps Trigger + sibling clear `<button>`; `focus-within` ring avoids nested focus chrome. */
 const INLINE_TRIGGER_FRAME_CLASS =
@@ -95,10 +95,11 @@ const InlineFilterTrigger = forwardRef<
       variant="outline"
       aria-label={`${label} filter`}
       className={cn(
-        INLINE_TRIGGER_CLASS,
+        INLINE_TRIGGER_BASE_CLASS,
         "focus-visible:ring-0 focus-visible:ring-offset-0",
-        active &&
-          "border-primary/60 bg-primary/10 font-medium text-foreground hover:border-primary/70 hover:bg-primary/20 hover:text-foreground",
+        active
+          ? "border-primary/60 bg-primary/10 font-medium text-foreground hover:border-primary/70 hover:bg-primary/20 hover:text-foreground data-[state=open]:border-primary/60 data-[state=open]:bg-primary/10 data-[state=open]:text-foreground"
+          : "data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
         className,
       )}
       {...props}

--- a/src/components/workspace/tracker-ident-badges.tsx
+++ b/src/components/workspace/tracker-ident-badges.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 
 const trackerBadgeClass =
-  "min-w-0 max-w-[min(100%,14rem)] shrink truncate rounded-none border border-[#00FF85] bg-[#00FF85]/14 px-3 py-1.5 text-sm font-medium leading-snug text-foreground shadow-none";
+  "min-w-0 max-w-[min(100%,14rem)] shrink truncate rounded-none border border-primary bg-primary/14 px-3 py-1.5 text-sm font-medium leading-snug text-foreground shadow-none";
 
 interface TrackerIdentBadgesProps {
   setName: string;


### PR DESCRIPTION
## Summary
- Restyle compare dialog partner picker: each candidate uses the same bordered row shell and set/archetype/tuning badge pills as the anchor tracker.
- Switch tracker identity badges (and tuning pill) from hardcoded `#00FF85` to the `primary` design token so they match active filter styling.
- Keep the low-opacity green fill on filter triggers when they have selections and the dropdown is open.

## Test plan
- [ ] Open compare from a tracker; confirm anchor **A** row and each picker option show bordered rows with green badge pills.
- [ ] Select a partner and verify **B** row + merged compare grid still render correctly.
- [ ] On dashboard grid/table, apply archetype/tuning filters; confirm green fill stays when the menu is open.
- [ ] Confirm tracker panel header badges use brand green (`#07ad6b`), not neon `#00FF85`.
- [ ] Storybook: `Workspace/CompareDialog` → `PartnerNotYetPicked`, `Workspace/TrackerFilterBar` → `PopulatedFilters`.


Made with [Cursor](https://cursor.com)