### PR TITLE
Add saved filter views with shareable snapshots

### DIFF
--- a/.storybook/mocks/saved-filter-views.ts
+++ b/.storybook/mocks/saved-filter-views.ts
@@ -1,0 +1,38 @@
+import type { SavedFilterViewRow } from "@/lib/db/types";
+import { MOCK_GRID_FILTERS_POPULATED } from "./grid-filters";
+
+const mockPayload = {
+  version: 1 as const,
+  setHashes: MOCK_GRID_FILTERS_POPULATED.setHashes,
+  archetypeHashes: MOCK_GRID_FILTERS_POPULATED.archetypeHashes,
+  tuningHashes: MOCK_GRID_FILTERS_POPULATED.tuningHashes,
+  tertiaryStats: MOCK_GRID_FILTERS_POPULATED.tertiaryStats,
+};
+
+export const MOCK_SAVED_FILTER_VIEW_OWNED: SavedFilterViewRow = {
+  id: "11111111-1111-4111-8111-111111111111",
+  user_id: "user-1",
+  name: "Arc + Health rolls",
+  filters: mockPayload,
+  view_mode: "grid",
+  share_slug: "abc123shareslug",
+  source_user_id: null,
+  source_display_name: null,
+  source_share_slug: null,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+export const MOCK_SAVED_FILTER_VIEW_SHARED: SavedFilterViewRow = {
+  id: "22222222-2222-4222-8222-222222222222",
+  user_id: "user-1",
+  name: "Friend's PvE focus",
+  filters: mockPayload,
+  view_mode: "table",
+  share_slug: null,
+  source_user_id: "user-2",
+  source_display_name: "FriendGuardian",
+  source_share_slug: "friendslug1234",
+  created_at: "2026-01-02T00:00:00.000Z",
+  updated_at: "2026-01-02T00:00:00.000Z",
+};

--- a/src/app/api/saved-views/[id]/route.ts
+++ b/src/app/api/saved-views/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+import { crossSiteOriginBlockResponse } from "@/lib/auth/api-origin-check";
+import { getSessionFromRequest } from "@/lib/auth/session";
+import {
+  deleteSavedView,
+  renameSavedView,
+} from "@/lib/saved-views/queries";
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(80),
+});
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const blocked = crossSiteOriginBlockResponse(req);
+  if (blocked) return blocked;
+
+  const session = await getSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  const { id } = await params;
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Body must be JSON" }, { status: 400 });
+  }
+
+  const parsed = updateSchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const view = await renameSavedView(session.userId, id, parsed.data.name);
+  if (!view) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ view });
+}
+
+export async function DELETE(req: NextRequest, { params }: Params) {
+  const blocked = crossSiteOriginBlockResponse(req);
+  if (blocked) return blocked;
+
+  const session = await getSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  const { id } = await params;
+
+  const deleted = await deleteSavedView(session.userId, id);
+  if (!deleted) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/saved-views/[id]/share/route.ts
+++ b/src/app/api/saved-views/[id]/share/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { crossSiteOriginBlockResponse } from "@/lib/auth/api-origin-check";
+import { getSessionFromRequest } from "@/lib/auth/session";
+import { clientEnv } from "@/lib/env";
+import {
+  ensureShareSlug,
+  revokeShareSlug,
+} from "@/lib/saved-views/queries";
+import { buildSavedFilterViewShareUrl } from "@/lib/saved-views/schema";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const blocked = crossSiteOriginBlockResponse(req);
+  if (blocked) return blocked;
+
+  const session = await getSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  const { id } = await params;
+
+  const view = await ensureShareSlug(session.userId, id);
+  if (!view?.share_slug) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const origin = clientEnv().NEXT_PUBLIC_APP_URL;
+  const url = buildSavedFilterViewShareUrl(origin, view.share_slug);
+  return NextResponse.json({ slug: view.share_slug, url });
+}
+
+export async function DELETE(req: NextRequest, { params }: Params) {
+  const blocked = crossSiteOriginBlockResponse(req);
+  if (blocked) return blocked;
+
+  const session = await getSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  const { id } = await params;
+
+  const view = await revokeShareSlug(session.userId, id);
+  if (!view) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ view });
+}

--- a/src/app/api/saved-views/route.ts
+++ b/src/app/api/saved-views/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+import { crossSiteOriginBlockResponse } from "@/lib/auth/api-origin-check";
+import { getSessionFromRequest } from "@/lib/auth/session";
+import {
+  createSavedView,
+  listSavedViewsForUser,
+} from "@/lib/saved-views/queries";
+import { savedFilterViewPayloadSchema } from "@/lib/saved-views/schema";
+
+const createSchema = z.object({
+  name: z.string().min(1).max(80),
+  filters: savedFilterViewPayloadSchema,
+});
+
+export async function GET(req: NextRequest) {
+  const session = await getSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  const views = await listSavedViewsForUser(session.userId);
+  return NextResponse.json({ views });
+}
+
+export async function POST(req: NextRequest) {
+  const blocked = crossSiteOriginBlockResponse(req);
+  if (blocked) return blocked;
+
+  const session = await getSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Body must be JSON" }, { status: 400 });
+  }
+
+  const parsed = createSchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const view = await createSavedView(session.userId, {
+    name: parsed.data.name,
+    filters: parsed.data.filters,
+  });
+
+  return NextResponse.json({ view }, { status: 201 });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import { DashboardWorkspace } from "@/components/dashboard/dashboard-workspace";
 import { manifestSelectorsFromLookups } from "@/lib/views/manifest-selectors-from-lookup";
 import { buildGridLookupPayload } from "@/lib/views/grid-lookup-payload.server";
 import { parseGridFilters } from "@/lib/workspace/grid-filters-schema";
+import { listSavedViewsForUser } from "@/lib/saved-views/queries";
 import {
   decodeGridFiltersFromShare,
   GRID_FILTERS_SHARE_PARAM,
@@ -23,11 +24,11 @@ import { bungieIconUrl } from "@/lib/bungie/constants";
 export const dynamic = "force-dynamic";
 
 interface DashboardPageProps {
-  searchParams: Promise<{ f?: string }>;
+  searchParams: Promise<{ f?: string; savedViewImported?: string }>;
 }
 
 export default async function DashboardPage({ searchParams }: DashboardPageProps) {
-  const { f } = await searchParams;
+  const { f, savedViewImported } = await searchParams;
   const dashboardPath = f
     ? `/dashboard?${GRID_FILTERS_SHARE_PARAM}=${encodeURIComponent(f)}`
     : "/dashboard";
@@ -74,10 +75,11 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
     }
   }
 
-  const [cached, lookups, versionCheck] = await Promise.all([
+  const [cached, lookups, versionCheck, savedViews] = await Promise.all([
     getCachedInventoryWithSyncedAt(session.userId),
     getManifestLookups(),
     checkManifestVersion(),
+    listSavedViewsForUser(session.userId),
   ]);
 
   const inventory = cached?.items ?? [];
@@ -158,8 +160,10 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       inventory={inventory}
       lookupPayload={lookupPayload}
       initialGridFilters={initialGridFilters}
+      initialSavedViews={savedViews}
       appliedFromShare={appliedFromShare}
       invalidShareLink={invalidShareLink}
+      savedViewImportedId={savedViewImported ?? null}
     />
   );
 }

--- a/src/app/saved-views/[slug]/page.tsx
+++ b/src/app/saved-views/[slug]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound, redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { importSharedView } from "@/lib/saved-views/queries";
+
+export const dynamic = "force-dynamic";
+
+interface SavedViewImportPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function SavedViewImportPage({
+  params,
+}: SavedViewImportPageProps) {
+  const { slug } = await params;
+  const returnTo = `/saved-views/${encodeURIComponent(slug)}`;
+
+  const session = await getSession();
+  if (!session) {
+    redirect(`/?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  const imported = await importSharedView(session.userId, slug);
+  if (!imported) {
+    notFound();
+  }
+
+  redirect(
+    `/dashboard?savedViewImported=${encodeURIComponent(imported.id)}`,
+  );
+}

--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { toast } from "sonner";
-import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import type { DerivedArmorPieceJson, SavedFilterViewRow } from "@/lib/db/types";
 import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
 import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
 import { useGridFiltersPersistence } from "@/lib/workspace/use-grid-filters-persistence";
+import {
+  applyPayloadToGridFilters,
+  parseSavedFilterViewPayload,
+  savedViewPayloadMatchesFilters,
+} from "@/lib/saved-views/schema";
 import type { TrackerFormSelectors } from "@/components/workspace/new-tracker-dialog";
 import { AppHeader } from "@/components/app-header";
 import { GridWorkspace } from "@/components/workspace/grid-workspace";
@@ -15,6 +20,7 @@ import {
   WorkspaceViewModeTabs,
   type WorkspaceViewMode,
 } from "@/components/dashboard/workspace-view-mode-tabs";
+import { SavedViewsMenu } from "@/components/workspace/saved-views-menu";
 
 export interface DashboardWorkspaceProps {
   displayName: string;
@@ -26,8 +32,10 @@ export interface DashboardWorkspaceProps {
   inventory: DerivedArmorPieceJson[];
   lookupPayload: GridLookupPayload;
   initialGridFilters: GridFiltersJson;
+  initialSavedViews: SavedFilterViewRow[];
   appliedFromShare?: boolean;
   invalidShareLink?: boolean;
+  savedViewImportedId?: string | null;
 }
 
 export function DashboardWorkspace({
@@ -40,14 +48,52 @@ export function DashboardWorkspace({
   inventory,
   lookupPayload,
   initialGridFilters,
+  initialSavedViews,
   appliedFromShare = false,
   invalidShareLink = false,
+  savedViewImportedId = null,
 }: DashboardWorkspaceProps) {
   const [mode, setMode] = useState<WorkspaceViewMode>("grid");
+  const [savedViews, setSavedViews] =
+    useState<SavedFilterViewRow[]>(initialSavedViews);
   const tabs = <WorkspaceViewModeTabs mode={mode} onModeChange={setMode} />;
   const { filters, onFiltersChange } =
     useGridFiltersPersistence(initialGridFilters);
   const shareHandledRef = useRef(false);
+  const importHandledRef = useRef(false);
+
+  const activeSavedViewId = useMemo(() => {
+    for (const view of savedViews) {
+      const payload = parseSavedFilterViewPayload(view.filters);
+      if (!payload) continue;
+      if (savedViewPayloadMatchesFilters(filters, payload)) {
+        return view.id;
+      }
+    }
+    return null;
+  }, [filters, savedViews]);
+
+  const applySavedView = useCallback(
+    (view: SavedFilterViewRow) => {
+      const payload = parseSavedFilterViewPayload(view.filters);
+      if (!payload) {
+        toast.error("This view has invalid saved data.");
+        return;
+      }
+      onFiltersChange(applyPayloadToGridFilters(filters, payload));
+    },
+    [filters, onFiltersChange],
+  );
+
+  const savedViewsSlot = (
+    <SavedViewsMenu
+      views={savedViews}
+      activeViewId={activeSavedViewId}
+      filters={filters}
+      onViewsChange={setSavedViews}
+      onApply={applySavedView}
+    />
+  );
 
   useEffect(() => {
     if (shareHandledRef.current) return;
@@ -67,6 +113,23 @@ export function DashboardWorkspace({
     onFiltersChange,
   ]);
 
+  useEffect(() => {
+    if (importHandledRef.current || !savedViewImportedId) return;
+    importHandledRef.current = true;
+    const imported = savedViews.find((v) => v.id === savedViewImportedId);
+    if (!imported) {
+      toast.warning("Could not apply the shared view.");
+      return;
+    }
+    applySavedView(imported);
+    const fromName = imported.source_display_name?.trim();
+    toast.success(
+      fromName
+        ? `Shared view applied — from ${fromName}.`
+        : "Shared view applied to your filters.",
+    );
+  }, [applySavedView, savedViewImportedId, savedViews]);
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       <AppHeader
@@ -83,6 +146,7 @@ export function DashboardWorkspace({
           selectors={selectors}
           filters={filters}
           onFiltersChange={onFiltersChange}
+          savedViewsSlot={savedViewsSlot}
         />
       ) : (
         <GridWorkspace
@@ -94,6 +158,7 @@ export function DashboardWorkspace({
           lookupPayload={lookupPayload}
           filters={filters}
           onFiltersChange={onFiltersChange}
+          savedViewsSlot={savedViewsSlot}
         />
       )}
     </div>

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -54,6 +54,7 @@ interface InventoryTableViewProps {
   selectors: TrackerFormSelectors;
   filters: GridFiltersJson;
   onFiltersChange: (next: GridFiltersJson) => void;
+  savedViewsSlot?: ReactNode;
 }
 
 export function InventoryTableView({
@@ -65,6 +66,7 @@ export function InventoryTableView({
   selectors,
   filters,
   onFiltersChange,
+  savedViewsSlot,
 }: InventoryTableViewProps) {
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
 
@@ -172,6 +174,7 @@ export function InventoryTableView({
                               singular: "piece",
                               plural: "pieces",
                             }}
+                            savedViewsSlot={savedViewsSlot}
                           />
                         </TableHead>
                       </TableRow>

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -54,6 +54,7 @@ interface GridWorkspaceProps {
   lookupPayload: GridLookupPayload;
   filters: GridFiltersJson;
   onFiltersChange: (next: GridFiltersJson) => void;
+  savedViewsSlot?: ReactNode;
 }
 
 type TrackerDescriptor = CompareTrackerDescriptor;
@@ -67,6 +68,7 @@ export function GridWorkspace({
   lookupPayload,
   filters,
   onFiltersChange,
+  savedViewsSlot,
 }: GridWorkspaceProps) {
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
 
@@ -228,6 +230,7 @@ export function GridWorkspace({
               resultCount={visibleTrackers.length}
               resultNoun={{ singular: "tracker", plural: "trackers" }}
               showTertiaryStatFilter={false}
+              savedViewsSlot={savedViewsSlot}
             />
           </div>
 

--- a/src/components/workspace/saved-views-menu.stories.tsx
+++ b/src/components/workspace/saved-views-menu.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+import type { SavedFilterViewRow } from "@/lib/db/types";
+import { SavedViewsMenu } from "./saved-views-menu";
+import { defaultGridFilters } from "@/lib/workspace/grid-filters-schema";
+import {
+  MOCK_SAVED_FILTER_VIEW_OWNED,
+  MOCK_SAVED_FILTER_VIEW_SHARED,
+} from "../../../.storybook/mocks/saved-filter-views";
+
+const meta: Meta<typeof SavedViewsMenu> = {
+  title: "Workspace/SavedViewsMenu",
+  component: SavedViewsMenu,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SavedViewsMenu>;
+
+function Render({
+  initialViews,
+  activeViewId = null,
+}: {
+  initialViews: SavedFilterViewRow[];
+  activeViewId?: string | null;
+}) {
+  const [views, setViews] = useState(initialViews);
+  return (
+    <SavedViewsMenu
+      views={views}
+      activeViewId={activeViewId}
+      filters={defaultGridFilters()}
+      onViewsChange={setViews}
+      onApply={() => {}}
+    />
+  );
+}
+
+export const Empty: Story = {
+  render: () => <Render initialViews={[]} />,
+};
+
+export const OwnedAndShared: Story = {
+  render: () => (
+    <Render
+      initialViews={[
+        MOCK_SAVED_FILTER_VIEW_OWNED,
+        MOCK_SAVED_FILTER_VIEW_SHARED,
+      ]}
+      activeViewId={MOCK_SAVED_FILTER_VIEW_OWNED.id}
+    />
+  ),
+};

--- a/src/components/workspace/saved-views-menu.tsx
+++ b/src/components/workspace/saved-views-menu.tsx
@@ -1,0 +1,629 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  CaretDown,
+  DotsThreeVertical,
+  LinkSimple,
+  Plus,
+} from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+import type { SavedFilterViewRow } from "@/lib/db/types";
+import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
+import {
+  buildSavedFilterViewShareUrl,
+  payloadFromGridFilters,
+  parseSavedFilterViewPayload,
+} from "@/lib/saved-views/schema";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+
+function isOwnedView(view: SavedFilterViewRow): boolean {
+  return view.source_user_id === null;
+}
+
+/** Same styling as the "Pinned sets" section label in armor-set-combobox. */
+const SAVED_VIEWS_SECTION_LABEL_CLASS =
+  "pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground";
+
+interface SavedViewsMenuProps {
+  views: SavedFilterViewRow[];
+  activeViewId: string | null;
+  filters: GridFiltersJson;
+  onViewsChange: (views: SavedFilterViewRow[]) => void;
+  onApply: (view: SavedFilterViewRow) => void;
+  className?: string;
+}
+
+export function SavedViewsMenu({
+  views,
+  activeViewId,
+  filters,
+  onViewsChange,
+  onApply,
+  className,
+}: SavedViewsMenuProps) {
+  const ownedViews = useMemo(
+    () => views.filter((v) => isOwnedView(v)),
+    [views],
+  );
+  const sharedViews = useMemo(
+    () => views.filter((v) => !isOwnedView(v)),
+    [views],
+  );
+
+  const activeView = useMemo(
+    () => views.find((v) => v.id === activeViewId) ?? null,
+    [activeViewId, views],
+  );
+
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [saveBusy, setSaveBusy] = useState(false);
+
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<SavedFilterViewRow | null>(
+    null,
+  );
+  const [renameName, setRenameName] = useState("");
+  const [renameBusy, setRenameBusy] = useState(false);
+
+  const [shareOpen, setShareOpen] = useState(false);
+  const [shareTarget, setShareTarget] = useState<SavedFilterViewRow | null>(
+    null,
+  );
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [shareBusy, setShareBusy] = useState(false);
+
+  const openSaveDialog = useCallback(() => {
+    setSaveName("");
+    setSaveOpen(true);
+  }, []);
+
+  const openRenameDialog = useCallback((view: SavedFilterViewRow) => {
+    setRenameTarget(view);
+    setRenameName(view.name);
+    setRenameOpen(true);
+  }, []);
+
+  const openShareDialog = useCallback(async (view: SavedFilterViewRow) => {
+    setShareTarget(view);
+    setShareUrl(null);
+    setShareOpen(true);
+    setShareBusy(true);
+    try {
+      const res = await fetch(`/api/saved-views/${view.id}/share`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error ?? `Share failed (${res.status})`);
+      }
+      const body = (await res.json()) as { slug: string; url: string };
+      setShareUrl(body.url);
+      onViewsChange(
+        views.map((v) =>
+          v.id === view.id ? { ...v, share_slug: body.slug } : v,
+        ),
+      );
+    } catch (err) {
+      setShareOpen(false);
+      toast.error(
+        err instanceof Error ? err.message : "Could not create share link.",
+      );
+    } finally {
+      setShareBusy(false);
+    }
+  }, [onViewsChange, views]);
+
+  const handleSave = useCallback(async () => {
+    const trimmed = saveName.trim();
+    if (!trimmed || saveBusy) return;
+    setSaveBusy(true);
+    try {
+      const res = await fetch("/api/saved-views", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: trimmed,
+          filters: payloadFromGridFilters(filters),
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error ?? `Save failed (${res.status})`);
+      }
+      const body = (await res.json()) as { view: SavedFilterViewRow };
+      onViewsChange(
+        [...views, body.view].sort((a, b) => a.name.localeCompare(b.name)),
+      );
+      setSaveOpen(false);
+      toast.success("View saved.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not save view.");
+    } finally {
+      setSaveBusy(false);
+    }
+  }, [filters, onViewsChange, saveBusy, saveName, views]);
+
+  const handleRename = useCallback(async () => {
+    if (!renameTarget) return;
+    const trimmed = renameName.trim();
+    if (!trimmed || renameBusy) return;
+    setRenameBusy(true);
+    try {
+      const res = await fetch(`/api/saved-views/${renameTarget.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error ?? `Rename failed (${res.status})`);
+      }
+      const body = (await res.json()) as { view: SavedFilterViewRow };
+      onViewsChange(
+        views
+          .map((v) => (v.id === body.view.id ? body.view : v))
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      );
+      setRenameOpen(false);
+      toast.success("View renamed.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Could not rename view.",
+      );
+    } finally {
+      setRenameBusy(false);
+    }
+  }, [onViewsChange, renameBusy, renameName, renameTarget, views]);
+
+  const handleDelete = useCallback(
+    async (view: SavedFilterViewRow) => {
+      try {
+        const res = await fetch(`/api/saved-views/${view.id}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as {
+            error?: string;
+          } | null;
+          throw new Error(body?.error ?? `Delete failed (${res.status})`);
+        }
+        onViewsChange(views.filter((v) => v.id !== view.id));
+        toast.success(
+          isOwnedView(view) ? "View deleted." : "Removed from your list.",
+        );
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Could not delete view.",
+        );
+      }
+    },
+    [onViewsChange, views],
+  );
+
+  const revokeShareForView = useCallback(
+    async (view: SavedFilterViewRow, closeDialog = false) => {
+      setShareBusy(true);
+      try {
+        const res = await fetch(`/api/saved-views/${view.id}/share`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as {
+            error?: string;
+          } | null;
+          throw new Error(body?.error ?? `Revoke failed (${res.status})`);
+        }
+        onViewsChange(
+          views.map((v) => (v.id === view.id ? { ...v, share_slug: null } : v)),
+        );
+        if (closeDialog) {
+          setShareOpen(false);
+          setShareUrl(null);
+        }
+        toast.success("Share link revoked.");
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Could not revoke share link.",
+        );
+      } finally {
+        setShareBusy(false);
+      }
+    },
+    [onViewsChange, views],
+  );
+
+  async function copyShareUrl() {
+    const url =
+      shareUrl ??
+      (shareTarget?.share_slug
+        ? buildSavedFilterViewShareUrl(
+            window.location.origin,
+            shareTarget.share_slug,
+          )
+        : null);
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("Link copied.");
+    } catch {
+      toast.error("Could not copy link.");
+    }
+  }
+
+  const triggerLabel = activeView?.name ?? "Views";
+
+  return (
+    <>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            aria-label="Saved views"
+            className={cn(
+              "h-9 shrink-0 gap-1.5 rounded-none px-3 text-xs",
+              activeView &&
+                "border-primary/60 bg-primary/10 font-medium text-foreground",
+              className,
+            )}
+          >
+            <span className="max-w-[10rem] truncate">{triggerLabel}</span>
+            <CaretDown
+              weight="duotone"
+              aria-hidden
+              className="!size-3.5 shrink-0 opacity-60"
+            />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="min-w-56 max-w-xs rounded-none py-1"
+          collisionPadding={16}
+        >
+          <DropdownMenuLabel className={SAVED_VIEWS_SECTION_LABEL_CLASS}>
+            Saved by you
+          </DropdownMenuLabel>
+          {ownedViews.length === 0 ? (
+            <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
+              No saved views yet.
+            </div>
+          ) : null}
+          {ownedViews.map((view) => (
+            <SavedViewRow
+              key={view.id}
+              view={view}
+              active={view.id === activeViewId}
+              onApply={() => onApply(view)}
+              owned
+              onRename={() => openRenameDialog(view)}
+              onShare={() => void openShareDialog(view)}
+              onRevokeShare={
+                view.share_slug
+                  ? () => void revokeShareForView(view)
+                  : undefined
+              }
+              onDelete={() => void handleDelete(view)}
+            />
+          ))}
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuLabel className={SAVED_VIEWS_SECTION_LABEL_CLASS}>
+            Shared with you
+          </DropdownMenuLabel>
+          {sharedViews.length === 0 ? (
+            <div className="px-3 py-2.5 text-sm text-muted-foreground/80">
+              No shared views yet.
+            </div>
+          ) : null}
+          {sharedViews.map((view) => (
+            <SavedViewRow
+              key={view.id}
+              view={view}
+              active={view.id === activeViewId}
+              onApply={() => onApply(view)}
+              owned={false}
+              onDelete={() => void handleDelete(view)}
+            />
+          ))}
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem
+            className="rounded-none"
+            onSelect={(e) => {
+              e.preventDefault();
+              openSaveDialog();
+            }}
+          >
+            <Plus weight="duotone" className="size-4" aria-hidden />
+            Save current filters as view…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={saveOpen} onOpenChange={setSaveOpen}>
+        <DialogContent className="rounded-none sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Save view</DialogTitle>
+            <DialogDescription>
+              Saves your current set, archetype, tuning, and tertiary filters.
+              Class and search are not included.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            placeholder="View name"
+            maxLength={80}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleSave();
+            }}
+          />
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-none"
+              onClick={() => setSaveOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="rounded-none"
+              disabled={!saveName.trim() || saveBusy}
+              onClick={() => void handleSave()}
+            >
+              {saveBusy ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent className="rounded-none sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename view</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={renameName}
+            onChange={(e) => setRenameName(e.target.value)}
+            placeholder="View name"
+            maxLength={80}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleRename();
+            }}
+          />
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-none"
+              onClick={() => setRenameOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="rounded-none"
+              disabled={!renameName.trim() || renameBusy}
+              onClick={() => void handleRename()}
+            >
+              {renameBusy ? "Saving…" : "Rename"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={shareOpen} onOpenChange={setShareOpen}>
+        <DialogContent className="rounded-none sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Share view</DialogTitle>
+            <DialogDescription>
+              Anyone with this link can add a snapshot to their dashboard after
+              signing in.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex gap-2">
+            <Input
+              readOnly
+              value={
+                shareUrl ??
+                (shareBusy
+                  ? "Generating link…"
+                  : shareTarget?.share_slug
+                    ? buildSavedFilterViewShareUrl(
+                        typeof window !== "undefined"
+                          ? window.location.origin
+                          : "",
+                        shareTarget.share_slug,
+                      )
+                    : "")
+              }
+              className="font-mono text-xs"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="shrink-0 rounded-none"
+              aria-label="Copy share link"
+              disabled={shareBusy || !shareUrl}
+              onClick={() => void copyShareUrl()}
+            >
+              <LinkSimple weight="duotone" className="size-4" aria-hidden />
+            </Button>
+          </div>
+          <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
+            <Button
+              type="button"
+              variant="destructive"
+              className="rounded-none"
+              disabled={shareBusy}
+              onClick={() => {
+                if (shareTarget) void revokeShareForView(shareTarget, true);
+              }}
+            >
+              Revoke link
+            </Button>
+            <Button
+              type="button"
+              className="rounded-none"
+              disabled={shareBusy || !shareUrl}
+              onClick={() => void copyShareUrl()}
+            >
+              Copy link
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function SavedViewRow({
+  view,
+  active,
+  owned,
+  onApply,
+  onRename,
+  onShare,
+  onRevokeShare,
+  onDelete,
+}: {
+  view: SavedFilterViewRow;
+  active: boolean;
+  owned: boolean;
+  onApply: () => void;
+  onRename?: () => void;
+  onShare?: () => void;
+  onRevokeShare?: () => void;
+  onDelete: () => void;
+}) {
+  const payload = parseSavedFilterViewPayload(view.filters);
+
+  return (
+    <div className="group/row flex min-w-0 items-center gap-0.5 px-1">
+      <DropdownMenuItem
+        className={cn(
+          "min-w-0 flex-1 cursor-pointer rounded-none",
+          active && "bg-accent font-medium",
+        )}
+        onSelect={(e) => {
+          e.preventDefault();
+          if (!payload) {
+            toast.error("This view has invalid saved data.");
+            return;
+          }
+          onApply();
+        }}
+      >
+        <span className="flex min-w-0 flex-col gap-0.5">
+          <span className="truncate">{view.name}</span>
+          {!owned ? (
+            <span className="truncate text-muted-foreground">
+              from {view.source_display_name ?? "someone"}
+            </span>
+          ) : null}
+        </span>
+      </DropdownMenuItem>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Actions for ${view.name}`}
+            className="size-7 shrink-0 rounded-none opacity-70 group-hover/row:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DotsThreeVertical
+              weight="bold"
+              className="size-3.5"
+              aria-hidden
+            />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="min-w-40 rounded-none py-1"
+          collisionPadding={16}
+        >
+          {owned ? (
+            <>
+              <DropdownMenuItem
+                className="rounded-none"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  onRename?.();
+                }}
+              >
+                Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="rounded-none"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  onShare?.();
+                }}
+              >
+                Get share link
+              </DropdownMenuItem>
+              {view.share_slug ? (
+                <DropdownMenuItem
+                  className="rounded-none"
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    onRevokeShare?.();
+                  }}
+                >
+                  Revoke share link
+                </DropdownMenuItem>
+              ) : null}
+              <DropdownMenuSeparator />
+            </>
+          ) : null}
+          <DropdownMenuItem
+            className="rounded-none text-destructive focus:text-destructive"
+            onSelect={(e) => {
+              e.preventDefault();
+              onDelete();
+            }}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type ButtonHTMLAttributes,
+  type ReactNode,
 } from "react";
 import {
   CaretDown,
@@ -198,6 +199,8 @@ interface TrackerFilterBarProps {
   resultNoun: ResultNoun;
   /** Tracker grid hides tertiary filtering; inventory table keeps it enabled. */
   showTertiaryStatFilter?: boolean;
+  /** Saved filter views menu — rendered after class tabs, before Sets. */
+  savedViewsSlot?: ReactNode;
   className?: string;
 }
 
@@ -216,6 +219,7 @@ export function TrackerFilterBar({
   resultCount,
   resultNoun,
   showTertiaryStatFilter = true,
+  savedViewsSlot,
   className,
 }: TrackerFilterBarProps) {
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -491,6 +495,8 @@ export function TrackerFilterBar({
       </div>
 
       <div aria-hidden className="h-6 w-px shrink-0 self-center bg-border" />
+
+      {savedViewsSlot}
 
       <Popover open={setsOpen} onOpenChange={setSetsOpen}>
         <div className={cn(INLINE_TRIGGER_FRAME_CLASS, "hidden md:inline-flex")}>

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -133,6 +133,63 @@ export type Database = {
           }
         ];
       };
+      saved_filter_views: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          filters: Json;
+          view_mode: string;
+          share_slug: string | null;
+          source_user_id: string | null;
+          source_display_name: string | null;
+          source_share_slug: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          filters: Json;
+          view_mode: string;
+          share_slug?: string | null;
+          source_user_id?: string | null;
+          source_display_name?: string | null;
+          source_share_slug?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          filters?: Json;
+          view_mode?: string;
+          share_slug?: string | null;
+          source_user_id?: string | null;
+          source_display_name?: string | null;
+          source_share_slug?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "saved_filter_views_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "saved_filter_views_source_user_id_fkey";
+            columns: ["source_user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       inventory_cache: {
         Row: {
           user_id: string;
@@ -301,6 +358,7 @@ export type TablesUpdate<T extends keyof Database["public"]["Tables"]> =
 
 export type UserRow = Tables<"users">;
 export type ViewRow = Tables<"views">;
+export type SavedFilterViewRow = Tables<"saved_filter_views">;
 export type OAuthTokensRow = Tables<"oauth_tokens">;
 export type InventoryCacheRow = Tables<"inventory_cache">;
 export type ManifestVersionRow = Tables<"manifest_versions">;

--- a/src/lib/saved-views/queries.ts
+++ b/src/lib/saved-views/queries.ts
@@ -1,0 +1,265 @@
+import "server-only";
+
+import { randomBytes } from "node:crypto";
+import { getServiceRoleClient } from "@/lib/db/server";
+import type { SavedFilterViewRow } from "@/lib/db/types";
+import {
+  parseSavedFilterViewPayload,
+  type SavedFilterViewPayload,
+} from "@/lib/saved-views/schema";
+
+/** Legacy column — filters-only saved views no longer use workspace mode. */
+const LEGACY_VIEW_MODE = "grid";
+
+const SHARE_SLUG_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567";
+const SHARE_SLUG_LEN = 12;
+
+function randomShareSlug(): string {
+  const bytes = randomBytes(SHARE_SLUG_LEN);
+  let out = "";
+  for (let i = 0; i < SHARE_SLUG_LEN; i++) {
+    out += SHARE_SLUG_ALPHABET[bytes[i]! % SHARE_SLUG_ALPHABET.length]!;
+  }
+  return out;
+}
+
+export async function listSavedViewsForUser(
+  userId: string,
+): Promise<SavedFilterViewRow[]> {
+  const sb = getServiceRoleClient();
+  const { data, error } = await sb
+    .from("saved_filter_views")
+    .select("*")
+    .eq("user_id", userId)
+    .order("name", { ascending: true });
+  if (error) {
+    throw new Error(`listSavedViewsForUser failed: ${error.message}`);
+  }
+  return (data ?? []) as SavedFilterViewRow[];
+}
+
+export async function getSavedViewForUser(
+  userId: string,
+  id: string,
+): Promise<SavedFilterViewRow | null> {
+  const sb = getServiceRoleClient();
+  const { data } = await sb
+    .from("saved_filter_views")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("id", id)
+    .maybeSingle();
+  return (data as SavedFilterViewRow) ?? null;
+}
+
+export async function createSavedView(
+  userId: string,
+  input: {
+    name: string;
+    filters: SavedFilterViewPayload;
+  },
+): Promise<SavedFilterViewRow> {
+  const sb = getServiceRoleClient();
+  const trimmedName = input.name.trim();
+  const { data, error } = await sb
+    .from("saved_filter_views")
+    .insert({
+      user_id: userId,
+      name: trimmedName,
+      filters: input.filters,
+      view_mode: LEGACY_VIEW_MODE,
+    })
+    .select("*")
+    .single();
+  if (error || !data) {
+    throw new Error(`createSavedView failed: ${error?.message ?? "unknown"}`);
+  }
+  return data as SavedFilterViewRow;
+}
+
+export async function renameSavedView(
+  userId: string,
+  id: string,
+  name: string,
+): Promise<SavedFilterViewRow | null> {
+  const sb = getServiceRoleClient();
+  const { data: existing } = await sb
+    .from("saved_filter_views")
+    .select("id, source_user_id")
+    .eq("user_id", userId)
+    .eq("id", id)
+    .maybeSingle();
+  if (!existing || existing.source_user_id !== null) {
+    return null;
+  }
+
+  const { data, error } = await sb
+    .from("saved_filter_views")
+    .update({
+      name: name.trim(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("user_id", userId)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) {
+    throw new Error(`renameSavedView failed: ${error.message}`);
+  }
+  return (data as SavedFilterViewRow) ?? null;
+}
+
+export async function deleteSavedView(
+  userId: string,
+  id: string,
+): Promise<boolean> {
+  const sb = getServiceRoleClient();
+  const { error, count } = await sb
+    .from("saved_filter_views")
+    .delete({ count: "exact" })
+    .eq("user_id", userId)
+    .eq("id", id);
+  if (error) {
+    throw new Error(`deleteSavedView failed: ${error.message}`);
+  }
+  return (count ?? 0) > 0;
+}
+
+export async function ensureShareSlug(
+  userId: string,
+  id: string,
+): Promise<SavedFilterViewRow | null> {
+  const sb = getServiceRoleClient();
+  const { data: row } = await sb
+    .from("saved_filter_views")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("id", id)
+    .maybeSingle();
+  if (!row || row.source_user_id !== null) {
+    return null;
+  }
+  if (row.share_slug) {
+    return row as SavedFilterViewRow;
+  }
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const slug = randomShareSlug();
+    const { data, error } = await sb
+      .from("saved_filter_views")
+      .update({
+        share_slug: slug,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId)
+      .eq("id", id)
+      .is("share_slug", null)
+      .select("*")
+      .maybeSingle();
+    if (!error && data) {
+      return data as SavedFilterViewRow;
+    }
+    if (error?.code !== "23505") {
+      throw new Error(`ensureShareSlug failed: ${error?.message ?? "unknown"}`);
+    }
+  }
+  throw new Error("ensureShareSlug failed: could not allocate unique slug");
+}
+
+export async function revokeShareSlug(
+  userId: string,
+  id: string,
+): Promise<SavedFilterViewRow | null> {
+  const sb = getServiceRoleClient();
+  const { data: existing } = await sb
+    .from("saved_filter_views")
+    .select("id, source_user_id")
+    .eq("user_id", userId)
+    .eq("id", id)
+    .maybeSingle();
+  if (!existing || existing.source_user_id !== null) {
+    return null;
+  }
+
+  const { data, error } = await sb
+    .from("saved_filter_views")
+    .update({
+      share_slug: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("user_id", userId)
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error) {
+    throw new Error(`revokeShareSlug failed: ${error.message}`);
+  }
+  return (data as SavedFilterViewRow) ?? null;
+}
+
+export async function importSharedView(
+  recipientUserId: string,
+  slug: string,
+): Promise<SavedFilterViewRow | null> {
+  const sb = getServiceRoleClient();
+
+  const { data: existingImport } = await sb
+    .from("saved_filter_views")
+    .select("*")
+    .eq("user_id", recipientUserId)
+    .eq("source_share_slug", slug)
+    .maybeSingle();
+  if (existingImport) {
+    return existingImport as SavedFilterViewRow;
+  }
+
+  const { data: source } = await sb
+    .from("saved_filter_views")
+    .select("*")
+    .eq("share_slug", slug)
+    .is("source_user_id", null)
+    .maybeSingle();
+  if (!source) {
+    return null;
+  }
+
+  const sourcePayload = parseSavedFilterViewPayload(source.filters);
+  if (!sourcePayload) {
+    return null;
+  }
+
+  const { data: sourceUser } = await sb
+    .from("users")
+    .select("display_name")
+    .eq("id", source.user_id)
+    .maybeSingle();
+
+  const { data: inserted, error } = await sb
+    .from("saved_filter_views")
+    .insert({
+      user_id: recipientUserId,
+      name: source.name,
+      filters: sourcePayload,
+      view_mode: source.view_mode,
+      source_user_id: source.user_id,
+      source_display_name: sourceUser?.display_name ?? "Unknown Guardian",
+      source_share_slug: slug,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      const { data: raced } = await sb
+        .from("saved_filter_views")
+        .select("*")
+        .eq("user_id", recipientUserId)
+        .eq("source_share_slug", slug)
+        .maybeSingle();
+      return (raced as SavedFilterViewRow) ?? null;
+    }
+    throw new Error(`importSharedView failed: ${error.message}`);
+  }
+
+  return (inserted as SavedFilterViewRow) ?? null;
+}

--- a/src/lib/saved-views/schema.ts
+++ b/src/lib/saved-views/schema.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+import { ARMOR_STAT_NAMES, type ArmorStatName } from "@/lib/db/types";
+import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
+
+const HASH_LIST_MAX = 256;
+
+export const savedFilterViewPayloadSchema = z.object({
+  version: z.literal(1),
+  setHashes: z.array(z.number().int().nonnegative()).max(HASH_LIST_MAX),
+  archetypeHashes: z.array(z.number().int().nonnegative()).max(HASH_LIST_MAX),
+  tuningHashes: z.array(z.number().int().nonnegative()).max(HASH_LIST_MAX),
+  tertiaryStats: z
+    .array(
+      z.enum(
+        ARMOR_STAT_NAMES as unknown as [ArmorStatName, ...ArmorStatName[]],
+      ),
+    )
+    .max(ARMOR_STAT_NAMES.length),
+});
+
+export type SavedFilterViewPayload = z.infer<typeof savedFilterViewPayloadSchema>;
+
+export function parseSavedFilterViewPayload(
+  raw: unknown,
+): SavedFilterViewPayload | null {
+  const parsed = savedFilterViewPayloadSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function payloadFromGridFilters(
+  filters: GridFiltersJson,
+): SavedFilterViewPayload {
+  return {
+    version: 1,
+    setHashes: [...filters.setHashes],
+    archetypeHashes: [...filters.archetypeHashes],
+    tuningHashes: [...filters.tuningHashes],
+    tertiaryStats: [...filters.tertiaryStats],
+  };
+}
+
+export function applyPayloadToGridFilters(
+  current: GridFiltersJson,
+  payload: SavedFilterViewPayload,
+): GridFiltersJson {
+  return {
+    ...current,
+    version: 1,
+    setHashes: [...payload.setHashes],
+    archetypeHashes: [...payload.archetypeHashes],
+    tuningHashes: [...payload.tuningHashes],
+    tertiaryStats: [...payload.tertiaryStats],
+  };
+}
+
+function sortedNumbers(values: readonly number[]): number[] {
+  return [...values].sort((a, b) => a - b);
+}
+
+function sortedStrings(values: readonly string[]): string[] {
+  return [...values].sort();
+}
+
+export function savedViewPayloadMatchesFilters(
+  filters: GridFiltersJson,
+  payload: SavedFilterViewPayload,
+): boolean {
+  const aSets = sortedNumbers(filters.setHashes);
+  const bSets = sortedNumbers(payload.setHashes);
+  if (aSets.length !== bSets.length || aSets.some((v, i) => v !== bSets[i])) {
+    return false;
+  }
+
+  const aArchetypes = sortedNumbers(filters.archetypeHashes);
+  const bArchetypes = sortedNumbers(payload.archetypeHashes);
+  if (
+    aArchetypes.length !== bArchetypes.length ||
+    aArchetypes.some((v, i) => v !== bArchetypes[i])
+  ) {
+    return false;
+  }
+
+  const aTunings = sortedNumbers(filters.tuningHashes);
+  const bTunings = sortedNumbers(payload.tuningHashes);
+  if (aTunings.length !== bTunings.length || aTunings.some((v, i) => v !== bTunings[i])) {
+    return false;
+  }
+
+  const aStats = sortedStrings(filters.tertiaryStats);
+  const bStats = sortedStrings(payload.tertiaryStats);
+  return (
+    aStats.length === bStats.length && aStats.every((v, i) => v === bStats[i])
+  );
+}
+
+export function buildSavedFilterViewShareUrl(
+  origin: string,
+  slug: string,
+): string {
+  const base = origin.replace(/\/$/, "");
+  return `${base}/saved-views/${encodeURIComponent(slug)}`;
+}

--- a/supabase/migrations/0015_saved_filter_views.sql
+++ b/supabase/migrations/0015_saved_filter_views.sql
@@ -1,0 +1,27 @@
+-- Named, shareable dashboard filter presets (distinct from tracker `views` panels).
+
+create table public.saved_filter_views (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  name text not null check (char_length(name) between 1 and 80),
+  filters jsonb not null,
+  view_mode text not null check (view_mode in ('grid', 'table')),
+  share_slug text,
+  source_user_id uuid references public.users(id) on delete set null,
+  source_display_name text,
+  source_share_slug text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index saved_filter_views_user_id_idx on public.saved_filter_views(user_id);
+
+create unique index saved_filter_views_share_slug_uidx
+  on public.saved_filter_views(share_slug)
+  where share_slug is not null;
+
+create unique index saved_filter_views_user_source_slug_uidx
+  on public.saved_filter_views(user_id, source_share_slug)
+  where source_share_slug is not null;
+
+alter table public.saved_filter_views enable row level security;


### PR DESCRIPTION
## Summary

- Adds named filter presets ("Views") in the dashboard filter bar, stored in a new `saved_filter_views` table (distinct from tracker `views` panels).
- Users can save, apply, rename, delete, and share presets; share links import a snapshot into "Shared with you" after sign-in.
- Applying a view updates set/archetype/tuning/tertiary filters only—class, search, and Tracker/Table mode are unchanged.

## Test plan

- [ ] Run `npm run db:push` to apply `0015_saved_filter_views.sql`
- [ ] Save current filters as a view; confirm it appears under "Saved by you"
- [ ] Apply the view in Tracker and Table modes; confirm filters update without switching modes
- [ ] Generate a share link, open in a second account; confirm snapshot under "Shared with you" with creator name
- [ ] Revoke share link; confirm new imports 404; existing snapshots remain
- [ ] `npm run build` and Storybook tests for `SavedViewsMenu`


Made with [Cursor](https://cursor.com)