### PR TITLE
perf: improve dashboard responsiveness

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,11 +1,10 @@
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
-import { Info, Warning } from "@phosphor-icons/react/dist/ssr";
 import { getSession } from "@/lib/auth/session";
 import { getServiceRoleClient } from "@/lib/db/server";
 import { getCachedInventoryWithSyncedAt } from "@/lib/inventory/sync";
 import { getManifestLookups } from "@/lib/manifest/lookups";
-import { checkManifestVersion } from "@/lib/manifest/version-check";
-import { SyncManifestButton } from "@/components/dashboard/sync-manifest-button";
+import { ManifestStatusBanner } from "@/components/dashboard/manifest-status-banner";
 import { DashboardWorkspace } from "@/components/dashboard/dashboard-workspace";
 import { manifestSelectorsFromLookups } from "@/lib/views/manifest-selectors-from-lookup";
 import { buildGridLookupPayload } from "@/lib/views/grid-lookup-payload.server";
@@ -39,18 +38,16 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
 
   const sb = getServiceRoleClient();
 
-  const [userRowRes, cached, lookups, versionCheck, savedViews] =
-    await Promise.all([
-      sb
-        .from("users")
-        .select("display_name, profile_picture_path, grid_filters")
-        .eq("id", session.userId)
-        .maybeSingle(),
-      getCachedInventoryWithSyncedAt(session.userId),
-      getManifestLookups(),
-      checkManifestVersion(),
-      listSavedViewsForUser(session.userId),
-    ]);
+  const [userRowRes, cached, lookups, savedViews] = await Promise.all([
+    sb
+      .from("users")
+      .select("display_name, profile_picture_path, grid_filters")
+      .eq("id", session.userId)
+      .maybeSingle(),
+    getCachedInventoryWithSyncedAt(session.userId),
+    getManifestLookups(),
+    listSavedViewsForUser(session.userId),
+  ]);
 
   const userRow = userRowRes.data;
   const displayName = userRow?.display_name ?? session.displayName;
@@ -70,65 +67,9 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
   const lookupPayload = buildGridLookupPayload(lookups);
 
   const banners = (
-    <>
-      {!lookups.version ? (
-        <div
-          role="alert"
-          className="flex flex-col gap-3 rounded-none border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
-        >
-          <Warning weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-          <div className="flex-1">
-            <p className="font-medium">Manifest not synced</p>
-            <p className="text-muted-foreground">
-              Sets, archetypes, and tunings won&rsquo;t populate until the
-              manifest is loaded. This pulls a few MB of Destiny
-              definitions from Bungie and may take 30–60 seconds.
-            </p>
-          </div>
-          <div className="shrink-0 sm:self-center">
-            <SyncManifestButton label="Sync now" />
-          </div>
-        </div>
-      ) : versionCheck.schemaOutdated ? (
-        <div
-          role="alert"
-          className="flex flex-col gap-3 rounded-none border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
-        >
-          <Warning weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-          <div className="flex-1">
-            <p className="font-medium">Manifest needs to be re-derived</p>
-            <p className="text-muted-foreground">
-              New derived tables were added by a schema migration but
-              haven&rsquo;t been populated yet. Run a resync to backfill
-              archetype stat pairs and stat plugs.
-            </p>
-          </div>
-          <div className="shrink-0 sm:self-center">
-            <SyncManifestButton label="Resync" />
-          </div>
-        </div>
-      ) : versionCheck.needsResync ? (
-        <div
-          role="status"
-          className="flex flex-col gap-3 rounded-none border border-blue-500/30 bg-blue-500/5 p-4 text-sm sm:flex-row sm:items-start"
-        >
-          <Info weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
-          <div className="flex-1">
-            <p className="font-medium">A new Destiny manifest is available</p>
-            <p className="text-muted-foreground">
-              Cached version{" "}
-              <code className="font-mono text-xs">{versionCheck.cachedVersion}</code>
-              {" "}
-              &rarr; live version{" "}
-              <code className="font-mono text-xs">{versionCheck.liveVersion}</code>.
-            </p>
-          </div>
-          <div className="shrink-0 sm:self-center">
-            <SyncManifestButton variant="secondary" label="Resync" />
-          </div>
-        </div>
-      ) : null}
-    </>
+    <Suspense fallback={null}>
+      <ManifestStatusBanner manifestVersion={lookups.version} />
+    </Suspense>
   );
 
   return (

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useDeferredValue, useMemo, useRef } from "react";
 import type { ReactNode } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import { SLOT_LABELS, bungieIconUrl } from "@/lib/bungie/constants";
 import {
@@ -32,6 +33,9 @@ const INVENTORY_TABLE_COLGROUP = (
     <col className="w-[15rem]" />
   </colgroup>
 );
+
+/** Approximate single-row height; the virtualizer remeasures real rows on mount. */
+const ESTIMATED_ROW_HEIGHT_PX = 41;
 
 function formatLocation(piece: DerivedArmorPieceJson): string {
   const loc = piece.location;
@@ -65,10 +69,35 @@ export function InventoryTableView({
 }: InventoryTableViewProps) {
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
 
-  const filteredRows = useMemo(
-    () => filterInventoryPieces(inventory, filters),
-    [inventory, filters],
+  // Keep typing responsive: defer the search term so the filter + sort pass
+  // runs on a lower-priority render instead of blocking every keystroke.
+  const deferredSearch = useDeferredValue(filters.search);
+  const filtersForFiltering = useMemo(
+    () =>
+      deferredSearch === filters.search
+        ? filters
+        : { ...filters, search: deferredSearch },
+    [filters, deferredSearch],
   );
+  const filteredRows = useMemo(
+    () => filterInventoryPieces(inventory, filtersForFiltering),
+    [inventory, filtersForFiltering],
+  );
+
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: filteredRows.length,
+    getScrollElement: () => scrollerRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT_PX,
+    overscan: 10,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const totalSize = rowVirtualizer.getTotalSize();
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? totalSize - virtualRows[virtualRows.length - 1].end
+      : 0;
 
   const hasTopMessage = Boolean(banners) || Boolean(syncWarning);
 
@@ -156,7 +185,10 @@ export function InventoryTableView({
                     </TableHeader>
                   </Table>
                 </div>
-                <div className="menu-scrollbar max-h-[calc(100dvh-13rem)] min-h-0 min-w-0 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]">
+                <div
+                  ref={scrollerRef}
+                  className="menu-scrollbar max-h-[calc(100dvh-13rem)] min-h-0 min-w-0 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]"
+                >
                   <Table
                     className="w-full table-fixed border-separate border-spacing-0"
                     containerClassName="overflow-visible"
@@ -173,53 +205,70 @@ export function InventoryTableView({
                           </TableCell>
                         </TableRow>
                       ) : (
-                        filteredRows.map((piece) => (
-                          <TableRow
-                            key={piece.itemInstanceId}
-                            className="border-b-0 shadow-[inset_0_-1px_0_0_var(--border)] hover:bg-accent/60"
-                          >
-                            <TableCell className="w-px whitespace-nowrap py-1 pe-2 align-middle">
-                              {piece.iconPath ? (
-                                <span className="inline-flex rounded-none border border-border bg-accent leading-none">
-                                  {/* eslint-disable-next-line @next/next/no-img-element -- Bungie CDN thumbnails; avoid bloating the bundle with next/image remotePatterns. */}
-                                  <img
-                                    src={bungieIconUrl(piece.iconPath)}
-                                    alt={`${SLOT_LABELS[piece.slot]} — ${inventoryPieceDisplayName(piece) ?? "armor"}`}
-                                    className="block h-auto max-h-7 max-w-9 w-auto"
-                                    loading="lazy"
+                        <>
+                          {paddingTop > 0 ? (
+                            <tr aria-hidden>
+                              <td colSpan={7} style={{ height: paddingTop }} />
+                            </tr>
+                          ) : null}
+                          {virtualRows.map((vRow) => {
+                            const piece = filteredRows[vRow.index];
+                            return (
+                              <TableRow
+                                key={piece.itemInstanceId}
+                                data-index={vRow.index}
+                                ref={rowVirtualizer.measureElement}
+                                className="border-b-0 shadow-[inset_0_-1px_0_0_var(--border)] hover:bg-accent/60"
+                              >
+                                <TableCell className="w-px whitespace-nowrap py-1 pe-2 align-middle">
+                                  {piece.iconPath ? (
+                                    <span className="inline-flex rounded-none border border-border bg-accent leading-none">
+                                      {/* eslint-disable-next-line @next/next/no-img-element -- Bungie CDN thumbnails; avoid bloating the bundle with next/image remotePatterns. */}
+                                      <img
+                                        src={bungieIconUrl(piece.iconPath)}
+                                        alt={`${SLOT_LABELS[piece.slot]} — ${inventoryPieceDisplayName(piece) ?? "armor"}`}
+                                        className="block h-auto max-h-7 max-w-9 w-auto"
+                                        loading="lazy"
+                                      />
+                                    </span>
+                                  ) : (
+                                    <div
+                                      role="img"
+                                      aria-label={`${SLOT_LABELS[piece.slot]} — no artwork`}
+                                      className="inline-block size-7 rounded-none border border-border bg-accent/60"
+                                    />
+                                  )}
+                                </TableCell>
+                                <TableCell className="py-1.5 text-foreground/90">
+                                  {inventoryPieceDisplayName(piece) ?? "—"}
+                                </TableCell>
+                                <TableCell className="py-1.5 text-foreground/90">
+                                  {piece.archetypeName ?? "—"}
+                                </TableCell>
+                                <TableCell className="py-1.5 text-foreground/80">
+                                  {piece.tertiaryStat ?? "—"}
+                                </TableCell>
+                                <TableCell className="py-1.5 text-foreground/90">
+                                  {piece.tuningName ?? "—"}
+                                </TableCell>
+                                <TableCell className="py-1.5 text-muted-foreground">
+                                  {formatLocation(piece)}
+                                </TableCell>
+                                <TableCell className="py-1.5 pe-2 align-middle">
+                                  <InventoryItemActions
+                                    piece={piece}
+                                    targetClass={filters.class}
                                   />
-                                </span>
-                              ) : (
-                                <div
-                                  role="img"
-                                  aria-label={`${SLOT_LABELS[piece.slot]} — no artwork`}
-                                  className="inline-block size-7 rounded-none border border-border bg-accent/60"
-                                />
-                              )}
-                            </TableCell>
-                            <TableCell className="py-1.5 text-foreground/90">
-                              {inventoryPieceDisplayName(piece) ?? "—"}
-                            </TableCell>
-                            <TableCell className="py-1.5 text-foreground/90">
-                              {piece.archetypeName ?? "—"}
-                            </TableCell>
-                            <TableCell className="py-1.5 text-foreground/80">
-                              {piece.tertiaryStat ?? "—"}
-                            </TableCell>
-                            <TableCell className="py-1.5 text-foreground/90">
-                              {piece.tuningName ?? "—"}
-                            </TableCell>
-                            <TableCell className="py-1.5 text-muted-foreground">
-                              {formatLocation(piece)}
-                            </TableCell>
-                            <TableCell className="py-1.5 pe-2 align-middle">
-                              <InventoryItemActions
-                                piece={piece}
-                                targetClass={filters.class}
-                              />
-                            </TableCell>
-                          </TableRow>
-                        ))
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                          {paddingBottom > 0 ? (
+                            <tr aria-hidden>
+                              <td colSpan={7} style={{ height: paddingBottom }} />
+                            </tr>
+                          ) : null}
+                        </>
                       )}
                     </TableBody>
                   </Table>

--- a/src/components/dashboard/manifest-status-banner.tsx
+++ b/src/components/dashboard/manifest-status-banner.tsx
@@ -1,0 +1,85 @@
+import { Info, Warning } from "@phosphor-icons/react/dist/ssr";
+import { checkManifestVersion } from "@/lib/manifest/version-check";
+import { SyncManifestButton } from "@/components/dashboard/sync-manifest-button";
+
+/**
+ * Advisory manifest banner. Rendered inside a `<Suspense>` boundary on the
+ * dashboard so the workspace can paint immediately — the version check makes a
+ * live Bungie request and must never block first paint.
+ */
+export async function ManifestStatusBanner({
+  manifestVersion,
+}: {
+  manifestVersion: string | null;
+}) {
+  if (!manifestVersion) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col gap-3 rounded-none border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
+      >
+        <Warning weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+        <div className="flex-1">
+          <p className="font-medium">Manifest not synced</p>
+          <p className="text-muted-foreground">
+            Sets, archetypes, and tunings won&rsquo;t populate until the
+            manifest is loaded. This pulls a few MB of Destiny definitions from
+            Bungie and may take 30–60 seconds.
+          </p>
+        </div>
+        <div className="shrink-0 sm:self-center">
+          <SyncManifestButton label="Sync now" />
+        </div>
+      </div>
+    );
+  }
+
+  const versionCheck = await checkManifestVersion();
+
+  if (versionCheck.schemaOutdated) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col gap-3 rounded-none border border-amber-500/30 bg-amber-500/5 p-4 text-sm sm:flex-row sm:items-start"
+      >
+        <Warning weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+        <div className="flex-1">
+          <p className="font-medium">Manifest needs to be re-derived</p>
+          <p className="text-muted-foreground">
+            New derived tables were added by a schema migration but haven&rsquo;t
+            been populated yet. Run a resync to backfill archetype stat pairs and
+            stat plugs.
+          </p>
+        </div>
+        <div className="shrink-0 sm:self-center">
+          <SyncManifestButton label="Resync" />
+        </div>
+      </div>
+    );
+  }
+
+  if (versionCheck.needsResync) {
+    return (
+      <div
+        role="status"
+        className="flex flex-col gap-3 rounded-none border border-blue-500/30 bg-blue-500/5 p-4 text-sm sm:flex-row sm:items-start"
+      >
+        <Info weight="duotone" className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+        <div className="flex-1">
+          <p className="font-medium">A new Destiny manifest is available</p>
+          <p className="text-muted-foreground">
+            Cached version{" "}
+            <code className="font-mono text-xs">{versionCheck.cachedVersion}</code>{" "}
+            &rarr; live version{" "}
+            <code className="font-mono text-xs">{versionCheck.liveVersion}</code>.
+          </p>
+        </div>
+        <div className="shrink-0 sm:self-center">
+          <SyncManifestButton variant="secondary" label="Resync" />
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -2,6 +2,7 @@
 
 import {
   useCallback,
+  useDeferredValue,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -11,6 +12,10 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
 import { enumerateVisibleTrackers } from "@/lib/filters/enumerate-trackers";
+import {
+  indexInventoryByTriple,
+  inventoryTripleKey,
+} from "@/lib/views/progress";
 import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
 import type { TrackerFormSelectors } from "@/lib/views/tracker-form-selectors";
 import {
@@ -34,6 +39,9 @@ import {
   TRACKER_WIDTH,
 } from "@/lib/workspace/workspace-constants";
 import { usePinnedArmorSets } from "@/lib/views/use-pinned-armor-sets";
+
+/** Stable empty bucket so tiles with no matching pieces keep referential identity. */
+const EMPTY_PIECES: DerivedArmorPieceJson[] = [];
 
 const ROW_GAP_PX = 16;
 /** Virtual row height for scaled tiles + vertical gap. */
@@ -82,11 +90,32 @@ export function GridWorkspace({
     return out;
   }, [inventory]);
 
-  const inventoryForClass = inventoryByClass[filters.class] ?? [];
+  const inventoryForClass = useMemo(
+    () => inventoryByClass[filters.class] ?? EMPTY_PIECES,
+    [inventoryByClass, filters.class],
+  );
 
+  // Typing in the search box must stay responsive. Defer the search term so the
+  // full cross-product enumeration runs on a lower-priority render instead of
+  // blocking every keystroke; other filter dimensions still update eagerly.
+  const deferredSearch = useDeferredValue(filters.search);
+  const filtersForEnumeration = useMemo(
+    () =>
+      deferredSearch === filters.search
+        ? filters
+        : { ...filters, search: deferredSearch },
+    [filters, deferredSearch],
+  );
   const visibleTrackers = useMemo(
-    () => enumerateVisibleTrackers(filters, selectors),
-    [filters, selectors],
+    () => enumerateVisibleTrackers(filtersForEnumeration, selectors),
+    [filtersForEnumeration, selectors],
+  );
+
+  // Bucket the class inventory once so each tile resolves its matching pieces
+  // with a single lookup instead of re-scanning the whole inventory.
+  const inventoryIndex = useMemo(
+    () => indexInventoryByTriple(inventoryForClass),
+    [inventoryForClass],
   );
   const unblocked = gridFiltersHaveUnblockingSelection(filters);
 
@@ -222,7 +251,15 @@ export function GridWorkspace({
                           <GridTile
                             key={ephemeralTrackerId(d)}
                             descriptor={d}
-                            inventory={inventoryForClass}
+                            inventory={
+                              inventoryIndex.get(
+                                inventoryTripleKey(
+                                  d.setHash,
+                                  d.archetypeHash,
+                                  d.tuningHash,
+                                ),
+                              ) ?? EMPTY_PIECES
+                            }
                             lookupPayload={lookupPayload}
                             hasInventory={hasInventory}
                             onCompareClick={() => setCompareAnchor(d)}

--- a/src/lib/views/progress.ts
+++ b/src/lib/views/progress.ts
@@ -54,6 +54,46 @@ export function tertiaryStatsForArchetype(
   return orderTertiaryStatsForDisplay(raw);
 }
 
+/** Identity key for the `(set × archetype × tuning)` triple a tracker matches. */
+export function inventoryTripleKey(
+  setHash: number,
+  archetypeHash: number,
+  tuningHash: number,
+): string {
+  return `${setHash}:${archetypeHash}:${tuningHash}`;
+}
+
+/**
+ * Bucket inventory by `(set, archetype, tuning)` so each tracker tile resolves
+ * its candidate pieces with a single map lookup instead of re-scanning the
+ * whole inventory. Pieces missing any of the three hashes can never match a
+ * tracker — matching requires strict equality on all three — so they're
+ * dropped here rather than carried into every bucket.
+ */
+export function indexInventoryByTriple(
+  inventory: DerivedArmorPieceJson[],
+): Map<string, DerivedArmorPieceJson[]> {
+  const out = new Map<string, DerivedArmorPieceJson[]>();
+  for (const piece of inventory) {
+    if (
+      piece.setHash == null ||
+      piece.archetypeHash == null ||
+      piece.tuningHash == null
+    ) {
+      continue;
+    }
+    const key = inventoryTripleKey(
+      piece.setHash,
+      piece.archetypeHash,
+      piece.tuningHash,
+    );
+    const bucket = out.get(key);
+    if (bucket) bucket.push(piece);
+    else out.set(key, [piece]);
+  }
+  return out;
+}
+
 export function computeViewProgress(
   view: ViewRow,
   inventory: DerivedArmorPieceJson[],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Four targeted, behavior-preserving optimizations to make the dashboard feel more responsive. Each change also simplifies the surrounding code (fewer blocking dependencies, fewer per-frame scans) rather than adding complexity.

## Changes

### 1. Stream the manifest version banner instead of blocking first paint
`DashboardPage` previously gated its initial render on a 5-way `Promise.all` that included `checkManifestVersion()` — which makes a **live Bungie HTTP request** in the critical path, just to decide whether to show an advisory banner. On serverless cold starts (per-instance 30‑min memo) every visitor paid that round-trip before seeing anything.

The banner is now an async server component (`ManifestStatusBanner`) wrapped in `<Suspense fallback={null}>`. The dashboard shell, grid, and filters paint as soon as the user row / inventory cache / manifest lookups / saved views resolve; the banner streams in when the version check completes. First paint no longer depends on Bungie.

### 2. Defer the search term so typing stays responsive
The search input wrote straight into `filters.search`, so every keystroke re-ran the full `enumerateVisibleTrackers` cross-product + sort (grid) and `filterInventoryPieces` + sort (table) synchronously on the main thread. Both views now feed a `useDeferredValue` copy of the search term into the heavy computation, keeping the input smooth while React drops stale work. Other filter dimensions still update eagerly.

### 3. Index inventory by `(set × archetype × tuning)`
`computeViewProgress` linearly scanned the entire class inventory for **every visible tile** (and twice for compare). Added `indexInventoryByTriple` / `inventoryTripleKey` in `progress.ts`; `GridWorkspace` builds the index once per inventory change and hands each tile its pre-bucketed candidate slice, so per-tile work drops from `O(inventory)` to `O(matches)`. Pieces missing any of the three hashes can never match a tracker, so they're dropped from the index entirely.

### 4. Virtualize the inventory table
Table mode rendered every filtered row (each with an actions cell) unvirtualized — thousands of DOM nodes for a large vault. Now virtualized with `@tanstack/react-virtual` (already a dependency, same lib the grid uses) via the spacer-row + `measureElement` recipe, preserving native table layout and dynamic row heights.

## Verification
- `npm run lint` — no new errors/warnings introduced (the 2 pre-existing errors in `scripts/stub-server-only.cjs` and `inventory-auto-sync.tsx` are unrelated and present on `main`).
- `npm run build` — compiles, TypeScript clean, all routes generated.

## Notes
- No public component props changed, so existing stories are unaffected.
- A separate, larger idea (optimistic local inventory updates to avoid the full `router.refresh()` after equip/move) was intentionally left out — it changes the data-ownership model and warrants its own discussion.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6fa74d7-2121-48a5-823b-83f0b8aa8c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6fa74d7-2121-48a5-823b-83f0b8aa8c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

