### PR TITLE
Improve table-view filter bar: actions on the right, responsive collapse

### DIFF
--- a/src/components/workspace/armor-sets-filter-dimension.tsx
+++ b/src/components/workspace/armor-sets-filter-dimension.tsx
@@ -52,7 +52,7 @@ export function ArmorSetsFilterDimension({
   inlineWrapperClass = "",
   stowedSubTriggerClass = "",
 }: ArmorSetsFilterDimensionProps) {
-  const label = "Sets";
+  const label = "Armor Sets";
   const panel = (
     <ArmorSetMultiSelectPanel
       key={classKey}
@@ -102,7 +102,7 @@ export function ArmorSetsFilterDimension({
   return (
     <DropdownMenuSub>
       <FilterDimensionSubTrigger
-        label="Armor sets"
+        label="Armor Sets"
         selectionCount={values.length}
         className={stowedSubTriggerClass}
       />

--- a/src/components/workspace/saved-views-menu.tsx
+++ b/src/components/workspace/saved-views-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { CaretDown, Plus, X } from "@phosphor-icons/react/dist/ssr";
+import { BookmarkSimple, CaretDown, Plus, X } from "@phosphor-icons/react/dist/ssr";
 import type { SavedFilterViewRow } from "@/lib/db/types";
 import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
 import {
@@ -43,6 +43,8 @@ export interface SavedViewsMenuProps {
   onClearActive: () => void;
   className?: string;
   variant?: "inline" | "stowed";
+  /** Inline only — icon-only trigger for narrow bars (mirrors search collapse). */
+  compact?: boolean;
   /** Inline only — wrapper visibility (e.g. container-query hide). */
   inlineWrapperClass?: string;
   /** Stowed only — sub-trigger visibility inside the aggregate Filters menu. */
@@ -63,6 +65,7 @@ export function SavedViewsMenu({
   onClearActive,
   className,
   variant = "inline",
+  compact = false,
   inlineWrapperClass = "",
   stowedSubTriggerClass = "",
 }: SavedViewsMenuProps) {
@@ -258,29 +261,41 @@ export function SavedViewsMenu({
             <Button
               type="button"
               variant="outline"
-              aria-label="Saved views"
+              aria-label={activeView ? `Saved views — ${activeView.name}` : "Saved views"}
+              title={compact && activeView ? activeView.name : undefined}
               className={cn(
-                "group/saved-views-trigger h-9 shrink-0 gap-1.5 rounded-none px-3 text-xs focus-visible:ring-0 focus-visible:ring-offset-0",
+                "group/saved-views-trigger h-9 shrink-0 gap-1.5 rounded-none text-xs focus-visible:ring-0 focus-visible:ring-offset-0",
+                compact ? "size-9 px-0" : "px-3",
                 activeView
                   ? "border-primary/60 bg-primary/10 font-medium text-foreground hover:border-primary/70 hover:bg-primary/20 hover:text-foreground data-[state=open]:border-primary/60 data-[state=open]:bg-primary/10 data-[state=open]:text-foreground"
                   : "data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
                 className,
               )}
             >
-              <span className="max-w-[10rem] truncate text-left">
-                {triggerLabel}
-              </span>
-              {activeView ? (
-                <span aria-hidden className="inline-block w-5 shrink-0" />
-              ) : null}
-              <CaretDown
-                weight="duotone"
-                aria-hidden
-                className="!size-3.5 shrink-0 opacity-60 transition group-hover/saved-views-trigger:opacity-90 group-data-[state=open]/saved-views-trigger:rotate-180"
-              />
+              {compact ? (
+                <BookmarkSimple
+                  weight={activeView ? "fill" : "regular"}
+                  aria-hidden
+                  className="!size-4 shrink-0"
+                />
+              ) : (
+                <>
+                  <span className="max-w-[10rem] truncate text-left">
+                    {triggerLabel}
+                  </span>
+                  {activeView ? (
+                    <span aria-hidden className="inline-block w-5 shrink-0" />
+                  ) : null}
+                  <CaretDown
+                    weight="duotone"
+                    aria-hidden
+                    className="!size-3.5 shrink-0 opacity-60 transition group-hover/saved-views-trigger:opacity-90 group-data-[state=open]/saved-views-trigger:rotate-180"
+                  />
+                </>
+              )}
             </Button>
           </DropdownMenuTrigger>
-          {activeView ? (
+          {!compact && activeView ? (
             <button
               type="button"
               aria-label="Clear saved view"

--- a/src/components/workspace/tracker-filter-bar.stories.tsx
+++ b/src/components/workspace/tracker-filter-bar.stories.tsx
@@ -6,6 +6,11 @@ import {
   MOCK_GRID_FILTERS_EMPTY,
   MOCK_GRID_FILTERS_POPULATED,
 } from "../../../.storybook/mocks/grid-filters";
+import {
+  MOCK_SAVED_FILTER_VIEW_OWNED,
+  MOCK_SAVED_FILTER_VIEW_SHARED,
+} from "../../../.storybook/mocks/saved-filter-views";
+import type { SavedViewsBarProps } from "./saved-views-menu";
 import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
 
 const meta: Meta<typeof TrackerFilterBar> = {
@@ -21,14 +26,30 @@ function Render({
   initial,
   showTertiaryStatFilter = true,
   showRarityFilter = false,
+  withSavedViews = true,
   width = 960,
 }: {
   initial: GridFiltersJson;
   showTertiaryStatFilter?: boolean;
   showRarityFilter?: boolean;
+  withSavedViews?: boolean;
   width?: number;
 }) {
   const [value, setValue] = useState<GridFiltersJson>(initial);
+  const [views, setViews] = useState([
+    MOCK_SAVED_FILTER_VIEW_OWNED,
+    MOCK_SAVED_FILTER_VIEW_SHARED,
+  ]);
+  const savedViews: SavedViewsBarProps | undefined = withSavedViews
+    ? {
+        views,
+        activeViewId: null,
+        filters: value,
+        onViewsChange: setViews,
+        onApply: () => {},
+        onClearActive: () => {},
+      }
+    : undefined;
   return (
     <div className="border border-border bg-card px-3" style={{ width }}>
       <TrackerFilterBar
@@ -41,6 +62,7 @@ function Render({
         resultNoun={{ singular: "tracker", plural: "trackers" }}
         showTertiaryStatFilter={showTertiaryStatFilter}
         showRarityFilter={showRarityFilter}
+        savedViews={savedViews}
       />
     </div>
   );

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -79,7 +79,6 @@ export function TrackerFilterBar({
   const [setsOpen, setSetsOpen] = useState(false);
   const searchExpanded = searchUiOpen || value.search.trim().length > 0;
   const collapseTier = useFilterBarCollapseTier(barRef);
-  const savedViewsInline = collapseTier !== "filters-menu";
 
   const sortedSets = useMemo(
     () => selectors.setsByClass[value.class],
@@ -202,8 +201,9 @@ export function TrackerFilterBar({
     onToggleTuning: toggleTuning,
     onToggleStat: toggleStat,
     onSwitchRarity: switchRarity,
-    savedViews:
-      collapseTier === "filters-menu" ? savedViews : undefined,
+    // Saved views lives permanently in the right-hand action cluster, so it is
+    // never stowed into the left "Filters" overflow menu.
+    savedViews: undefined,
   };
 
   return (
@@ -235,13 +235,6 @@ export function TrackerFilterBar({
       </div>
 
       <div aria-hidden className="h-6 w-px shrink-0 self-center bg-border" />
-
-      {savedViews && savedViewsInline ? (
-        <SavedViewsMenu
-          {...savedViews}
-          inlineWrapperClass={FILTER_INLINE_CORE}
-        />
-      ) : null}
 
       {showRarityFilter ? (
         <RarityFilterDimension
@@ -314,6 +307,21 @@ export function TrackerFilterBar({
         {resultCount === 1 ? resultNoun.singular : resultNoun.plural} for{" "}
         {CLASS_NAMES[value.class] ?? "class"}.
       </p>
+
+      {savedViews ? (
+        <>
+          {collapseTier === "filters-menu" ? null : (
+            <div
+              aria-hidden
+              className="h-6 w-px shrink-0 self-center bg-border"
+            />
+          )}
+          <SavedViewsMenu
+            {...savedViews}
+            compact={collapseTier === "filters-menu"}
+          />
+        </>
+      ) : null}
 
       <ShareFilterLinkButton
         filters={value}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Takes a pass on the shared `TrackerFilterBar` (used by both the table and grid views) to improve layout and responsiveness:

- **Saved views + share moved to the right.** The saved-views menu and the share-link button now sit on the right edge of the bar (grouped with search), while the class tabs and all filter dimensions stay on the left. A divider separates the left filters from the right-hand actions.
- **"Sets" → "Armor Sets".** The inline armor-sets filter trigger now reads "Armor Sets" (it previously said just "Sets"); the stowed/overflow variant copy is aligned to match.
- **Responsive on smaller screens.** Saved views is no longer stowed into the left "Filters" overflow menu. Instead, at the narrowest container tier it collapses to an icon-only trigger (a bookmark icon, mirroring how search collapses to a magnifier), so the right-hand actions stay visible and the search icon is no longer clipped on narrow bars.

## Layout

```
[ Titan Hunter Warlock ] | [ Armor Sets ] [ Archetypes ] [ Tunings ] [ Tertiary ]   …count…   | [ Views ] [ 🔗 ] [ 🔍 ]
```

At the narrowest tier the left filters collapse into a single **Filters** menu and saved views becomes a bookmark icon:

```
[ Titan Hunter Warlock ]  [ ⚙ Filters ]   [ 🔖 ] [ 🔗 ] [ 🔍 ]
```

## Verification

- `npm run lint` — no new issues in changed files (pre-existing errors in `stub-server-only.cjs` and `inventory-auto-sync.tsx` are unrelated).
- `npm run build` — passes.
- `npx vitest run --project=storybook tracker-filter-bar` — 8/8 interaction + a11y tests pass.
- Verified visually via Storybook screenshots at wide (1240px), mid (1000px), and narrow (480px) widths; confirmed the search icon stays within bounds at 480px after the compact collapse.

## Notes

- `TrackerFilterBar` is shared between the table and grid views, so these changes apply to both for consistency.
- The story was updated to wire up the existing saved-views mock fixtures so the new right-hand cluster is exercised by the story tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-093a6c01-6baf-4b5f-898b-e724f36f6215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-093a6c01-6baf-4b5f-898b-e724f36f6215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

