### PR TITLE
Improve table view armor set search (fuzzy, primary placement)

### DIFF
--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -222,6 +222,8 @@ export function InventoryTableView({
                             plural: "pieces",
                           }}
                           showRarityFilter
+                          searchPlacement="start"
+                          searchDefaultExpanded
                           savedViews={savedViews}
                         />
                       </TableHead>

--- a/src/components/workspace/tracker-filter-bar.stories.tsx
+++ b/src/components/workspace/tracker-filter-bar.stories.tsx
@@ -26,12 +26,16 @@ function Render({
   initial,
   showTertiaryStatFilter = true,
   showRarityFilter = false,
+  searchPlacement,
+  searchDefaultExpanded,
   withSavedViews = true,
   width = 960,
 }: {
   initial: GridFiltersJson;
   showTertiaryStatFilter?: boolean;
   showRarityFilter?: boolean;
+  searchPlacement?: "start" | "end";
+  searchDefaultExpanded?: boolean;
   withSavedViews?: boolean;
   width?: number;
 }) {
@@ -62,6 +66,8 @@ function Render({
         resultNoun={{ singular: "tracker", plural: "trackers" }}
         showTertiaryStatFilter={showTertiaryStatFilter}
         showRarityFilter={showRarityFilter}
+        searchPlacement={searchPlacement}
+        searchDefaultExpanded={searchDefaultExpanded}
         savedViews={savedViews}
       />
     </div>
@@ -115,5 +121,18 @@ export const NarrowFullFilters: Story = {
 export const InventoryTableWithRarity: Story = {
   render: () => (
     <Render initial={MOCK_GRID_FILTERS_POPULATED} showRarityFilter width={1200} />
+  ),
+};
+
+/** Table view: primary set search leftmost and expanded by default. */
+export const InventoryTableSearchPrimary: Story = {
+  render: () => (
+    <Render
+      initial={MOCK_GRID_FILTERS_EMPTY}
+      showRarityFilter
+      searchPlacement="start"
+      searchDefaultExpanded
+      width={1200}
+    />
   ),
 };

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -57,6 +57,9 @@ interface TrackerFilterBarProps {
   resultNoun: ResultNoun;
   showTertiaryStatFilter?: boolean;
   showRarityFilter?: boolean;
+  /** Table view: search is the primary control — leftmost and always visible. */
+  searchPlacement?: "start" | "end";
+  searchDefaultExpanded?: boolean;
   savedViews?: SavedViewsBarProps;
   className?: string;
 }
@@ -71,14 +74,23 @@ export function TrackerFilterBar({
   resultNoun,
   showTertiaryStatFilter = true,
   showRarityFilter = false,
+  searchPlacement = "end",
+  searchDefaultExpanded = false,
   savedViews,
   className,
 }: TrackerFilterBarProps) {
   const barRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const [searchUiOpen, setSearchUiOpen] = useState(false);
+  const [searchUiOpen, setSearchUiOpen] = useState(searchDefaultExpanded);
   const [setsOpen, setSetsOpen] = useState(false);
-  const searchExpanded = searchUiOpen || value.search.trim().length > 0;
+  const searchExpanded =
+    searchDefaultExpanded ||
+    searchUiOpen ||
+    value.search.trim().length > 0;
+  const searchPlaceholder =
+    searchPlacement === "start"
+      ? "Search sets (e.g. ferro smoke)"
+      : "Search armor";
   const collapseTier = useFilterBarCollapseTier(barRef);
 
   const sortedSets = useMemo(
@@ -186,6 +198,75 @@ export function TrackerFilterBar({
     ? inventoryFiltersHaveShareableSelection(value)
     : gridFiltersHaveUnblockingSelection(value);
 
+  const searchField = searchExpanded ? (
+    <div
+      role="search"
+      className={cn(
+        "relative -my-2 min-h-[60px] min-w-0",
+        searchPlacement === "start"
+          ? "w-44 shrink-0 sm:w-52 lg:w-60"
+          : "lg:max-w-xs",
+      )}
+    >
+      <MagnifyingGlass
+        weight="regular"
+        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        aria-hidden
+      />
+      <input
+        ref={searchInputRef}
+        type="search"
+        value={value.search}
+        onChange={(e) => onChange({ ...value, search: e.target.value })}
+        placeholder={searchPlaceholder}
+        aria-label="Search armor sets"
+        onBlur={() => {
+          if (!searchDefaultExpanded && !value.search.trim()) {
+            setSearchUiOpen(false);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (e.key !== "Escape") return;
+          if (value.search.trim()) {
+            onChange({ ...value, search: "" });
+          } else if (!searchDefaultExpanded) {
+            setSearchUiOpen(false);
+            e.currentTarget.blur();
+          }
+        }}
+        className="h-[60px] w-full min-w-0 border-0 border-b border-white bg-transparent py-0 ps-9 pe-9 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/80 focus-visible:border-b focus-visible:border-white focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-search-cancel-button]:hidden"
+      />
+      {value.search ? (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onPointerDown={(e) => e.preventDefault()}
+          onClick={() => onChange({ ...value, search: "" })}
+          className="absolute right-2 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <X weight="bold" className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      ) : null}
+    </div>
+  ) : (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label="Search armor sets"
+      aria-expanded={searchExpanded}
+      className="size-9 shrink-0 self-center rounded-none border-0 shadow-none hover:bg-accent/50"
+      onClick={() => {
+        setSearchUiOpen(true);
+        queueMicrotask(() =>
+          searchInputRef.current?.focus({ preventScroll: true }),
+        );
+      }}
+    >
+      <MagnifyingGlass weight="regular" aria-hidden className="size-4" />
+    </Button>
+  );
+
   const overflowProps = {
     collapseTier,
     value,
@@ -223,6 +304,10 @@ export function TrackerFilterBar({
         className,
       )}
     >
+      {searchPlacement === "start" ? (
+        <div className="shrink-0">{searchField}</div>
+      ) : null}
+
       <div className={cn(chromeToolbarShellClass, "min-w-0")} role="group" aria-label="Class">
         {CLASS_TABS.map((tab, index) => (
           <button
@@ -329,69 +414,9 @@ export function TrackerFilterBar({
         className="size-9 shrink-0 rounded-none"
       />
 
-      <div className="ml-auto min-w-0">
-        {searchExpanded ? (
-          <div
-            role="search"
-            className="relative -my-2 min-h-[60px] min-w-0 lg:max-w-xs"
-          >
-            <MagnifyingGlass
-              weight="regular"
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-              aria-hidden
-            />
-            <input
-              ref={searchInputRef}
-              type="search"
-              value={value.search}
-              onChange={(e) => onChange({ ...value, search: e.target.value })}
-              placeholder="Search armor"
-              aria-label="Search armor"
-              onBlur={() => {
-                if (!value.search.trim()) setSearchUiOpen(false);
-              }}
-              onKeyDown={(e) => {
-                if (e.key !== "Escape") return;
-                if (value.search.trim()) {
-                  onChange({ ...value, search: "" });
-                } else {
-                  setSearchUiOpen(false);
-                  e.currentTarget.blur();
-                }
-              }}
-              className="h-[60px] w-full min-w-0 border-0 border-b border-white bg-transparent py-0 ps-9 pe-9 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/80 focus-visible:border-b focus-visible:border-white focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-search-cancel-button]:hidden"
-            />
-            {value.search ? (
-              <button
-                type="button"
-                aria-label="Clear search"
-                onPointerDown={(e) => e.preventDefault()}
-                onClick={() => onChange({ ...value, search: "" })}
-                className="absolute right-2 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              >
-                <X weight="bold" className="h-3.5 w-3.5" aria-hidden />
-              </button>
-            ) : null}
-          </div>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="Search armor"
-            aria-expanded={searchExpanded}
-            className="size-9 shrink-0 self-center rounded-none border-0 shadow-none hover:bg-accent/50"
-            onClick={() => {
-              setSearchUiOpen(true);
-              queueMicrotask(() =>
-                searchInputRef.current?.focus({ preventScroll: true }),
-              );
-            }}
-          >
-            <MagnifyingGlass weight="regular" aria-hidden className="size-4" />
-          </Button>
-        )}
-      </div>
+      {searchPlacement === "end" ? (
+        <div className="ml-auto min-w-0 shrink-0">{searchField}</div>
+      ) : null}
     </div>
   );
 }

--- a/src/lib/filters/filter-inventory.ts
+++ b/src/lib/filters/filter-inventory.ts
@@ -1,9 +1,9 @@
-import {
-  SLOT_LABELS,
-  SLOT_ORDER,
-  type ArmorSlot,
-} from "@/lib/bungie/constants";
+import { SLOT_ORDER, type ArmorSlot } from "@/lib/bungie/constants";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import {
+  inventoryPieceMatchesSetSearch,
+  tokenizeInventorySearchQuery,
+} from "@/lib/filters/inventory-set-search";
 import type { GridFiltersJson } from "@/lib/workspace/grid-filters-schema";
 
 function slotRank(slot: ArmorSlot): number {
@@ -48,21 +48,11 @@ export function filterInventoryPieces(
       (p) => p.tertiaryStat != null && allowed.has(p.tertiaryStat),
     );
   }
-  const trimmedSearch = filters.search.trim().toLowerCase();
-  if (trimmedSearch) {
-    rows = rows.filter((p) => {
-      const haystack = [
-        inventoryPieceDisplayName(p),
-        p.archetypeName,
-        p.tuningName,
-        p.tertiaryStat,
-        SLOT_LABELS[p.slot],
-      ]
-        .filter((v): v is string => Boolean(v))
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(trimmedSearch);
-    });
+  const searchTokens = tokenizeInventorySearchQuery(filters.search);
+  if (searchTokens.length > 0) {
+    rows = rows.filter((p) =>
+      inventoryPieceMatchesSetSearch(p, searchTokens),
+    );
   }
   return [...rows].sort((a, b) => {
     const sd = slotRank(a.slot) - slotRank(b.slot);

--- a/src/lib/filters/inventory-set-search.test.ts
+++ b/src/lib/filters/inventory-set-search.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  inventoryPieceMatchesSetSearch,
+  looseInventoryNameMatch,
+  tokenizeInventorySearchQuery,
+} from "@/lib/filters/inventory-set-search";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+
+function piece(displayName: string): DerivedArmorPieceJson {
+  return {
+    itemInstanceId: "x",
+    itemHash: 1,
+    slot: "helmet",
+    classType: 0,
+    setHash: 1,
+    setName: displayName,
+    displayName,
+    location: { kind: "vault" },
+  };
+}
+
+describe("tokenizeInventorySearchQuery", () => {
+  it("splits on whitespace and lowercases", () => {
+    expect(tokenizeInventorySearchQuery("  Ferro   Smoke ")).toEqual([
+      "ferro",
+      "smoke",
+    ]);
+  });
+});
+
+describe("looseInventoryNameMatch", () => {
+  it("matches prefix substrings", () => {
+    expect(looseInventoryNameMatch("ferro", "Ferropotent")).toBe(true);
+    expect(looseInventoryNameMatch("smoke", "Smokejumper")).toBe(true);
+  });
+
+  it("matches ordered subsequence for partial typing", () => {
+    expect(looseInventoryNameMatch("frpot", "Ferropotent")).toBe(true);
+  });
+
+  it("rejects unrelated names", () => {
+    expect(looseInventoryNameMatch("ferro", "Smokejumper")).toBe(false);
+  });
+});
+
+describe("inventoryPieceMatchesSetSearch", () => {
+  it("ORs tokens across display names", () => {
+    const ferro = piece("Ferropotent");
+    const smoke = piece("Smokejumper");
+    const other = piece("Iron Will Suit");
+    const tokens = tokenizeInventorySearchQuery("ferro smoke");
+    expect(inventoryPieceMatchesSetSearch(ferro, tokens)).toBe(true);
+    expect(inventoryPieceMatchesSetSearch(smoke, tokens)).toBe(true);
+    expect(inventoryPieceMatchesSetSearch(other, tokens)).toBe(false);
+  });
+});

--- a/src/lib/filters/inventory-set-search.ts
+++ b/src/lib/filters/inventory-set-search.ts
@@ -1,0 +1,55 @@
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+
+function pieceDisplayName(piece: DerivedArmorPieceJson): string | null {
+  return piece.displayName ?? piece.setName ?? null;
+}
+
+/** Split a search box value into lowercase tokens (whitespace-separated). */
+export function tokenizeInventorySearchQuery(query: string): string[] {
+  return query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+/** Strip punctuation so "smoke-jumper" and "smokejumper" align. */
+export function normalizeInventorySearchText(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+/**
+ * Loose match for armor set / display names: normalized substring, then
+ * ordered subsequence (typo-tolerant partial typing).
+ */
+export function looseInventoryNameMatch(
+  token: string,
+  displayName: string,
+): boolean {
+  const t = normalizeInventorySearchText(token);
+  const n = normalizeInventorySearchText(displayName);
+  if (t.length === 0) return true;
+  if (n.length === 0) return false;
+  if (n.includes(t)) return true;
+
+  let ti = 0;
+  for (let ni = 0; ni < n.length && ti < t.length; ni++) {
+    if (n[ni] === t[ti]) ti++;
+  }
+  return ti === t.length;
+}
+
+/**
+ * Table search: each whitespace token must match the piece display name (set or
+ * exotic item name). Tokens combine with OR — "ferro smoke" surfaces both
+ * Ferropotent and Smokejumper rows. Other grid filters still AND on top.
+ */
+export function inventoryPieceMatchesSetSearch(
+  piece: DerivedArmorPieceJson,
+  tokens: readonly string[],
+): boolean {
+  if (tokens.length === 0) return true;
+  const name = pieceDisplayName(piece);
+  if (!name) return false;
+  return tokens.some((token) => looseInventoryNameMatch(token, name));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,8 +12,21 @@ const dirname =
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.join(dirname, 'src'),
+    },
+  },
   test: {
     projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          include: ['src/**/*.test.ts'],
+          environment: 'node',
+        },
+      },
       {
         extends: true,
         plugins: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves inventory **table view** search so it behaves like a primary filter control and matches armor **set names** loosely.

## UX changes (table view only)

- **Search is leftmost** on the filter bar (before class tabs and dimension filters).
- **Search stays expanded** by default (no magnifying-glass collapse step).
- Placeholder hints multi-set discovery: `Search sets (e.g. ferro smoke)`.
- Grid view keeps the previous end-aligned, collapsible search.

## Search behavior

- Queries split on whitespace into **tokens** (e.g. `ferro smoke` → `ferro`, `smoke`).
- Tokens match the piece **display name** (legendary set name or exotic item name) with **OR** semantics — any token match includes the row.
- **Loose matching** per token:
  - Normalized substring (punctuation-insensitive)
  - Ordered **subsequence** fallback for partial / typo-tolerant typing
- Example: `ferro smoke` returns Ferropotent and Smokejumper pieces; users can still narrow with set/archetype/tuning/rarity filters (AND with the existing pipeline).
- `useDeferredValue` on search input is unchanged for responsive typing.

## Implementation

- New `src/lib/filters/inventory-set-search.ts` (pure matching helpers).
- `filter-inventory.ts` uses set-focused token search instead of a single haystack substring across archetype/tuning/slot.
- `TrackerFilterBar` gains `searchPlacement` and `searchDefaultExpanded` props; table passes `start` + expanded.
- Unit tests in `inventory-set-search.test.ts`; Vitest **unit** project added alongside Storybook tests.

## How to verify

1. Open dashboard → table view.
2. Confirm search field is visible on the **left** of the filter bar.
3. Type `ferro smoke` (with inventory containing those sets) — both sets should appear.
4. Add archetype/set filters — results should intersect with search.
5. `npm exec vitest -- --project=unit --run`

## Notes

- Search still persists in `grid_filters` and share links (`?f=`); saved named views still exclude search (unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a43696f-c360-411c-9039-0a20f6a768ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a43696f-c360-411c-9039-0a20f6a768ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

