### PR TITLE
Fix single-column tracker grid after opening saved view links

### DIFF
--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -161,8 +161,10 @@ export function GridWorkspace({
 
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const [columnCount, setColumnCount] = useState(1);
+  const showTrackerGrid = unblocked && visibleTrackers.length > 0;
 
   useLayoutEffect(() => {
+    if (!showTrackerGrid) return;
     const el = scrollerRef.current;
     if (!el) return;
     const tick = () => {
@@ -173,7 +175,7 @@ export function GridWorkspace({
     const ro = new ResizeObserver(tick);
     ro.observe(el);
     return () => ro.disconnect();
-  }, []);
+  }, [showTrackerGrid]);
 
   const rows = useMemo<TrackerDescriptor[][]>(() => {
     if (visibleTrackers.length === 0 || columnCount < 1) return [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening a saved view share link (`/saved-views/[slug]`) redirects to the dashboard and applies filters in a client `useEffect`. On first mount, the tracker grid scroller is not rendered yet (filters are still empty), so the column-count `ResizeObserver` never attached. `columnCount` stayed at its initial value of `1`, leaving trackers in a single column even on wide screens.

## Fix

Re-run the column-count layout effect when the tracker grid becomes visible (`unblocked` filters with at least one matching tracker), so the `ResizeObserver` is attached once the scroller element exists.

## How to verify

1. Save a view with filters that show multiple trackers.
2. Copy the share link and open it in a new tab (or incognito after sign-in).
3. Confirm the grid uses multiple columns on a wide viewport (same as applying the view from the menu on an already-loaded dashboard).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d729475-82cd-47d5-b7b8-5267f9b03370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d729475-82cd-47d5-b7b8-5267f9b03370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

