### PR TITLE
Add shareable dashboard filter links via URL encoding.

### DIFF
--- a/src/app/api/auth/bungie/callback/route.ts
+++ b/src/app/api/auth/bungie/callback/route.ts
@@ -11,6 +11,11 @@ import { bungieOAuthRedirectUri } from "@/lib/auth/bungie-redirect-uri";
 import { requestCookieValue } from "@/lib/auth/request-cookie";
 import { persistTokens } from "@/lib/auth/tokens";
 import { profilePictureRelPathFromMembership } from "@/lib/bungie/profile-picture";
+import {
+  clearPostAuthReturnCookie,
+  defaultPostAuthReturnPath,
+  readPostAuthReturnCookie,
+} from "@/lib/auth/post-auth-return";
 
 function clearOauthStateCookie(res: NextResponse) {
   res.cookies.set(
@@ -159,6 +164,8 @@ export async function GET(req: NextRequest) {
   // without any cross-site/redirect heuristic interference. The page then
   // navigates to /dashboard.
   const jwt = await signSessionJwt(user);
+  const returnPath =
+    readPostAuthReturnCookie(req) ?? defaultPostAuthReturnPath();
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -174,7 +181,7 @@ export async function GET(req: NextRequest) {
   var t=${JSON.stringify(jwt)};
   fetch("/api/auth/install",{method:"POST",credentials:"include",headers:{"Content-Type":"application/json"},body:JSON.stringify({t:t})})
     .then(function(r){
-      if(r.ok){location.replace("/dashboard");return;}
+      if(r.ok){location.replace(${JSON.stringify(returnPath)});return;}
       r.text().then(function(b){location.replace("/?auth_error="+encodeURIComponent("Install failed: "+r.status+" "+b));});
     })
     .catch(function(e){location.replace("/?auth_error="+encodeURIComponent(String(e&&e.message||e)));});
@@ -183,11 +190,13 @@ export async function GET(req: NextRequest) {
 <noscript><p>JavaScript is required to complete sign-in. <a style="color:#9bf" href="/api/auth/bungie/login">Try again</a>.</p></noscript>
 </body>
 </html>`;
-  return new NextResponse(html, {
+  const res = new NextResponse(html, {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
       "Cache-Control": "no-store",
     },
   });
+  clearPostAuthReturnCookie(res);
+  return res;
 }

--- a/src/app/api/auth/bungie/login/route.ts
+++ b/src/app/api/auth/bungie/login/route.ts
@@ -10,6 +10,10 @@ import {
   bungieOAuthRedirectUri,
   canonicalBungieLoginIfNeeded,
 } from "@/lib/auth/bungie-redirect-uri";
+import {
+  sanitizePostAuthReturnPath,
+  setPostAuthReturnCookie,
+} from "@/lib/auth/post-auth-return";
 
 export async function GET(req: NextRequest) {
   const canonical = canonicalBungieLoginIfNeeded(req);
@@ -26,5 +30,11 @@ export async function GET(req: NextRequest) {
     state,
     bungieOAuthStateCookieOptions(BUNGIE_OAUTH_STATE_TTL_SECONDS),
   );
+  const returnTo = sanitizePostAuthReturnPath(
+    new URL(req.url).searchParams.get("returnTo"),
+  );
+  if (returnTo) {
+    setPostAuthReturnCookie(res, returnTo);
+  }
   return res;
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,13 +14,31 @@ import { DashboardWorkspace } from "@/components/dashboard/dashboard-workspace";
 import { manifestSelectorsFromLookups } from "@/lib/views/manifest-selectors-from-lookup";
 import { buildGridLookupPayload } from "@/lib/views/grid-lookup-payload.server";
 import { parseGridFilters } from "@/lib/workspace/grid-filters-schema";
+import {
+  decodeGridFiltersFromShare,
+  GRID_FILTERS_SHARE_PARAM,
+} from "@/lib/workspace/grid-filters-share";
 import { bungieIconUrl } from "@/lib/bungie/constants";
 
 export const dynamic = "force-dynamic";
 
-export default async function DashboardPage() {
+interface DashboardPageProps {
+  searchParams: Promise<{ f?: string }>;
+}
+
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const { f } = await searchParams;
+  const dashboardPath = f
+    ? `/dashboard?${GRID_FILTERS_SHARE_PARAM}=${encodeURIComponent(f)}`
+    : "/dashboard";
+
   const session = await getSession();
-  if (!session) redirect("/");
+  if (!session) {
+    redirect(`/?returnTo=${encodeURIComponent(dashboardPath)}`);
+  }
+
+  const sharedFilters = f ? decodeGridFiltersFromShare(f) : null;
+  const invalidShareLink = Boolean(f) && sharedFilters === null;
 
   const sb = getServiceRoleClient();
   const { data: userRow } = await sb
@@ -34,7 +52,9 @@ export default async function DashboardPage() {
     userRow.profile_picture_path.trim().length > 0
       ? bungieIconUrl(userRow.profile_picture_path.trim())
       : null;
-  const initialGridFilters = parseGridFilters(userRow?.grid_filters ?? null);
+  const initialGridFilters =
+    sharedFilters ?? parseGridFilters(userRow?.grid_filters ?? null);
+  const appliedFromShare = sharedFilters !== null;
 
   let syncWarning: string | null = null;
   try {
@@ -138,6 +158,8 @@ export default async function DashboardPage() {
       inventory={inventory}
       lookupPayload={lookupPayload}
       initialGridFilters={initialGridFilters}
+      appliedFromShare={appliedFromShare}
+      invalidShareLink={invalidShareLink}
     />
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,18 +8,27 @@ import {
   NEW_TRACKER_FAB_SHADOW,
 } from "@/components/workspace/new-tracker-fab-styles";
 import { getSession } from "@/lib/auth/session";
+import {
+  defaultPostAuthReturnPath,
+  sanitizePostAuthReturnPath,
+} from "@/lib/auth/post-auth-return";
 
 interface HomePageProps {
-  searchParams: Promise<{ auth_error?: string }>;
+  searchParams: Promise<{ auth_error?: string; returnTo?: string }>;
 }
 
 export default async function HomePage({ searchParams }: HomePageProps) {
+  const { auth_error, returnTo: returnToRaw } = await searchParams;
+  const safeReturnTo = sanitizePostAuthReturnPath(returnToRaw ?? null);
+
   const session = await getSession();
   if (session) {
-    redirect("/dashboard");
+    redirect(safeReturnTo ?? defaultPostAuthReturnPath());
   }
 
-  const { auth_error } = await searchParams;
+  const loginHref = safeReturnTo
+    ? `/api/auth/bungie/login?returnTo=${encodeURIComponent(safeReturnTo)}`
+    : "/api/auth/bungie/login";
 
   return (
     <main className="flex min-h-[100dvh] flex-1 flex-col items-center justify-center overflow-auto bg-background px-6 py-16 text-foreground">
@@ -57,7 +66,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
           ) : null}
 
           <Button asChild className={NEW_TRACKER_FAB_CLASSES} style={NEW_TRACKER_FAB_SHADOW}>
-            <Link href="/api/auth/bungie/login">
+            <Link href={loginHref}>
               Sign in with Bungie
               <SignIn weight="duotone" className="h-5 w-5" aria-hidden />
             </Link>

--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
+import { toast } from "sonner";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
 import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
@@ -25,6 +26,8 @@ export interface DashboardWorkspaceProps {
   inventory: DerivedArmorPieceJson[];
   lookupPayload: GridLookupPayload;
   initialGridFilters: GridFiltersJson;
+  appliedFromShare?: boolean;
+  invalidShareLink?: boolean;
 }
 
 export function DashboardWorkspace({
@@ -37,11 +40,32 @@ export function DashboardWorkspace({
   inventory,
   lookupPayload,
   initialGridFilters,
+  appliedFromShare = false,
+  invalidShareLink = false,
 }: DashboardWorkspaceProps) {
   const [mode, setMode] = useState<WorkspaceViewMode>("grid");
   const tabs = <WorkspaceViewModeTabs mode={mode} onModeChange={setMode} />;
   const { filters, onFiltersChange } =
     useGridFiltersPersistence(initialGridFilters);
+  const shareHandledRef = useRef(false);
+
+  useEffect(() => {
+    if (shareHandledRef.current) return;
+    if (invalidShareLink) {
+      shareHandledRef.current = true;
+      toast.warning("This share link is invalid or out of date.");
+      return;
+    }
+    if (!appliedFromShare) return;
+    shareHandledRef.current = true;
+    onFiltersChange(initialGridFilters);
+    toast.success("Shared filters applied to your inventory.");
+  }, [
+    appliedFromShare,
+    invalidShareLink,
+    initialGridFilters,
+    onFiltersChange,
+  ]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/src/components/workspace/share-filter-link-button.stories.tsx
+++ b/src/components/workspace/share-filter-link-button.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { ShareFilterLinkButton } from "./share-filter-link-button";
+import {
+  MOCK_GRID_FILTERS_EMPTY,
+  MOCK_GRID_FILTERS_POPULATED,
+} from "../../../.storybook/mocks/grid-filters";
+
+const meta: Meta<typeof ShareFilterLinkButton> = {
+  title: "Workspace/ShareFilterLinkButton",
+  component: ShareFilterLinkButton,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ShareFilterLinkButton>;
+
+export const Enabled: Story = {
+  args: {
+    filters: MOCK_GRID_FILTERS_POPULATED,
+  },
+  beforeEach() {
+    Object.assign(navigator, {
+      clipboard: { writeText: fn().mockResolvedValue(undefined) },
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: /copy link to filters/i }),
+    );
+    await expect(navigator.clipboard.writeText).toHaveBeenCalled();
+  },
+};
+
+export const DisabledNoSelection: Story = {
+  args: {
+    filters: MOCK_GRID_FILTERS_EMPTY,
+    disabled: true,
+  },
+};

--- a/src/components/workspace/share-filter-link-button.tsx
+++ b/src/components/workspace/share-filter-link-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { LinkSimple } from "@phosphor-icons/react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
+import { buildDashboardShareUrl } from "@/lib/workspace/grid-filters-share";
+
+interface ShareFilterLinkButtonProps {
+  filters: GridFiltersJson;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function ShareFilterLinkButton({
+  filters,
+  disabled = false,
+  className,
+}: ShareFilterLinkButtonProps) {
+  const [copying, setCopying] = useState(false);
+
+  const copyLink = useCallback(async () => {
+    if (disabled || copying) return;
+    setCopying(true);
+    try {
+      const url = buildDashboardShareUrl(window.location.origin, filters);
+      await navigator.clipboard.writeText(url);
+      toast.success("Link copied — share it to apply these filters.");
+    } catch {
+      toast.error("Could not copy link.");
+    } finally {
+      setCopying(false);
+    }
+  }, [copying, disabled, filters]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label="Copy link to filters"
+          disabled={disabled || copying}
+          className={className}
+          onClick={() => void copyLink()}
+        >
+          <LinkSimple weight="duotone" className="size-4" aria-hidden />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {disabled
+          ? "Select a set, archetype, or tuning to share"
+          : "Copy link to these filters"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -34,9 +34,11 @@ import {
 import { ArmorSetMultiSelectPanel } from "@/components/views/armor-set-combobox";
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
 import {
+  gridFiltersHaveUnblockingSelection,
   type GridFilterClass,
   type GridFiltersJson,
 } from "@/lib/workspace/grid-filters-schema";
+import { ShareFilterLinkButton } from "@/components/workspace/share-filter-link-button";
 
 const FILTER_MENU_CONTENT_CLASS =
   "max-h-[min(60vh,20rem)] min-w-56 overflow-y-auto rounded-none py-2 shadow-xl";
@@ -686,6 +688,12 @@ export function TrackerFilterBar({
         {resultCount === 1 ? resultNoun.singular : resultNoun.plural} for{" "}
         {CLASS_NAMES[value.class] ?? "class"}.
       </p>
+
+      <ShareFilterLinkButton
+        filters={value}
+        disabled={!gridFiltersHaveUnblockingSelection(value)}
+        className="size-9 shrink-0 rounded-none"
+      />
 
       <div className="ml-auto min-w-0">
         {searchExpanded ? (

--- a/src/lib/auth/post-auth-return.ts
+++ b/src/lib/auth/post-auth-return.ts
@@ -1,0 +1,76 @@
+import type { NextRequest, NextResponse } from "next/server";
+import { requestCookieValue } from "@/lib/auth/request-cookie";
+
+/** HttpOnly cookie holding a post-OAuth redirect path (dashboard + optional query). */
+export const POST_AUTH_RETURN_COOKIE = "armor_checklist_return";
+
+export const POST_AUTH_RETURN_TTL_SECONDS = 10 * 60;
+
+const MAX_RETURN_PATH_LENGTH = 2048;
+
+const DASHBOARD_RETURN_RE = /^\/dashboard(\?[^#]*)?$/;
+
+/**
+ * Allow only relative `/dashboard` paths (optionally with query) to block open redirects.
+ */
+export function sanitizePostAuthReturnPath(
+  input: string | null | undefined,
+): string | null {
+  if (input == null) return null;
+  const trimmed = input.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_RETURN_PATH_LENGTH) {
+    return null;
+  }
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return null;
+  if (trimmed.includes("\\")) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(trimmed);
+  } catch {
+    return null;
+  }
+  if (decoded.includes("\\") || decoded.startsWith("//")) return null;
+  if (!DASHBOARD_RETURN_RE.test(decoded)) return null;
+  return decoded;
+}
+
+export function postAuthReturnCookieOptions(maxAge: number) {
+  const prod = process.env.NODE_ENV === "production";
+  return {
+    httpOnly: true,
+    path: "/",
+    maxAge,
+    secure: prod,
+    sameSite: "lax" as const,
+  };
+}
+
+export function defaultPostAuthReturnPath(): string {
+  return "/dashboard";
+}
+
+export function readPostAuthReturnCookie(req: NextRequest): string | null {
+  const raw = requestCookieValue(req, POST_AUTH_RETURN_COOKIE);
+  return sanitizePostAuthReturnPath(raw ?? null);
+}
+
+export function setPostAuthReturnCookie(
+  res: NextResponse,
+  path: string,
+): void {
+  const safe = sanitizePostAuthReturnPath(path);
+  if (!safe) return;
+  res.cookies.set(
+    POST_AUTH_RETURN_COOKIE,
+    safe,
+    postAuthReturnCookieOptions(POST_AUTH_RETURN_TTL_SECONDS),
+  );
+}
+
+export function clearPostAuthReturnCookie(res: NextResponse): void {
+  res.cookies.set(
+    POST_AUTH_RETURN_COOKIE,
+    "",
+    postAuthReturnCookieOptions(0),
+  );
+}

--- a/src/lib/workspace/grid-filters-share.ts
+++ b/src/lib/workspace/grid-filters-share.ts
@@ -1,0 +1,68 @@
+import {
+  gridFiltersSchema,
+  type GridFiltersJson,
+} from "@/lib/workspace/grid-filters-schema";
+
+/** Query param on `/dashboard` carrying a shared filter payload. */
+export const GRID_FILTERS_SHARE_PARAM = "f";
+
+function toBase64Url(bytes: Uint8Array): string {
+  const b64 =
+    typeof Buffer !== "undefined"
+      ? Buffer.from(bytes).toString("base64")
+      : btoa(String.fromCharCode(...bytes));
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function fromBase64Url(encoded: string): Uint8Array | null {
+  const padded = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  const padLen = (4 - (padded.length % 4)) % 4;
+  const b64 = padded + "=".repeat(padLen);
+  try {
+    if (typeof Buffer !== "undefined") {
+      return new Uint8Array(Buffer.from(b64, "base64"));
+    }
+    const binary = atob(b64);
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      out[i] = binary.charCodeAt(i);
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/** Encode filters for the `f` query param (base64url JSON). */
+export function encodeGridFiltersForShare(filters: GridFiltersJson): string {
+  const json = JSON.stringify(filters);
+  const bytes = new TextEncoder().encode(json);
+  return toBase64Url(bytes);
+}
+
+/** Decode `f` param; returns null when missing, corrupt, or invalid schema. */
+export function decodeGridFiltersFromShare(
+  param: string | null | undefined,
+): GridFiltersJson | null {
+  if (param == null || param.trim() === "") return null;
+  const bytes = fromBase64Url(param.trim());
+  if (bytes === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return null;
+  }
+  const result = gridFiltersSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+/** Full dashboard URL with encoded filters. */
+export function buildDashboardShareUrl(
+  origin: string,
+  filters: GridFiltersJson,
+): string {
+  const base = origin.replace(/\/$/, "");
+  const encoded = encodeURIComponent(encodeGridFiltersForShare(filters));
+  return `${base}/dashboard?${GRID_FILTERS_SHARE_PARAM}=${encoded}`;
+}


### PR DESCRIPTION
Recipients can open a copied /dashboard?f=… link, sign in through Bungie OAuth with the return path preserved, and see the shared filters applied against their own inventory.