### PR TITLE
Fix optimizer stat verification and slider achievable ranges

### DIFF
--- a/.storybook/mocks/armor-pieces.ts
+++ b/.storybook/mocks/armor-pieces.ts
@@ -13,15 +13,15 @@ const TUNE = MOCK_TUNINGS[0]!;
 const CHAR_TITAN = "char-titan-01";
 const CHAR_HUNTER = "char-hunter-01";
 
-/** Tier-5 style totals: +30 / +25 / +20 plugs plus +Weapons / -Grenade tuning. */
+/** Tier-5 style totals: +30 / +25 / +20 plugs plus +5 / −5 tuning. */
 function mockStatTotals(
   tertiary: ArmorStatName,
 ): Partial<Record<ArmorStatName, number>> {
   return {
-    Weapons: 40,
+    Weapons: 35,
     Health: 25,
     [tertiary]: 20,
-    Grenade: -10,
+    Grenade: -5,
   };
 }
 

--- a/docs/optimizer-stat-calculation-fix-handoff.md
+++ b/docs/optimizer-stat-calculation-fix-handoff.md
@@ -1,0 +1,317 @@
+# Handoff: Optimizer shows impossible build totals
+
+**Status:** Open — investigation complete; implementation not started.  
+**Last updated:** 2026-05-31  
+**Repo:** `armorset-checklist`  
+**Related:** [loadout-optimizer-handoff.md](./loadout-optimizer-handoff.md), [optimizer-exotic-bounds-bug-handoff.md](./optimizer-exotic-bounds-bug-handoff.md)
+
+---
+
+## 1. Bug summary (give this to the new agent)
+
+The Optimize tab returns builds with **stat totals that cannot exist in-game** — e.g. **674 total** with Mobility/Weapons at **200**, when five Tier 5 pieces + five +10 mods should cap around **~425** armor+mod points (375 intrinsics + 50 mod budget, plus fragments).
+
+Two independent bugs inflate numbers:
+
+1. **Assumed mod budget is duplicated per target stat** — five major mods (+50 total) are applied **to every stat with min > 0**, not once across the build.
+2. **Tuning is summed via per-stat ceilings** — `getPieceStatCeiling()` takes the max of each stat across debuff variants independently, which **drops mandatory −5 penalties** (only the debuff target varies; the +5 stat is fixed at drop).
+
+Search stores these inflated totals in `solution.totals` and `OptimizerResultCard` displays them unchanged.
+
+---
+
+## 2. Reproduction
+
+1. Sign in → `/dashboard` → **Optimize** tab.
+2. Select class (e.g. Warlock), lock an exotic (e.g. Speaker's Sight).
+3. Set stat targets on **multiple stats** (e.g. 200 / 50 / 50 / 100 / 50 / 100).
+4. **Assumed stat mods:** Major count = **5**, minor unchecked.
+5. Require two armor sets (REQ), run optimizer.
+6. Observe results with **total ~650–700** and individual stats at or above targets despite piece rows not supporting the math.
+
+**Expected after fix:** No result whose verified totals exceed physical limits; total sum roughly ≤ ~425 + fragment bonus (order-of-magnitude sanity check).
+
+---
+
+## 3. Domain rules (do not re-litigate)
+
+### 3.1 Stat scale
+
+- UI uses **raw Armor 3.0 point totals** on a **0–200** slider (`OPTIMIZER_STAT_MAX` in `src/lib/optimizer/stat-range.ts`). This is intentional (DIM/D2ArmorPicker-style), not pre-3.0 tiers.
+- Each piece contributes ~50–80 points from intrinsics + tuning; five pieces ≈ **250–400** before mods.
+
+### 3.2 Tuning (critical)
+
+Each armor piece has a **predetermined tuning direction at drop** (e.g. `+Weapons`). Whether the tuning mod is **committed** (slotted) or **uncommitted** (empty socket) does **not** change the boost direction.
+
+- **Fixed at drop:** +5 on one stat (from `tuningName` / `tuningHash`, e.g. `+Weapons`).
+- **Player choice (only when uncommitted):** which stat takes **−5** among ~5 reusable plugs that share the same +stat.
+- **Committed:** exact +5/−5 pair in `statTotals`; no branching needed.
+- **Uncommitted:** `tuningVariants[]` holds full stat maps per debuff option; **same +5 stat every time**, different −5 target.
+
+**Wrong model (current ceiling):** max each stat across variants → can show 0 penalty on Grenade and 0 on Melee simultaneously.  
+**Correct model:** pick **exactly one** variant per uncommitted piece (one −5 somewhere).
+
+Reference: `src/lib/inventory/derive.ts` lines 196–263, comments on reusable plugs.
+
+### 3.3 Assumed stat mods
+
+- Up to **5 major** mods (+10 each) = **+50 total** across the whole loadout (one mod slot per armor piece).
+- Optional **minor** mods: +5 per piece = +25 total if all five use minor (see `AssumedStatModsPanel` copy).
+- Mod budget is a **shared pool**, not per target stat.
+- UI copy: “+50 on target stats” means the pool applies toward stats with mins, **not** +50 on each stat (`assumed-stat-mods-panel.tsx`).
+
+### 3.4 Subclass fragments
+
+- Flat per-stat offset via `computeFragmentStatOffset()` — already correct; keep as additive input to verification.
+
+---
+
+## 4. Current calculation pipeline
+
+```
+loadout-optimizer-view.tsx
+  fragmentStatOffset + modStatOffset → statOffset
+  optimizerRequest { pool, constraints, statOffset, ... }
+       ↓
+search.ts (Web Worker: process.worker.ts)
+  startTotals = statOffset
+  for each of 5 pieces: startTotals[stat] += getPieceStatCeiling(piece, stat)
+  if satisfiesConstraints(startTotals) → push { totals: startTotals }
+       ↓
+optimizer-result-card.tsx
+  displays solution.totals (sum for “Total” footer)
+```
+
+| Step | File | Issue |
+|------|------|--------|
+| Mod offset | `mod-offset.ts` + `loadout-optimizer-view.tsx` | `computeAssumedModStatOffset(..., activeTargetStats)` sets full budget on **each** active target |
+| Piece sum | `search.ts`, `bounds.ts` | Uses `getPieceStatCeiling` for totals, not verified assignment |
+| Display | `optimizer-result-card.tsx` | No recompute from listed pieces |
+| Constraints | `constraints.ts` | `satisfiesConstraints` only checks per-stat min/max; no total-sum or mod-pool check |
+
+**Note:** `totalsFromPieces()` in `constraints.ts` correctly uses `getPieceStatValue()` (committed roll) but search **does not use it** for final solutions.
+
+---
+
+## 5. Target architecture
+
+Introduce a single verification module used by **search** (accept/reject + final totals) and **bounds** (achievable bands):
+
+```
+src/lib/optimizer/resolve-loadout-totals.ts   (new)
+```
+
+### 5.1 Public API (suggested)
+
+```ts
+type AssumedStatMods = import("./mod-offset").AssumedStatMods;
+
+/** One debuff branch for an uncommitted piece. */
+type TuningAssignment = Partial<Record<ArmorStatName, number>>; // full stat map
+
+export type ResolvedLoadout = {
+  totals: Record<ArmorStatName, number>;
+  /** Per slot: which tuning branch was used (undefined = committed statTotals). */
+  tuningBySlot?: Partial<Record<OptimizerSlotKey, TuningAssignment>>;
+  /** How many +10 / +5 mods placed on each stat (sum of major ≤ majorCount). */
+  modAllocation?: Partial<Record<ArmorStatName, number>>;
+};
+
+/** Returns null if no valid tuning + mod assignment satisfies constraints. */
+export function resolveLoadoutTotals(
+  pieces: DerivedArmorPieceJson[],           // length 5, slot order
+  constraints: StatConstraintRow[],
+  fragmentOffset: Partial<Record<ArmorStatName, number>>,
+  assumedMods: AssumedStatMods,
+): ResolvedLoadout | null;
+```
+
+### 5.2 Resolution algorithm (sketch)
+
+1. **Armor base:** For each piece, start from `getPieceStatValue()` if committed; if uncommitted, iterate `tuningVariants` (include `statTotals` as one candidate). Each candidate is a full `Partial<Record<ArmorStatName, number>>` — **do not** merge per-stat max across candidates.
+
+2. **Combine five pieces:** Sum chosen branch per piece → `armorTotals`.
+
+3. **Add fragments:** `addStatOffsets(armorTotals, fragmentOffset)`.
+
+4. **Allocate mods (finite pool):**
+   - `majorSlots = assumedMods.majorCount` (0–5), each grants +10 to one stat.
+   - `minorPool = assumedMods.minor ? 5 * 5 : 0` (+5 per piece, same stacking rules as today’s `mod-offset.ts`).
+   - Greedy or small LP: assign mods to satisfy active `constraints` (mins), prefer stats in constraint priority order, minimize waste. If any active min still unmet → `null`.
+   - **Only stats with active mins** may receive assumed mods (matches UI intent).
+
+5. **Validate:** `satisfiesConstraints(finalTotals, constraints)` and all stats ≥ 0.
+
+6. **Search over tuning:** ≤5 pieces × ≤~5 variants → ≤3125 combos worst case; cheap at end of search only (not per branch during enumeration). Use greedy debuff pick first; fall back to full small cross-product if needed.
+
+### 5.3 What stays optimistic (pruning only)
+
+`getPieceStatCeiling` may remain in `partialCanReachMins` **only if** pruning is updated to not assume zero debuffs. Safer approach for Phase 1:
+
+- **Pruning:** use per-slot max of `getPieceStatValue` + fixed +5 on predetermined tuning stat (ignore debuff for upper bound on boosted stat; for other stats use value without counting −5 as 0).
+- **Acceptance:** always call `resolveLoadoutTotals`.
+
+Document in code comments that ceiling-based pruning can be loose (explores extra branches) but must not be used for `solution.totals`.
+
+---
+
+## 6. Implementation plan (phased)
+
+### Phase 0 — Fix mod offset API (blocking, small)
+
+**Goal:** Stop adding +50 to every target stat before search runs.
+
+**Files:**
+- `src/lib/optimizer/mod-offset.ts`
+- `src/lib/optimizer/mod-offset.test.ts`
+- `src/components/dashboard/loadout-optimizer-view.tsx`
+
+**Changes:**
+1. Change `computeAssumedModStatOffset` so it returns the **total pool size** in a shape usable by verification, **not** duplicated per stat. Suggested:
+   - Export `totalAssumedModBudget(assumedMods): { majorTotal: number; minorTotal: number }`.
+   - Remove or deprecate applying `total` to every entry in `targetStats`.
+   - View layer: stop merging mod offset into `statOffset` for search; pass `assumedStatMods` on `OptimizerRequest` instead (add field to `types.ts`).
+
+2. Keep **fragments-only** in `statOffset` on the request (rename comment for clarity).
+
+3. Update `AssumedStatModsPanel` helper text if needed (“+50 total toward target stats”).
+
+**Tests:**
+- 4 active targets + majorCount 5 → total mod points available = **50**, not 200.
+- majorCount 3 + minor true → 30 + 25 = **55** total pool.
+
+**Verify:** Unit tests pass; manually confirm `statOffset` no longer adds +50 to every stat in devtools/logging.
+
+---
+
+### Phase 1 — `resolveLoadoutTotals` + search verification (core fix)
+
+**Goal:** Only emit solutions that pass verification; store verified totals.
+
+**Files:**
+- `src/lib/optimizer/resolve-loadout-totals.ts` (new)
+- `src/lib/optimizer/resolve-loadout-totals.test.ts` (new)
+- `src/lib/optimizer/types.ts` — add `assumedStatMods?: AssumedStatMods` to `OptimizerRequest`; optional `resolved?: ResolvedLoadout` on `OptimizerSolution`
+- `src/lib/optimizer/search.ts`
+- `src/lib/optimizer/search.test.ts`
+- `src/components/dashboard/loadout-optimizer-view.tsx` — pass `assumedStatMods` on request
+- `src/lib/optimizer/process.worker.ts` — no logic change if request shape updated
+
+**Changes:**
+1. Implement `resolveLoadoutTotals` per §5.2.
+2. In `searchLoadouts`, when `slotIndex >= SLOT_ORDER.length` and set/exotic checks pass:
+   - Call `resolveLoadoutTotals(chosen, constraints, fragmentOffset, assumedMods)`.
+   - If `null`, return (do not push candidate).
+   - Push `{ slots, totals: resolved.totals, signature, interchangeable, ... }`.
+3. During enumeration, **stop** adding `getPieceStatCeiling` into `partialTotals` for acceptance; keep a separate partial sum for pruning if desired (Phase 2 can tighten pruning).
+4. Update/remove test `"counts alternate tuning branches toward stat targets"` — replace with test that uncommitted debuff variants produce **verified** totals including exactly one −5 per uncommitted piece.
+
+**Tests (required):**
+| Case | Expect |
+|------|--------|
+| 5× committed pieces, one target, majorCount 5 | Totals = sum(values) + fragments + up to +50 on target |
+| Uncommitted piece, 2 debuff variants | Cannot report totals with **both** debuffs at 0 if one variant has −5 |
+| 6 active targets, majorCount 5 | Total sum **≤** armor sum + 50 + fragments (not +300 mods) |
+| Impossible mins | `resolveLoadoutTotals` → `null`, search returns [] |
+
+**Verify:** Reproduce §2 scenario → no 650+ totals; or zero results if truly impossible.
+
+---
+
+### Phase 2 — Align bounds / slider gray bands
+
+**Goal:** Achievable min/max bars use same mod + tuning rules as search.
+
+**Files:**
+- `src/lib/optimizer/bounds.ts`
+- `src/lib/optimizer/bounds.test.ts`
+- `src/lib/optimizer/use-stat-bounds-for-sliders.ts` (if it passes statOffset)
+
+**Changes:**
+1. Thread `assumedStatMods` into bounds functions (same as search).
+2. Replace independent-stat max that adds duplicated mod offset with calls to `resolveLoadoutTotals` or a cheaper **`maxAchievableForStat(constraints, exceptStat)`** helper sharing mod/tuning logic.
+3. `jointStatBounds` / `computeHeuristicConstrainedStatBounds` should not sum ceilings into displayed bounds without verification.
+
+**Verify:** Gray band max for a stat ≤ verified max from Phase 1 on same pool.
+
+---
+
+### Phase 3 — UI clarity (optional but recommended)
+
+**Goal:** User can sanity-check how totals were computed.
+
+**Files:**
+- `src/components/optimizer/optimizer-result-card.tsx`
+- Optional: `assumed-stat-mods-panel.tsx` footer
+
+**Changes:**
+1. If `solution.modAllocation` / tuning assignments exist, show footnote: e.g. “Includes 5× +10 Weapons, 2× +10 Discipline; assumes +Weapons/−Grenade on helmet (uncommitted).”
+2. Consider showing **armor-only subtotal** vs **with mods/fragments** (small text).
+
+**Verify:** Storybook story for `OptimizerResultCard` with resolved metadata; `npm run test-storybook`.
+
+---
+
+## 7. Files reference map
+
+| File | Role |
+|------|------|
+| `src/lib/inventory/compute-stat-totals.ts` | `getPieceStatValue`, `getPieceStatCeiling` — keep ceiling for pruning only |
+| `src/lib/inventory/derive.ts` | Source of `statTotals`, `tuningVariants`, `tuningCommitted` |
+| `src/lib/views/tuning-positive-stat.ts` | `tuningPositiveArmorStat()` — predetermined +5 stat |
+| `src/lib/optimizer/mod-offset.ts` | Mod budget constants + broken offset helper |
+| `src/lib/optimizer/fragment-offset.ts` | Fragment deltas + `addStatOffsets` |
+| `src/lib/optimizer/constraints.ts` | `satisfiesConstraints`, `totalsFromPieces` |
+| `src/lib/optimizer/search.ts` | Enumeration + **must verify before push** |
+| `src/lib/optimizer/bounds.ts` | Slider achievable bands — align in Phase 2 |
+| `src/components/dashboard/loadout-optimizer-view.tsx` | Wires offsets, constraints, worker request |
+| `src/components/optimizer/optimizer-result-card.tsx` | Displays `solution.totals` |
+
+---
+
+## 8. Acceptance criteria
+
+- [ ] No optimizer result where sum of six stats exceeds **armor sum + total mod budget + fragment net** (document formula in test).
+- [ ] Uncommitted pieces: displayed totals reflect **one** debuff variant per piece; never all −5 penalties zero unless pieces truly have no penalty in that branch.
+- [ ] Setting major mod count to 5 with N active target stats does **not** add `50 × N` to the build total.
+- [ ] Existing exotic lock / set bonus / dedupe behavior unchanged (regression: `search.test.ts`, `bounds.test.ts`, `exotic-lock.test.ts`).
+- [ ] `npm run build` and vitest tests for touched files pass.
+- [ ] Manual: §2 reproduction no longer shows ~674 totals.
+
+---
+
+## 9. Non-goals (this handoff)
+
+- Set bonus stat effects (still deferred per product handoff).
+- Masterwork / artifact / weapon stats.
+- Persisted build goals DB.
+- Changing 0–200 slider scale.
+- Rewriting full joint bounds enumeration for billion-combo vaults (heuristic bounds OK if consistent with verify).
+
+---
+
+## 10. Commands
+
+```bash
+npm run lint
+npx vitest run src/lib/optimizer/resolve-loadout-totals.test.ts
+npx vitest run src/lib/optimizer/search.test.ts src/lib/optimizer/mod-offset.test.ts src/lib/optimizer/bounds.test.ts
+npm run build
+npm run dev:http   # manual §2 repro
+npm run storybook  # Phase 3 stories
+```
+
+---
+
+## 11. Suggested first task
+
+**Start Phase 0 + Phase 1:** Fix `computeAssumedModStatOffset` / request shape, implement `resolveLoadoutTotals`, gate `searchLoadouts` on it. That alone fixes the worst user-visible bug (674 totals). Phase 2 can follow in the same PR or a quick follow-up.
+
+Do **not** only clamp display — reject impossible combos at search time so grouped signatures and vault advisor witness sets stay honest.
+
+---
+
+## 12. Context from investigation thread
+
+User confirmed tuning model: **drop determines +5 stat; only −5 target is chosen later.** Prior agent analysis incorrectly described variant choice as affecting boost direction — boost is fixed, debuff varies. Mod duplication bug explains ~250 extra points when six stats have mins > 0 and majorCount = 5 (300 phantom mod points vs 50 real).

--- a/scripts/verify-dim-loadout.ts
+++ b/scripts/verify-dim-loadout.ts
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
   const pieces: DerivedArmorPieceJson[] = [];
 
   for (const row of rows ?? []) {
-    const items = row.items as DerivedArmorPieceJson[];
+    const items = row.items as unknown as DerivedArmorPieceJson[];
     if (!Array.isArray(items)) continue;
     const matched = items.filter((p) => idSet.has(p.itemInstanceId));
     if (matched.length === 0) continue;
@@ -219,7 +219,7 @@ async function main(): Promise<void> {
   let warlockInventory: DerivedArmorPieceJson[] = [];
   for (const row of rows ?? []) {
     if (ownerUserId != null && row.user_id !== ownerUserId) continue;
-    const items = row.items as DerivedArmorPieceJson[];
+    const items = row.items as unknown as DerivedArmorPieceJson[];
     if (!Array.isArray(items)) continue;
     warlockInventory.push(...items.filter((p) => p.classType === classType));
   }

--- a/scripts/verify-dim-loadout.ts
+++ b/scripts/verify-dim-loadout.ts
@@ -1,0 +1,303 @@
+/**
+ * Verify a DIM loadout by instance id against cached inventory (no browser cookie).
+ * Run: npx tsx --tsconfig tsconfig.json scripts/verify-dim-loadout.ts
+ */
+import { loadEnvConfig } from "@next/env";
+import type { DerivedArmorPieceJson } from "../src/lib/db/types";
+
+loadEnvConfig(process.cwd());
+
+const DIM_IDS = [
+  "6917530125283917710",
+  "6917530167771126356",
+  "6917530146795020473",
+  "6917530159911796935",
+  "6917530147186685296",
+];
+
+/** Screenshot targets: Weapons 200, Class 50, Grenade 100, Super 70; Health/Melee unset. */
+const SCREENSHOT_CONSTRAINTS = [
+  { stat: "Weapons" as const, min: 200 },
+  { stat: "Class" as const, min: 50 },
+  { stat: "Grenade" as const, min: 100 },
+  { stat: "Super" as const, min: 70 },
+];
+
+const ASSUMED_MODS_SCREENSHOT = {
+  majorCount: 5,
+  slotFill: true,
+  artifice: true,
+};
+
+async function main(): Promise<void> {
+  const { getServiceRoleClient } = await import("../src/lib/db/server");
+  const { getManifestLookups } = await import("../src/lib/manifest/lookups");
+  const { buildOptimizerLookupPayload } = await import(
+    "../src/lib/views/optimizer-lookup-payload.server"
+  );
+  const { enrichPieceWithExoticBudget } = await import(
+    "../src/lib/inventory/exotic-stat-fallback"
+  );
+  const { verifyLoadout } = await import("../src/lib/optimizer/verify-loadout");
+  const { totalsFromPieces } = await import("../src/lib/optimizer/constraints");
+  const { totalAssumedModBudget } = await import("../src/lib/optimizer/mod-offset");
+  const { countPiecesBySetHash } = await import("../src/lib/optimizer/set-bonus");
+  const { searchLoadouts } = await import("../src/lib/optimizer/search");
+  const { resolveLoadoutTotals } = await import(
+    "../src/lib/optimizer/resolve-loadout-totals"
+  );
+  const { filterOptimizerPool } = await import("../src/lib/optimizer/pool");
+  const { estimateFilteredComboCount } = await import(
+    "../src/lib/optimizer/combo-count"
+  );
+  const { computeStatBounds } = await import("../src/lib/optimizer/bounds");
+  const sb = getServiceRoleClient();
+  const { data: rows, error } = await sb.from("inventory_cache").select("*");
+  if (error) throw error;
+
+  const idSet = new Set(DIM_IDS);
+  let ownerUserId: string | null = null;
+  const pieces: DerivedArmorPieceJson[] = [];
+
+  for (const row of rows ?? []) {
+    const items = row.items as DerivedArmorPieceJson[];
+    if (!Array.isArray(items)) continue;
+    const matched = items.filter((p) => idSet.has(p.itemInstanceId));
+    if (matched.length === 0) continue;
+    if (ownerUserId != null && row.user_id !== ownerUserId) {
+      console.warn(
+        "Warning: ids found under multiple users; using first match set.",
+      );
+    }
+    ownerUserId ??= row.user_id;
+    for (const id of DIM_IDS) {
+      const p = items.find((x) => x.itemInstanceId === id);
+      if (p) pieces.push(p);
+    }
+  }
+
+  const missing = DIM_IDS.filter(
+    (id) => !pieces.some((p) => p.itemInstanceId === id),
+  );
+
+  const report: Record<string, unknown> = {
+    cacheRows: rows?.length ?? 0,
+    ownerUserId: ownerUserId?.slice(0, 8) ?? null,
+    requestedIds: DIM_IDS,
+    missingIds: missing,
+    found: pieces.length,
+    assumedModBudget: totalAssumedModBudget(ASSUMED_MODS_SCREENSHOT),
+    pieces: pieces.map((p) => ({
+      itemInstanceId: p.itemInstanceId,
+      slot: p.slot,
+      displayName: p.displayName ?? p.setName,
+      isExotic: p.isExotic === true,
+      setHash: p.setHash,
+      setName: p.setName,
+      classType: p.classType,
+      tier: p.tier ?? null,
+      tuningCommitted: p.tuningCommitted ?? null,
+      tuningName: p.tuningName,
+      statTotals: p.statTotals ?? null,
+      hasStatTotals:
+        p.statTotals != null && Object.keys(p.statTotals).length > 0,
+      tuningVariantCount: p.tuningVariants?.length ?? 0,
+    })),
+  };
+
+  if (pieces.length > 0) {
+    report.armorTotals = totalsFromPieces(pieces);
+  }
+
+  const setCounts = Object.fromEntries(countPiecesBySetHash(pieces).entries());
+  report.setPieceCounts = setCounts;
+
+  const lookups = await getManifestLookups();
+  const optimizerLookup = buildOptimizerLookupPayload(lookups);
+  const enrichedPieces = pieces.map((p) =>
+    enrichPieceWithExoticBudget(p, optimizerLookup.exoticStatBudget),
+  );
+  const helmet = pieces.find((p) => p.slot === "helmet");
+  if (helmet?.isExotic) {
+    report.speakersSightItemHash = helmet.itemHash;
+    report.speakersSightEnrichedTotals = enrichedPieces.find(
+      (p) => p.slot === "helmet",
+    )?.statTotals;
+    report.exoticBudgetByHash =
+      optimizerLookup.exoticStatBudget.byItemHash[String(helmet.itemHash)] ??
+      null;
+  }
+
+  if (pieces.length === 5 && missing.length === 0) {
+    report.verifyRawCache = verifyLoadout(pieces, {
+      constraints: SCREENSHOT_CONSTRAINTS,
+      assumedMods: ASSUMED_MODS_SCREENSHOT,
+    });
+
+    report.armorTotalsEnriched = totalsFromPieces(enrichedPieces);
+    report.verifyEnriched = verifyLoadout(enrichedPieces, {
+      constraints: SCREENSHOT_CONSTRAINTS,
+      assumedMods: ASSUMED_MODS_SCREENSHOT,
+    });
+
+    const setHashes = [...countPiecesBySetHash(pieces).entries()].filter(
+      ([, n]) => n >= 2,
+    );
+    const setBonusSelections = setHashes.map(([setHash]) => ({
+      setHash,
+      requiredCount: 2,
+      perkHash: setHash,
+    }));
+
+    report.setBonusSelectionsTried = setBonusSelections;
+
+    const exotic = pieces.find((p) => p.isExotic);
+
+    report.searchLockedExoticRaw = searchLoadouts({
+      pool: pieces,
+      constraints: SCREENSHOT_CONSTRAINTS,
+      assumedStatMods: ASSUMED_MODS_SCREENSHOT,
+      setBonusSelections,
+      exoticLock:
+        exotic != null
+          ? {
+              mode: "locked" as const,
+              itemInstanceId: exotic.itemInstanceId,
+              slot: exotic.slot,
+            }
+          : { mode: "none" as const },
+    }).length;
+
+    report.searchLockedExoticEnriched = searchLoadouts({
+      pool: enrichedPieces,
+      constraints: SCREENSHOT_CONSTRAINTS,
+      assumedStatMods: ASSUMED_MODS_SCREENSHOT,
+      setBonusSelections,
+      exoticLock:
+        exotic != null
+          ? {
+              mode: "locked" as const,
+              itemInstanceId: exotic.itemInstanceId,
+              slot: exotic.slot,
+            }
+          : { mode: "none" as const },
+    }).length;
+
+    report.searchNoExoticEnriched = searchLoadouts({
+      pool: enrichedPieces,
+      constraints: SCREENSHOT_CONSTRAINTS,
+      assumedStatMods: ASSUMED_MODS_SCREENSHOT,
+      setBonusSelections,
+      exoticLock: { mode: "none" },
+    }).length;
+
+    report.searchNoExoticRaw = searchLoadouts({
+      pool: pieces,
+      constraints: SCREENSHOT_CONSTRAINTS,
+      assumedStatMods: ASSUMED_MODS_SCREENSHOT,
+      setBonusSelections,
+      exoticLock: { mode: "none" },
+    }).length;
+
+    const resolved = resolveLoadoutTotals(
+      enrichedPieces,
+      SCREENSHOT_CONSTRAINTS,
+      {},
+      ASSUMED_MODS_SCREENSHOT,
+    );
+    report.resolveTotalsEnriched = resolved?.totals ?? null;
+    report.modAllocationEnriched = resolved?.modAllocation ?? null;
+  }
+
+  const classType = 2;
+  const ferro = 3734029045;
+  const smoke = 2751989785;
+  const setBonuses = [
+    { setHash: ferro, requiredCount: 2, perkHash: ferro },
+    { setHash: smoke, requiredCount: 2, perkHash: smoke },
+  ];
+  let warlockInventory: DerivedArmorPieceJson[] = [];
+  for (const row of rows ?? []) {
+    if (ownerUserId != null && row.user_id !== ownerUserId) continue;
+    const items = row.items as DerivedArmorPieceJson[];
+    if (!Array.isArray(items)) continue;
+    warlockInventory.push(...items.filter((p) => p.classType === classType));
+  }
+  const poolNone = filterOptimizerPool(warlockInventory, classType, {
+    exoticLock: { mode: "none" },
+    exoticStatBudget: optimizerLookup.exoticStatBudget,
+  });
+  const poolAny = filterOptimizerPool(warlockInventory, classType, {
+    exoticLock: { mode: "any" },
+    exoticStatBudget: optimizerLookup.exoticStatBudget,
+  });
+  const exotic = pieces.find((p) => p.isExotic);
+  const poolLocked =
+    exotic != null
+      ? filterOptimizerPool(warlockInventory, classType, {
+          exoticLock: {
+            mode: "locked",
+            itemInstanceId: exotic.itemInstanceId,
+            slot: exotic.slot,
+          },
+          exoticStatBudget: optimizerLookup.exoticStatBudget,
+        })
+      : [];
+
+  report.warlockVault = {
+    pieces: warlockInventory.length,
+    poolNone: poolNone.length,
+    poolAny: poolAny.length,
+    poolLocked: poolLocked.length,
+    boundsLegendaryOnly: computeStatBounds(
+      poolNone,
+      {},
+      { mode: "none" },
+      SCREENSHOT_CONSTRAINTS,
+      ASSUMED_MODS_SCREENSHOT,
+    ),
+    boundsAnyExotic: computeStatBounds(
+      poolAny,
+      {},
+      { mode: "any" },
+      SCREENSHOT_CONSTRAINTS,
+      ASSUMED_MODS_SCREENSHOT,
+    ),
+    combosNone: estimateFilteredComboCount(poolNone, { mode: "none" }, {
+      constraints: SCREENSHOT_CONSTRAINTS,
+      setBonusSelections: setBonuses,
+      assumedMods: ASSUMED_MODS_SCREENSHOT,
+      cap: 5,
+    }),
+    combosAny: estimateFilteredComboCount(poolAny, { mode: "any" }, {
+      constraints: SCREENSHOT_CONSTRAINTS,
+      setBonusSelections: setBonuses,
+      assumedMods: ASSUMED_MODS_SCREENSHOT,
+      cap: 5,
+    }),
+    combosLocked:
+      poolLocked.length > 0
+        ? estimateFilteredComboCount(
+            poolLocked,
+            {
+              mode: "locked",
+              itemInstanceId: exotic!.itemInstanceId,
+              slot: exotic!.slot,
+            },
+            {
+              constraints: SCREENSHOT_CONSTRAINTS,
+              setBonusSelections: setBonuses,
+              assumedMods: ASSUMED_MODS_SCREENSHOT,
+              cap: 5,
+            },
+          )
+        : null,
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/debug/verify-loadout/route.ts
+++ b/src/app/api/debug/verify-loadout/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { requireSessionFromRequest } from "@/lib/auth/session";
+import { ARMOR_STAT_NAMES, type ArmorStatName } from "@/lib/db/types";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import { totalsFromPieces } from "@/lib/optimizer/constraints";
+import { totalAssumedModBudget } from "@/lib/optimizer/mod-offset";
+import { countPiecesBySetHash } from "@/lib/optimizer/set-bonus";
+import { verifyLoadout } from "@/lib/optimizer/verify-loadout";
+import { getCachedInventory } from "@/lib/inventory/sync";
+
+/** DIM / loadout instance ids (Bungie itemInstanceId strings). */
+function parseIdsParam(raw: string | null): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(/[\s,]+/)
+    .map((s) => s.replace(/^id:/i, "").replace(/['"]/g, "").trim())
+    .filter(Boolean);
+}
+
+function parseMin(
+  url: URL,
+  stat: ArmorStatName,
+): number {
+  const v = url.searchParams.get(`${stat}Min`);
+  if (v == null || v === "") return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n) : 0;
+}
+
+export async function GET(req: NextRequest) {
+  let session;
+  try {
+    session = await requireSessionFromRequest(req);
+  } catch {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const ids = parseIdsParam(url.searchParams.get("ids"));
+  if (ids.length === 0) {
+    return NextResponse.json(
+      {
+        error:
+          "Missing ids query param. Example: ?ids=6917530125283917710,6917530167771126356,...",
+      },
+      { status: 400 },
+    );
+  }
+
+  const inventory = (await getCachedInventory(session.userId)) ?? [];
+  const byId = new Map(inventory.map((p) => [p.itemInstanceId, p]));
+  const missing = ids.filter((id) => !byId.has(id));
+  const pieces = ids
+    .map((id) => byId.get(id))
+    .filter((p): p is DerivedArmorPieceJson => p != null);
+
+  const constraints = ARMOR_STAT_NAMES.map((stat) => ({
+    stat,
+    min: parseMin(url, stat),
+  })).filter((row) => row.min > 0);
+
+  const majorCount = Math.min(
+    5,
+    Math.max(0, Number(url.searchParams.get("majorCount") ?? "3") || 0),
+  );
+  const assumedMods = {
+    majorCount,
+    slotFill: url.searchParams.get("slotFill") !== "false",
+    artifice: url.searchParams.get("artifice") !== "false",
+  };
+
+  const armorTotals = pieces.length > 0 ? totalsFromPieces(pieces) : null;
+  const budget = totalAssumedModBudget(assumedMods);
+  const setCounts = Object.fromEntries(
+    countPiecesBySetHash(pieces).entries(),
+  );
+
+  const verify =
+    pieces.length === 5 && missing.length === 0
+      ? verifyLoadout(pieces, { constraints, assumedMods })
+      : null;
+
+  return NextResponse.json({
+    requestedIds: ids,
+    found: pieces.length,
+    missingIds: missing,
+    pieces: pieces.map((p) => ({
+      itemInstanceId: p.itemInstanceId,
+      slot: p.slot,
+      displayName: p.displayName ?? p.setName,
+      isExotic: p.isExotic === true,
+      setHash: p.setHash,
+      setName: p.setName,
+      tier: p.tier ?? null,
+      tuningCommitted: p.tuningCommitted ?? null,
+      tuningName: p.tuningName,
+      statTotals: p.statTotals ?? null,
+      hasStatTotals:
+        p.statTotals != null && Object.keys(p.statTotals).length > 0,
+      tuningVariantCount: p.tuningVariants?.length ?? 0,
+    })),
+    armorTotals,
+    assumedModBudget: budget,
+    setPieceCounts: setCounts,
+    constraints,
+    verify: verify?.ok
+      ? { ok: true, totals: verify.resolved.totals, modAllocation: verify.resolved.modAllocation }
+      : verify
+        ? { ok: false, reason: verify.reason }
+        : {
+            ok: false,
+            reason:
+              missing.length > 0
+                ? `Missing ${missing.length} id(s) from inventory cache — refresh inventory, then retry.`
+                : `Need exactly 5 ids (got ${pieces.length}).`,
+          },
+  });
+}

--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -25,6 +25,7 @@ import {
 import { WorkspaceAutoSync } from "@/components/dashboard/workspace-auto-sync";
 import { WorkspaceSyncProvider } from "@/components/dashboard/workspace-sync-status";
 import type { WorkspaceDataHealth } from "@/lib/workspace/workspace-data-health.shared";
+import { cn } from "@/lib/utils";
 import {
   InventoryEquipmentOnlyBanner,
   InventoryEquipmentOnlyProvider,
@@ -162,41 +163,60 @@ export function DashboardWorkspace({
           profilePictureUrl={profilePictureUrl}
           leadingAccessory={tabs}
         />
-        {mode === "table" ? (
-          <InventoryTableView
-            banners={banners}
-            syncWarning={syncWarning}
-            hasInventory={hasInventory}
-            inventory={inventory}
-            selectors={selectors}
-            filters={filters}
-            onFiltersChange={onFiltersChange}
-            savedViews={savedViewsMenuProps}
-          />
-        ) : mode === "grid" ? (
-          <GridWorkspace
-            banners={banners}
-            syncWarning={syncWarning}
-            hasInventory={hasInventory}
-            selectors={selectors}
-            inventory={inventory}
-            lookupPayload={lookupPayload}
-            filters={filters}
-            onFiltersChange={onFiltersChange}
-            savedViews={savedViewsMenuProps}
-          />
-        ) : (
-          <LoadoutOptimizerView
-            banners={banners}
-            syncWarning={syncWarning}
-            hasInventory={hasInventory}
-            inventory={inventory}
-            filters={filters}
-            onFiltersChange={onFiltersChange}
-            optimizerLookup={optimizerLookup}
-            statIconByName={lookupPayload.statIconByName}
-          />
-        )}
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div
+            className={cn(
+              "flex min-h-0 flex-1 flex-col",
+              mode !== "table" && "hidden",
+            )}
+          >
+            <InventoryTableView
+              banners={banners}
+              syncWarning={syncWarning}
+              hasInventory={hasInventory}
+              inventory={inventory}
+              selectors={selectors}
+              filters={filters}
+              onFiltersChange={onFiltersChange}
+              savedViews={savedViewsMenuProps}
+            />
+          </div>
+          <div
+            className={cn(
+              "flex min-h-0 flex-1 flex-col",
+              mode !== "grid" && "hidden",
+            )}
+          >
+            <GridWorkspace
+              banners={banners}
+              syncWarning={syncWarning}
+              hasInventory={hasInventory}
+              selectors={selectors}
+              inventory={inventory}
+              lookupPayload={lookupPayload}
+              filters={filters}
+              onFiltersChange={onFiltersChange}
+              savedViews={savedViewsMenuProps}
+            />
+          </div>
+          <div
+            className={cn(
+              "flex min-h-0 flex-1 flex-col",
+              mode !== "optimizer" && "hidden",
+            )}
+          >
+            <LoadoutOptimizerView
+              banners={banners}
+              syncWarning={syncWarning}
+              hasInventory={hasInventory}
+              inventory={inventory}
+              filters={filters}
+              onFiltersChange={onFiltersChange}
+              optimizerLookup={optimizerLookup}
+              statIconByName={lookupPayload.statIconByName}
+            />
+          </div>
+        </div>
         </div>
       </WorkspaceSyncProvider>
     </InventoryEquipmentOnlyProvider>

--- a/src/components/dashboard/loadout-optimizer-view.tsx
+++ b/src/components/dashboard/loadout-optimizer-view.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  startTransition,
+  type ReactNode,
+} from "react";
+import { Info } from "@phosphor-icons/react/dist/ssr";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { AssumedStatModsPanel } from "@/components/optimizer/assumed-stat-mods-panel";
 import { ExoticArmorPicker } from "@/components/optimizer/exotic-armor-picker";
 import { OptimizerResultCard } from "@/components/optimizer/optimizer-result-card";
 import { OptimizerSettingsSection } from "@/components/optimizer/optimizer-settings-section";
@@ -10,15 +18,25 @@ import { SetBonusPicker } from "@/components/optimizer/set-bonus-picker";
 import { StatRangeSlider } from "@/components/optimizer/stat-range-slider";
 import { SubclassFragmentPanel } from "@/components/optimizer/subclass-fragment-panel";
 import type { GridLookupPayload } from "@/lib/views/grid-lookup-payload";
-import { CLASS_NAMES, SLOT_ORDER } from "@/lib/bungie/constants";
+import { SLOT_ORDER } from "@/lib/bungie/constants";
 import { ARMOR_STAT_NAMES, type ArmorStatName } from "@/lib/db/types";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
-import { ClassGlyph } from "@/components/ui/class-glyph";
-import { cn } from "@/lib/utils";
-import { computeStatBounds } from "@/lib/optimizer/bounds";
+import { ClassSwitcher } from "@/components/workspace/class-switcher";
+import {
+  computeStatBounds,
+  estimateOptimizerComboCount,
+  SEARCH_AUTO_RUN_COMBO_LIMIT,
+} from "@/lib/optimizer/bounds";
+import {
+  estimateFilteredComboCount,
+} from "@/lib/optimizer/combo-count";
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value";
+import { useStatBoundsForSliders } from "@/lib/optimizer/use-stat-bounds-for-sliders";
+import { enrichPieceWithExoticBudget } from "@/lib/inventory/exotic-stat-fallback";
 import {
   defaultStatConstraints,
   hasStatTargets,
+  statConstraintsEqual,
 } from "@/lib/optimizer/constraints";
 import {
   DEFAULT_EXOTIC_LOCK,
@@ -26,9 +44,8 @@ import {
   uniqueOwnedExoticsForClass,
   type ExoticLock,
 } from "@/lib/optimizer/exotic-lock";
-import { computeFragmentStatOffset, addStatOffsets } from "@/lib/optimizer/fragment-offset";
+import { computeFragmentStatOffset } from "@/lib/optimizer/fragment-offset";
 import {
-  computeAssumedModStatOffset,
   DEFAULT_ASSUMED_STAT_MODS,
   type AssumedStatMods,
 } from "@/lib/optimizer/mod-offset";
@@ -49,15 +66,15 @@ import { WorkspaceSyncGatePanel } from "@/components/dashboard/workspace-sync-ga
 import { useWorkspaceSync } from "@/components/dashboard/workspace-sync-status";
 import { inventoryTableEmptyState } from "@/lib/workspace/workspace-data-health.shared";
 
-const OPTIMIZER_CLASS_OPTIONS: Array<{ value: GridFilterClass; label: string }> =
-  [
-    { value: 0, label: CLASS_NAMES[0] ?? "Titan" },
-    { value: 1, label: CLASS_NAMES[1] ?? "Hunter" },
-    { value: 2, label: CLASS_NAMES[2] ?? "Warlock" },
-  ];
-
 /** Subclass fragment slots are aspect-gated; current sandbox tops out at 5. */
 const MAX_FRAGMENTS = 5;
+
+function formatSearchComboCount(count: number, capped: boolean): string {
+  if (capped) {
+    return `${SEARCH_AUTO_RUN_COMBO_LIMIT.toLocaleString()}+`;
+  }
+  return count.toLocaleString();
+}
 
 export interface LoadoutOptimizerViewProps {
   className?: string;
@@ -94,9 +111,15 @@ export function LoadoutOptimizerView({
 
   // Optimizer state is independent from the Table/Tracker tabs — changing class
   // here doesn't mutate the shared workspace filters.
-  const [classType, setClassType] = useState<number>(filters.class);
+  const [classType, setClassType] = useState<GridFilterClass>(filters.class);
   const [constraints, setConstraints] = useState<StatConstraintRow[]>(
     defaultStatConstraints,
+  );
+  /** Debounced so dragging stat sliders does not restart vault search every tick. */
+  const searchConstraints = useDebouncedValue(constraints, 400);
+  const targetsPending = useMemo(
+    () => !statConstraintsEqual(constraints, searchConstraints),
+    [constraints, searchConstraints],
   );
   const [exoticLock, setExoticLock] = useState<ExoticLock>(DEFAULT_EXOTIC_LOCK);
   const [subclassState, setSubclassState] = useState<{
@@ -135,32 +158,35 @@ export function LoadoutOptimizerView({
       ),
     [selectedFragmentHashes, optimizerLookup, classType],
   );
-  const activeTargetStats = useMemo(
+  const statOffset = fragmentStatOffset;
+  const inventoryWithExoticBudget = useMemo(
     () =>
-      constraints
-        .filter((row) => row.min > 0)
-        .map((row) => row.stat),
-    [constraints],
-  );
-  const modStatOffset = useMemo(
-    () => computeAssumedModStatOffset(assumedStatMods, 5, activeTargetStats),
-    [assumedStatMods, activeTargetStats],
-  );
-  const statOffset = useMemo(
-    () => addStatOffsets(fragmentStatOffset, modStatOffset),
-    [fragmentStatOffset, modStatOffset],
+      optimizerLookup.exoticStatBudget
+        ? inventory.map((piece) =>
+            enrichPieceWithExoticBudget(
+              piece,
+              optimizerLookup.exoticStatBudget!,
+            ),
+          )
+        : inventory,
+    [inventory, optimizerLookup.exoticStatBudget],
   );
   const eligiblePieces = useMemo(
-    () => optimizerEligiblePieces(inventory, classType),
-    [inventory, classType],
+    () => optimizerEligiblePieces(inventoryWithExoticBudget, classType),
+    [inventoryWithExoticBudget, classType],
   );
   const optimizerPool = useMemo(
     () =>
-      filterOptimizerPool(inventory, classType, {
+      filterOptimizerPool(inventoryWithExoticBudget, classType, {
         exoticLock,
         exoticStatBudget: optimizerLookup.exoticStatBudget,
       }),
-    [inventory, classType, exoticLock, optimizerLookup.exoticStatBudget],
+    [
+      inventoryWithExoticBudget,
+      classType,
+      exoticLock,
+      optimizerLookup.exoticStatBudget,
+    ],
   );
   const ownedExotics = useMemo(
     () => uniqueOwnedExoticsForClass(inventory, classType),
@@ -185,37 +211,124 @@ export function LoadoutOptimizerView({
     () => inventory.filter((p) => p.classType === classType).length,
     [inventory, classType],
   );
-  const bounds = useMemo(
-    () => computeStatBounds(optimizerPool, statOffset, exoticLock),
-    [optimizerPool, statOffset, exoticLock],
-  );
-  const boundsWithExotics = useMemo(
+  const bounds = useStatBoundsForSliders({
+    pool: optimizerPool,
+    statOffset,
+    assumedStatMods,
+    exoticLock,
+    constraints,
+    setBonusSelections: selectedSetBonuses,
+  });
+  const rawComboCount = useMemo(
     () =>
-      exoticLock.mode === "none" && ownedExotics.length > 0
-        ? computeStatBounds(
-            filterOptimizerPool(inventory, classType, {
-              exoticLock: { mode: "any" },
-              exoticStatBudget: optimizerLookup.exoticStatBudget,
-            }),
-            statOffset,
-            { mode: "any" },
-          )
-        : null,
-    [
-      exoticLock.mode,
-      ownedExotics.length,
-      inventory,
-      classType,
-      statOffset,
-      optimizerLookup.exoticStatBudget,
-    ],
+      optimizerPool.length > 0
+        ? estimateOptimizerComboCount(optimizerPool, exoticLock)
+        : 0,
+    [optimizerPool, exoticLock],
   );
-  const exoticBoundsHint = useMemo(() => {
-    if (boundsWithExotics == null) return null;
-    return ARMOR_STAT_NAMES.some(
-      (stat) => boundsWithExotics[stat].max > bounds[stat].max,
-    );
-  }, [bounds, boundsWithExotics]);
+  const filteredComboEstimate = useMemo(() => {
+    if (optimizerPool.length === 0) {
+      return { count: 0, capped: false };
+    }
+    return estimateFilteredComboCount(optimizerPool, exoticLock, {
+      constraints: searchConstraints,
+      setBonusSelections: selectedSetBonuses,
+      statOffset: fragmentStatOffset,
+      assumedMods: assumedStatMods,
+      cap: SEARCH_AUTO_RUN_COMBO_LIMIT + 1,
+    });
+  }, [
+    optimizerPool,
+    exoticLock,
+    searchConstraints,
+    selectedSetBonuses,
+    fragmentStatOffset,
+    assumedStatMods,
+  ]);
+  const hasSearchFilters =
+    hasStatTargets(searchConstraints) || selectedSetBonuses.length > 0;
+  const exoticAnyFeasible = useMemo(() => {
+    if (
+      exoticLock.mode !== "none" ||
+      optimizerPool.length === 0 ||
+      !hasSearchFilters
+    ) {
+      return false;
+    }
+    const { count } = estimateFilteredComboCount(optimizerPool, {
+      mode: "any",
+    }, {
+      constraints: searchConstraints,
+      setBonusSelections: selectedSetBonuses,
+      statOffset: fragmentStatOffset,
+      assumedMods: assumedStatMods,
+      cap: 1,
+    });
+    return count > 0;
+  }, [
+    exoticLock.mode,
+    optimizerPool,
+    hasSearchFilters,
+    searchConstraints,
+    selectedSetBonuses,
+    fragmentStatOffset,
+    assumedStatMods,
+  ]);
+  const searchComboCount = hasSearchFilters
+    ? filteredComboEstimate.count
+    : rawComboCount;
+  const searchComboCapped = hasSearchFilters && filteredComboEstimate.capped;
+  const searchTooLarge =
+    searchComboCapped || searchComboCount > SEARCH_AUTO_RUN_COMBO_LIMIT;
+  const [exoticBoundsHint, setExoticBoundsHint] = useState(false);
+  useEffect(() => {
+    if (exoticLock.mode !== "none" || ownedExotics.length === 0) {
+      setExoticBoundsHint(false);
+      return;
+    }
+    let cancelled = false;
+    const run = () => {
+      if (cancelled) return;
+      const poolAny = filterOptimizerPool(inventoryWithExoticBudget, classType, {
+        exoticLock: { mode: "any" },
+        exoticStatBudget: optimizerLookup.exoticStatBudget,
+      });
+      const withExotics = computeStatBounds(
+        poolAny,
+        statOffset,
+        { mode: "any" },
+        constraints,
+        assumedStatMods,
+      );
+      setExoticBoundsHint(
+        ARMOR_STAT_NAMES.some((stat) => withExotics[stat].max > bounds[stat].max),
+      );
+    };
+    const idleId =
+      typeof requestIdleCallback === "function"
+        ? requestIdleCallback(run, { timeout: 3000 })
+        : null;
+    const timeoutId = idleId == null ? window.setTimeout(run, 50) : null;
+    return () => {
+      cancelled = true;
+      if (idleId != null && typeof cancelIdleCallback === "function") {
+        cancelIdleCallback(idleId);
+      }
+      if (timeoutId != null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [
+    exoticLock.mode,
+    ownedExotics.length,
+    inventoryWithExoticBudget,
+    classType,
+    statOffset,
+    optimizerLookup.exoticStatBudget,
+    bounds,
+    constraints,
+    assumedStatMods,
+  ]);
   const canRunOptimizer =
     optimizerPool.length > 0 && poolCoversAllSlots(optimizerPool);
   const missingSlotCoverage =
@@ -226,21 +339,67 @@ export function LoadoutOptimizerView({
   const optimizerRequest = useMemo(
     () => ({
       pool: optimizerPool,
-      constraints,
-      statOffset,
+      constraints: searchConstraints,
+      statOffset: fragmentStatOffset,
+      assumedStatMods,
       exoticLock,
       setBonusSelections: selectedSetBonuses,
       topN: 20,
     }),
-    [optimizerPool, constraints, statOffset, exoticLock, selectedSetBonuses],
+    [
+      optimizerPool,
+      searchConstraints,
+      fragmentStatOffset,
+      assumedStatMods,
+      exoticLock,
+      selectedSetBonuses,
+    ],
   );
+
+  const lockedExoticLabel = useMemo(() => {
+    if (exoticLock.mode !== "locked") return null;
+    const piece = inventory.find(
+      (p) => p.itemInstanceId === exoticLock.itemInstanceId,
+    );
+    return piece?.displayName ?? "Exotic armor";
+  }, [exoticLock, inventory]);
+  const activeStatTargets = hasStatTargets(constraints);
+  const canGenerateBuilds =
+    activeStatTargets || selectedSetBonuses.length > 0;
 
   useOptimizerAutoRun(
     optimizerRequest,
-    canRunOptimizer && setBonusConflict == null,
+    canRunOptimizer &&
+      setBonusConflict == null &&
+      !searchTooLarge &&
+      canGenerateBuilds,
     run,
     cancel,
   );
+
+  /** Hard-stop in-flight search when the pool or targets become invalid. */
+  useEffect(() => {
+    if (
+      !canRunOptimizer ||
+      setBonusConflict != null ||
+      (!hasStatTargets(searchConstraints) && selectedSetBonuses.length === 0)
+    ) {
+      cancel();
+    }
+  }, [
+    canRunOptimizer,
+    setBonusConflict,
+    searchConstraints,
+    selectedSetBonuses.length,
+    cancel,
+  ]);
+
+  /** Stop search only while targets are still moving (not after debounced commit). */
+  useEffect(() => {
+    if (targetsPending && hasStatTargets(constraints)) {
+      cancel();
+    }
+  }, [targetsPending, constraints, cancel]);
 
   const groupedResults = useMemo(
     () => groupSolutionsBySignature(workerState.solutions),
@@ -279,12 +438,13 @@ export function LoadoutOptimizerView({
 
   const hasTopMessage = Boolean(banners) || Boolean(syncWarning);
   const ready = hasInventory && emptyState === null;
-  const activeStatTargets = hasStatTargets(constraints);
 
   const updateConstraint = (stat: ArmorStatName, min: number) => {
-    setConstraints((rows) =>
-      rows.map((row) => (row.stat === stat ? { ...row, min } : row)),
-    );
+    startTransition(() => {
+      setConstraints((rows) =>
+        rows.map((row) => (row.stat === stat ? { ...row, min } : row)),
+      );
+    });
   };
 
   const handleSubclassChange = (key: string | null) => {
@@ -318,6 +478,13 @@ export function LoadoutOptimizerView({
 
   return (
     <div className={`flex min-h-0 flex-1 flex-col ${className}`}>
+      <div
+        role="status"
+        className="flex shrink-0 items-center gap-2 border-b border-blue-500/30 bg-blue-500/5 px-4 py-2 sm:px-6"
+      >
+        <Info weight="duotone" className="size-4 shrink-0 text-blue-500" aria-hidden />
+        <p className="text-sm font-medium">beta, barely works</p>
+      </div>
       {hasTopMessage ? (
         <div className="shrink-0">
           {banners ? (
@@ -351,39 +518,36 @@ export function LoadoutOptimizerView({
                       title="Class"
                       description="Optimizer uses vault and character armor for the selected class."
                     >
-                      <div
-                        className="flex flex-wrap items-center gap-2"
-                        role="group"
-                        aria-label="Class"
-                      >
-                        {OPTIMIZER_CLASS_OPTIONS.map((option) => {
-                          const selected = classType === option.value;
-                          return (
-                            <button
-                              key={option.value}
-                              type="button"
-                              aria-pressed={selected}
-                              title={option.label}
-                              className={cn(
-                                "inline-flex items-center gap-1.5 rounded-none border px-3 py-2 text-sm transition-colors",
-                                selected
-                                  ? "border-foreground bg-foreground text-background"
-                                  : "border-border bg-background text-foreground hover:bg-muted",
-                              )}
-                              onClick={() => setClassType(option.value)}
-                            >
-                              <ClassGlyph
-                                classType={option.value}
-                                className="size-5 shrink-0"
-                              />
-                              {option.label}
-                            </button>
-                          );
-                        })}
-                      </div>
+                      <ClassSwitcher
+                        value={classType}
+                        onChange={setClassType}
+                      />
                       <p className="mt-2 text-xs text-muted-foreground">
-                        {optimizerPool.length} Tier&nbsp;5 piece
-                        {optimizerPool.length === 1 ? "" : "s"} in pool
+                        {optimizerPool.length.toLocaleString()} Tier&nbsp;5
+                        piece{optimizerPool.length === 1 ? "" : "s"}
+                        {searchComboCount > 0 ? (
+                          <>
+                            {" "}
+                            · {formatSearchComboCount(searchComboCount, searchComboCapped)}{" "}
+                            loadout combination
+                            {searchComboCount === 1 && !searchComboCapped
+                              ? ""
+                              : "s"}
+                            {hasSearchFilters ? " match your filters" : ""}
+                            {exoticLock.mode === "locked" && lockedExoticLabel
+                              ? ` (locked ${lockedExoticLabel})`
+                              : null}
+                          </>
+                        ) : hasSearchFilters ? (
+                          <> · no loadouts match your filters</>
+                        ) : null}
+                        {hasSearchFilters && rawComboCount > searchComboCount ? (
+                          <>
+                            {" "}
+                            ({rawComboCount.toLocaleString()} in pool before
+                            filters)
+                          </>
+                        ) : null}
                       </p>
                     </OptimizerSettingsSection>
 
@@ -396,41 +560,7 @@ export function LoadoutOptimizerView({
                           description="Minimums on the 0–200 track. Double-click the shaded band to snap to max."
                           className="border-b-0"
                         >
-                          <fieldset className="space-y-1">
-                            <legend className="text-[11px] font-medium text-foreground">
-                              Assumed stat mods
-                            </legend>
-                            <div className="flex flex-wrap gap-x-3 gap-y-1">
-                              <label className="inline-flex items-center gap-1.5 text-xs">
-                                <input
-                                  type="checkbox"
-                                  checked={assumedStatMods.major}
-                                  onChange={(e) =>
-                                    setAssumedStatMods((prev) => ({
-                                      ...prev,
-                                      major: e.target.checked,
-                                    }))
-                                  }
-                                  className="size-3 shrink-0 rounded-none border-input"
-                                />
-                                Major (+50)
-                              </label>
-                              <label className="inline-flex items-center gap-1.5 text-xs">
-                                <input
-                                  type="checkbox"
-                                  checked={assumedStatMods.minor}
-                                  onChange={(e) =>
-                                    setAssumedStatMods((prev) => ({
-                                      ...prev,
-                                      minor: e.target.checked,
-                                    }))
-                                  }
-                                  className="size-3 shrink-0 rounded-none border-input"
-                                />
-                                Minor (+25)
-                              </label>
-                            </div>
-                          </fieldset>
+                          <div className="space-y-3">
                           {noTier5 ? (
                             <p className="mt-2 text-xs text-amber-600 dark:text-amber-500">
                               No Tier&nbsp;5 armor found for this class. Refresh
@@ -452,7 +582,17 @@ export function LoadoutOptimizerView({
                               item.
                             </p>
                           ) : null}
-                          <ul className="mt-2 space-y-1">
+                          {searchTooLarge && canGenerateBuilds ? (
+                            <p className="text-xs text-amber-600 dark:text-amber-500">
+                              {formatSearchComboCount(
+                                searchComboCount,
+                                searchComboCapped,
+                              )}{" "}
+                              matching loadouts — shaded bands are estimates.
+                              Click Generate builds in Results.
+                            </p>
+                          ) : null}
+                          <ul className="space-y-1">
                             {ARMOR_STAT_NAMES.map((stat) => {
                               const row = constraints.find((r) => r.stat === stat)!;
                               const range = bounds[stat];
@@ -471,6 +611,11 @@ export function LoadoutOptimizerView({
                               );
                             })}
                           </ul>
+                          <AssumedStatModsPanel
+                            value={assumedStatMods}
+                            onChange={setAssumedStatMods}
+                          />
+                          </div>
                         </OptimizerSettingsSection>
 
                         <OptimizerSettingsSection
@@ -553,23 +698,41 @@ export function LoadoutOptimizerView({
                             </p>
                           ) : null}
                         </div>
-                        {workerState.running ? (
-                          <span className="inline-flex items-center gap-2 text-xs text-foreground">
-                            <span
-                              className="size-3 animate-spin rounded-full border-2 border-muted-foreground/40 border-t-foreground"
-                              aria-hidden
-                            />
-                            Generating… {Math.round(workerState.progress)}%
+                        <div className="flex flex-wrap items-center gap-2">
+                          {canGenerateBuilds &&
+                          canRunOptimizer &&
+                          setBonusConflict == null &&
+                          !workerState.running &&
+                          !targetsPending ? (
                             <Button
                               type="button"
-                              variant="outline"
+                              variant={
+                                searchTooLarge ? "default" : "outline"
+                              }
                               size="sm"
-                              onClick={cancel}
+                              onClick={() => run(optimizerRequest)}
                             >
-                              Cancel
+                              Generate builds
                             </Button>
-                          </span>
-                        ) : null}
+                          ) : null}
+                          {workerState.running ? (
+                            <span className="inline-flex items-center gap-2 text-xs text-foreground">
+                              <span
+                                className="size-3 animate-spin rounded-full border-2 border-muted-foreground/40 border-t-foreground"
+                                aria-hidden
+                              />
+                              Generating… {Math.round(workerState.progress)}%
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={cancel}
+                              >
+                                Cancel
+                              </Button>
+                            </span>
+                          ) : null}
+                        </div>
                       </div>
                       {workerState.error ? (
                         <p role="alert" className="mt-2 text-sm text-destructive">
@@ -598,11 +761,19 @@ export function LoadoutOptimizerView({
                       </ul>
                     ) : groupedResults.size === 0 ? (
                       <p className="mt-2 text-sm text-muted-foreground">
-                        {!activeStatTargets
-                          ? "Set at least one stat minimum to generate builds."
+                        {!canGenerateBuilds
+                          ? "Set at least one stat minimum or armor set requirement to generate builds."
+                          : workerState.running
+                            ? `Generating builds… ${Math.round(workerState.progress)}%`
                           : workerState.hasCompletedRun
-                            ? "No builds match your targets. Lower a stat minimum, adjust set bonuses, or change the exotic."
-                            : "Generating builds…"}
+                            ? exoticAnyFeasible
+                              ? "No all-legendary builds match. Lock your exotic helmet (e.g. Speaker's Sight) or choose Any exotic below."
+                              : "No builds match your targets. Lower a stat minimum, adjust set bonuses, or change the exotic."
+                          : targetsPending
+                            ? "Updating targets…"
+                          : searchTooLarge
+                            ? "Large search space — click Generate builds above."
+                            : "Starting search…"}
                       </p>
                     ) : (
                       <ul className="space-y-3">

--- a/src/components/optimizer/assumed-stat-mods-panel.stories.tsx
+++ b/src/components/optimizer/assumed-stat-mods-panel.stories.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import {
+  DEFAULT_ASSUMED_STAT_MODS,
+  totalAssumedModBudget,
+  type AssumedStatMods,
+} from "@/lib/optimizer/mod-offset";
+import { AssumedStatModsPanel } from "./assumed-stat-mods-panel";
+
+const meta: Meta<typeof AssumedStatModsPanel> = {
+  title: "Optimizer/AssumedStatModsPanel",
+  component: AssumedStatModsPanel,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AssumedStatModsPanel>;
+
+function Render({ initial = DEFAULT_ASSUMED_STAT_MODS }: { initial?: AssumedStatMods }) {
+  const [value, setValue] = useState(initial);
+  const budget = totalAssumedModBudget(value);
+  return (
+    <div className="max-w-sm border border-border bg-card p-4">
+      <AssumedStatModsPanel value={value} onChange={setValue} />
+      <p
+        data-testid="mod-budget"
+        className="mt-3 text-xs tabular-nums text-muted-foreground"
+      >
+        majorCount={value.majorCount}, minorCount={budget.minorCount}, total=
+        {budget.total}
+      </p>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <Render />,
+};
+
+export const AllMinorMods: Story = {
+  render: () => <Render initial={{ majorCount: 0 }} />,
+};
+
+export const SelectMajorCount: Story = {
+  render: () => <Render />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "3" }));
+    await expect(canvas.getByTestId("mod-budget")).toHaveTextContent(
+      "majorCount=3, minorCount=2, total=40",
+    );
+    await expect(canvas.getByText(/3 major \(\+30\)/)).toBeInTheDocument();
+    await expect(canvas.getByText(/2 minor \(\+10\)/)).toBeInTheDocument();
+  },
+};
+
+export const FiveMajorsNoMinors: Story = {
+  render: () => <Render initial={{ majorCount: 5 }} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("mod-budget")).toHaveTextContent(
+      "minorCount=0, total=50",
+    );
+    await expect(canvas.getByText(/5 major \(\+50\)/)).toBeInTheDocument();
+  },
+};

--- a/src/components/optimizer/assumed-stat-mods-panel.tsx
+++ b/src/components/optimizer/assumed-stat-mods-panel.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  MAJOR_ARMOR_STAT_MOD,
+  MINOR_ARMOR_STAT_MOD,
+  totalAssumedModBudget,
+  type AssumedStatMods,
+} from "@/lib/optimizer/mod-offset";
+import { cn } from "@/lib/utils";
+import { OptimizerSegmentedControl } from "./optimizer-segmented-control";
+
+const MAJOR_MOD_COUNTS = [0, 1, 2, 3, 4, 5] as const;
+const PIECE_COUNT = 5;
+
+export type AssumedStatModsPanelProps = {
+  value: AssumedStatMods;
+  onChange: (next: AssumedStatMods) => void;
+  compact?: boolean;
+  className?: string;
+};
+
+/** Major mod count; remaining armor pieces assume minor (+5) mods. */
+export function AssumedStatModsPanel({
+  value,
+  onChange,
+  compact = true,
+  className,
+}: AssumedStatModsPanelProps) {
+  const budget = totalAssumedModBudget(value, PIECE_COUNT);
+  const modTotal = budget.total;
+
+  return (
+    <div
+      className={cn(
+        "border-t border-border pt-3",
+        compact ? "space-y-2.5" : "space-y-3",
+        className,
+      )}
+    >
+      <div>
+        <p
+          className={cn(
+            "font-semibold uppercase tracking-wide text-muted-foreground",
+            compact ? "text-[10px]" : "text-xs",
+          )}
+        >
+          Assumed stat mods
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          One mod per armor piece (+10 major or +5 minor on remaining pieces).
+          Applied to stats with a minimum target.
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
+          <span className="text-xs font-medium text-foreground">
+            Major (+{MAJOR_ARMOR_STAT_MOD} each)
+          </span>
+          <OptimizerSegmentedControl
+            ariaLabel="Major mod count"
+            value={value.majorCount}
+            options={MAJOR_MOD_COUNTS}
+            compact={compact}
+            onChange={(majorCount) => onChange({ ...value, majorCount })}
+          />
+        </div>
+        <p className="text-[10px] tabular-nums text-muted-foreground">
+          {modTotal > 0 ? (
+            <>
+              {budget.majorCount > 0 ? (
+                <span>
+                  {budget.majorCount} major (+{budget.majorTotal})
+                </span>
+              ) : null}
+              {budget.majorCount > 0 && budget.minorCount > 0 ? ", " : null}
+              {budget.minorCount > 0 ? (
+                <span>
+                  {budget.minorCount} minor (+{budget.minorTotal})
+                </span>
+              ) : null}
+              {" · "}+{modTotal} on target stats
+            </>
+          ) : (
+            "No stat mod budget"
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/optimizer/optimizer-result-card.tsx
+++ b/src/components/optimizer/optimizer-result-card.tsx
@@ -1,12 +1,80 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { ArmorStatIcon } from "@/components/ui/armor-stat-icon";
 import { ARMOR_STAT_NAMES, type ArmorStatName } from "@/lib/db/types";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
-import { SLOT_LABELS, SLOT_ORDER, bungieIconUrl } from "@/lib/bungie/constants";
+import { SLOT_ORDER, bungieIconUrl } from "@/lib/bungie/constants";
 import { inventoryPieceDisplayName } from "@/lib/filters/filter-inventory";
 import type { OptimizerSolution } from "@/lib/optimizer/types";
+import { tuningPositiveArmorStat } from "@/lib/views/tuning-positive-stat";
 import { cn } from "@/lib/utils";
+
+function pieceRollStats(
+  piece: DerivedArmorPieceJson,
+  statIconByName: Partial<Record<ArmorStatName, string>>,
+): ReactNode {
+  const tuningPositive = piece.tuningName
+    ? tuningPositiveArmorStat(piece.tuningName)
+    : null;
+  const tuningTitle =
+    piece.tuningHash === null
+      ? "Tuning unknown"
+      : `${piece.tuningName ?? "Tuning unknown"}${
+          piece.tuningCommitted === false ? " (uncommitted)" : ""
+        }`;
+
+  return (
+    <div className="flex shrink-0 items-center gap-2.5 text-[10px]">
+      <span
+        className="w-[4.5rem] truncate font-medium text-muted-foreground"
+        title={`Archetype: ${piece.archetypeName ?? "unknown"}`}
+      >
+        {piece.archetypeName ?? "—"}
+      </span>
+      <span
+        className="inline-flex w-[4.25rem] items-center gap-0.5"
+        title={`Tertiary: ${piece.tertiaryStat ?? "unknown"}`}
+      >
+        {piece.tertiaryStat ? (
+          <>
+            <ArmorStatIcon
+              stat={piece.tertiaryStat}
+              iconPath={statIconByName[piece.tertiaryStat]}
+              size="sm"
+            />
+            <span className="truncate font-medium text-foreground">
+              {piece.tertiaryStat}
+            </span>
+          </>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </span>
+      <span
+        className="inline-flex max-w-[5.5rem] items-center gap-0.5"
+        title={tuningTitle}
+      >
+        {tuningPositive ? (
+          <>
+            <ArmorStatIcon
+              stat={tuningPositive}
+              iconPath={statIconByName[tuningPositive]}
+              size="sm"
+            />
+            <span className="truncate font-medium text-foreground">
+              +{tuningPositive}
+            </span>
+          </>
+        ) : (
+          <span className="truncate text-muted-foreground">
+            {piece.tuningName ?? "—"}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
 
 function pieceLocationLabel(piece: DerivedArmorPieceJson): string {
   if (piece.location.kind === "vault") return "Vault";
@@ -87,20 +155,22 @@ export function OptimizerResultCard({
               {piece?.iconPath ? (
                 <img
                   src={bungieIconUrl(piece.iconPath)}
-                  alt=""
+                  alt={
+                    piece
+                      ? (inventoryPieceDisplayName(piece) ?? "Armor piece")
+                      : ""
+                  }
                   className="size-8 shrink-0 rounded-none border border-border object-cover"
                 />
               ) : (
                 <span className="size-8 shrink-0 rounded-none border border-border bg-muted" />
               )}
-              <span className="w-12 shrink-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                {SLOT_LABELS[slot]}
-              </span>
               <span className="min-w-0 flex-1 truncate text-foreground">
                 {piece
                   ? (inventoryPieceDisplayName(piece) ?? "Unknown piece")
                   : "Unknown piece"}
               </span>
+              {piece ? pieceRollStats(piece, statIconByName) : null}
               {swaps > 0 ? (
                 <span
                   className="shrink-0 text-[10px] text-muted-foreground"

--- a/src/components/optimizer/optimizer-segmented-control.tsx
+++ b/src/components/optimizer/optimizer-segmented-control.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+function segmentButtonClass(active: boolean, compact: boolean): string {
+  return cn(
+    "flex shrink-0 items-center justify-center border font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+    compact ? "size-7 text-xs tabular-nums" : "h-9 min-w-9 px-3 text-xs",
+    active
+      ? "border-border bg-background/80 text-foreground dark:bg-accent/80 dark:text-accent-foreground"
+      : "border-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground dark:hover:bg-accent/50 dark:hover:text-accent-foreground",
+  );
+}
+
+export type OptimizerSegmentedControlProps<T extends string | number> = {
+  value: T;
+  options: readonly T[];
+  onChange: (value: T) => void;
+  ariaLabel: string;
+  formatOption?: (value: T) => string;
+  compact?: boolean;
+  className?: string;
+};
+
+/** Compact aria-pressed segments — same chrome as ClassSwitcher tabs. */
+export function OptimizerSegmentedControl<T extends string | number>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  formatOption,
+  compact = true,
+  className,
+}: OptimizerSegmentedControlProps<T>) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex min-w-0 shrink-0 bg-card",
+        compact ? "h-7" : "h-9",
+        className,
+      )}
+    >
+      {options.map((option) => {
+        const active = value === option;
+        return (
+          <button
+            key={String(option)}
+            type="button"
+            aria-pressed={active}
+            className={segmentButtonClass(active, compact)}
+            onClick={() => onChange(option)}
+          >
+            {formatOption?.(option) ?? String(option)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/optimizer/stat-range-slider.tsx
+++ b/src/components/optimizer/stat-range-slider.tsx
@@ -1,16 +1,32 @@
 "use client";
 
-import { useCallback, useId } from "react";
+import { Check } from "@phosphor-icons/react/dist/ssr";
+import { useCallback, useId, type CSSProperties } from "react";
 import { ArmorStatIcon } from "@/components/ui/armor-stat-icon";
+import {
+  checkboxBoxClassName,
+  checkboxIconClassName,
+} from "@/components/ui/checkbox";
 import type { ArmorStatName } from "@/lib/db/types";
 import {
   clampOptimizerStat,
   OPTIMIZER_STAT_MAX,
   OPTIMIZER_STAT_MIN,
-  OPTIMIZER_STAT_TIER_MARKS,
+  OPTIMIZER_STAT_SEGMENTS,
   pctOnOptimizerTrack,
 } from "@/lib/optimizer/stat-range";
 import { cn } from "@/lib/utils";
+
+function segmentPositionStyle(value: number): CSSProperties {
+  const pct = pctOnOptimizerTrack(value);
+  if (value <= OPTIMIZER_STAT_MIN) {
+    return { left: `${pct}%`, transform: "translateY(-50%)" };
+  }
+  if (value >= OPTIMIZER_STAT_MAX) {
+    return { left: `${pct}%`, transform: "translate(-100%, -50%)" };
+  }
+  return { left: `${pct}%`, transform: "translate(-50%, -50%)" };
+}
 
 export type StatRangeSliderProps = {
   stat: ArmorStatName;
@@ -46,11 +62,29 @@ export function StatRangeSlider({
     onChange(clampOptimizerStat(achievableMax));
   };
 
-  const achLeft = pctOnOptimizerTrack(achievableMin);
-  const achWidth = Math.max(
-    0,
-    pctOnOptimizerTrack(achievableMax) - achLeft,
+  const handleSegmentClick = useCallback(
+    (segment: (typeof OPTIMIZER_STAT_SEGMENTS)[number]) => {
+      if (safeMin === segment) {
+        if (segment > OPTIMIZER_STAT_MIN) {
+          setMin(OPTIMIZER_STAT_MIN);
+        }
+        return;
+      }
+      setMin(segment);
+    },
+    [safeMin, setMin],
   );
+
+  const bandMin = Math.max(OPTIMIZER_STAT_MIN, achievableMin);
+  const bandMax = Math.max(bandMin, achievableMax);
+  let achLeft = pctOnOptimizerTrack(bandMin);
+  let achWidth = Math.max(0, pctOnOptimizerTrack(bandMax) - achLeft);
+  /** Minimum visible band so a point range (min === max) still reads on the track. */
+  const MIN_BAND_PCT = 3;
+  if (achWidth < MIN_BAND_PCT && bandMax > OPTIMIZER_STAT_MIN) {
+    achWidth = MIN_BAND_PCT;
+    achLeft = Math.min(achLeft, 100 - MIN_BAND_PCT);
+  }
   const selWidth = pctOnOptimizerTrack(safeMin);
 
   return (
@@ -101,29 +135,57 @@ export function StatRangeSlider({
         >
           <div className="absolute top-1/2 right-0 left-0 h-2 -translate-y-1/2 rounded-full bg-muted" />
 
-          {OPTIMIZER_STAT_TIER_MARKS.map((tier) => (
-            <span
-              key={tier}
-              className="pointer-events-none absolute top-1/2 z-10 h-3 w-px -translate-x-1/2 -translate-y-1/2 bg-border"
-              style={{ left: `${pctOnOptimizerTrack(tier)}%` }}
-              aria-hidden
-            />
-          ))}
-
           <div
-            className="absolute top-1/2 h-2 -translate-y-1/2 rounded-full bg-muted-foreground/35"
+            className="absolute top-1/2 z-[8] h-2 -translate-y-1/2 rounded-full bg-muted-foreground/35"
             style={{ left: `${achLeft}%`, width: `${achWidth}%` }}
-            title={`Achievable ${achievableMin}–${achievableMax} — double-click to set min to ${achievableMax}`}
+            title={`Achievable ${bandMin}–${bandMax} — double-click to set min to ${bandMax}`}
             onDoubleClick={handleAchievableDoubleClick}
           />
 
           {safeMin > OPTIMIZER_STAT_MIN ? (
             <div
-              className="absolute top-1/2 h-2 -translate-y-1/2 rounded-full bg-primary/55"
+              className="absolute top-1/2 z-[5] h-2 -translate-y-1/2 rounded-full bg-primary/55"
               style={{ left: "0%", width: `${selWidth}%` }}
               aria-hidden
             />
           ) : null}
+
+          {OPTIMIZER_STAT_SEGMENTS.map((segment) => {
+            const checked = safeMin === segment;
+            return (
+              <button
+                key={segment}
+                type="button"
+                role="checkbox"
+                aria-checked={checked}
+                aria-label={
+                  segment === OPTIMIZER_STAT_MIN
+                    ? `${stat} minimum none`
+                    : `${stat} minimum ${segment}`
+                }
+                className={cn(
+                  checkboxBoxClassName,
+                  "absolute top-1/2 z-[15] cursor-pointer",
+                  compact ? "size-3" : "size-4",
+                  checked
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border/70 bg-background text-transparent hover:border-foreground/50",
+                )}
+                style={segmentPositionStyle(segment)}
+                onClick={() => handleSegmentClick(segment)}
+              >
+                {checked ? (
+                  <Check
+                    weight="bold"
+                    className={cn(
+                      checkboxIconClassName,
+                      compact ? "h-2 w-2" : undefined,
+                    )}
+                  />
+                ) : null}
+              </button>
+            );
+          })}
 
           <input
             type="range"

--- a/src/components/workspace/class-switcher.tsx
+++ b/src/components/workspace/class-switcher.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { CLASS_NAMES } from "@/lib/bungie/constants";
+import type { GridFilterClass } from "@/lib/workspace/grid-filters-schema";
+import { cn } from "@/lib/utils";
+
+const CLASS_OPTIONS: Array<{ value: GridFilterClass; label: string }> = [
+  { value: 0, label: CLASS_NAMES[0] ?? "Titan" },
+  { value: 1, label: CLASS_NAMES[1] ?? "Hunter" },
+  { value: 2, label: CLASS_NAMES[2] ?? "Warlock" },
+];
+
+function classTabButtonClass(active: boolean, condensed: boolean): string {
+  return cn(
+    "flex shrink-0 items-center border font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+    condensed ? "h-full self-stretch px-2 text-[10px] leading-none" : "h-9 px-3 text-xs",
+    condensed
+      ? active
+        ? "border-transparent bg-primary/15 font-semibold text-foreground"
+        : "border-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground dark:hover:bg-accent/50 dark:hover:text-accent-foreground"
+      : active
+        ? "border-border bg-background/80 text-foreground dark:bg-accent/80 dark:text-accent-foreground"
+        : "border-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground dark:hover:bg-accent/50 dark:hover:text-accent-foreground",
+  );
+}
+
+export interface ClassSwitcherProps {
+  value: GridFilterClass;
+  onChange: (next: GridFilterClass) => void;
+  /** Compact tabs for embedding inside the table search field. */
+  variant?: "default" | "condensed";
+  className?: string;
+}
+
+/** Titan / Hunter / Warlock tabs — same chrome as the tracker filter bar. */
+export function ClassSwitcher({
+  value,
+  onChange,
+  variant = "default",
+  className,
+}: ClassSwitcherProps) {
+  const condensed = variant === "condensed";
+
+  return (
+    <div
+      role="group"
+      aria-label="Class"
+      className={cn(
+        condensed
+          ? "flex shrink-0 items-stretch self-stretch pl-1"
+          : "flex h-9 min-w-0 shrink-0 bg-card",
+        className,
+      )}
+    >
+      {CLASS_OPTIONS.map((tab) => {
+        const active = value === tab.value;
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            className={classTabButtonClass(active, condensed)}
+            onClick={() => onChange(tab.value)}
+            aria-pressed={active}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/workspace/tracker-filter-bar.tsx
+++ b/src/components/workspace/tracker-filter-bar.tsx
@@ -36,13 +36,8 @@ import {
   SavedViewsMenu,
   type SavedViewsBarProps,
 } from "@/components/workspace/saved-views-menu";
+import { ClassSwitcher } from "@/components/workspace/class-switcher";
 import { TrackerFilterBarOverflowMenus } from "@/components/workspace/tracker-filter-bar-overflow-menus";
-
-const CLASS_TABS: Array<{ value: GridFilterClass; label: string }> = [
-  { value: 0, label: "Titan" },
-  { value: 1, label: "Hunter" },
-  { value: 2, label: "Warlock" },
-];
 
 interface ResultNoun {
   singular: string;
@@ -270,43 +265,6 @@ export function TrackerFilterBar({
       </button>
     ) : null;
 
-  function classTabButtonClass(active: boolean, condensed = false) {
-    return cn(
-      "flex shrink-0 items-center border font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-      condensed ? "h-full self-stretch px-2 text-[10px] leading-none" : "h-9 px-3 text-xs",
-      condensed
-        ? active
-          ? "border-transparent bg-primary/15 font-semibold text-foreground"
-          : "border-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground dark:hover:bg-accent/50 dark:hover:text-accent-foreground"
-        : active
-          ? "border-border bg-background/80 text-foreground dark:bg-accent/80 dark:text-accent-foreground"
-          : "border-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground dark:hover:bg-accent/50 dark:hover:text-accent-foreground",
-    );
-  }
-
-  const embeddedClassSwitcher = (
-    <div
-      role="group"
-      aria-label="Class"
-      className="flex shrink-0 items-stretch self-stretch pl-1"
-    >
-      {CLASS_TABS.map((tab) => {
-        const active = value.class === tab.value;
-        return (
-          <button
-            key={tab.value}
-            type="button"
-            className={classTabButtonClass(active, true)}
-            onClick={() => switchClass(tab.value)}
-            aria-pressed={active}
-          >
-            {tab.label}
-          </button>
-        );
-      })}
-    </div>
-  );
-
   const searchField = searchExpanded ? (
     embedClassInSearch ? (
       <div
@@ -335,7 +293,11 @@ export function TrackerFilterBar({
           />
           {clearSearchButton(true)}
         </div>
-        {embeddedClassSwitcher}
+        <ClassSwitcher
+          variant="condensed"
+          value={value.class}
+          onChange={switchClass}
+        />
       </div>
     ) : (
       <div
@@ -426,26 +388,7 @@ export function TrackerFilterBar({
       ) : null}
 
       {!embedClassInSearch ? (
-        <div
-          className="flex h-9 min-w-0 shrink-0 bg-card"
-          role="group"
-          aria-label="Class"
-        >
-          {CLASS_TABS.map((tab) => {
-            const active = value.class === tab.value;
-            return (
-              <button
-                key={tab.value}
-                type="button"
-                className={classTabButtonClass(active)}
-                onClick={() => switchClass(tab.value)}
-                aria-pressed={active}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
+        <ClassSwitcher value={value.class} onChange={switchClass} />
       ) : null}
 
       {showSetFilter ? (

--- a/src/lib/hooks/use-debounced-value.ts
+++ b/src/lib/hooks/use-debounced-value.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Commits `value` after it stops changing for `delayMs` (slider → search pattern). */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/src/lib/inventory/armor-stat-destiny-hashes.ts
+++ b/src/lib/inventory/armor-stat-destiny-hashes.ts
@@ -1,0 +1,36 @@
+import {
+  ARMOR_STAT_NAMES,
+  type ArmorStatName,
+} from "@/lib/db/types";
+
+/**
+ * Bungie `DestinyStatDefinition` hashes for Armor 3.0 stat names.
+ * Used when `armor_stat_icons.destiny_stat_hash` is missing (pre-sync DBs) so
+ * profile ItemStats (component 304) can still map instance stat blocks.
+ */
+export const ARMOR_STAT_DESTINY_HASH: Record<ArmorStatName, number> = {
+  Weapons: 2_996_146_975,
+  Health: 392_767_087,
+  Class: 2_135_857_333,
+  Grenade: 1_735_777_505,
+  Melee: 4_244_567_218,
+  Super: 144_602_215,
+};
+
+/** Build hash → stat map, optionally overridden by manifest-synced rows. */
+export function buildDestinyStatHashToArmorStat(
+  fromDb?: Iterable<readonly [number, ArmorStatName]>,
+): Map<number, ArmorStatName> {
+  const map = new Map<number, ArmorStatName>();
+  for (const stat of ARMOR_STAT_NAMES) {
+    map.set(ARMOR_STAT_DESTINY_HASH[stat], stat);
+  }
+  if (fromDb) {
+    for (const [hash, stat] of fromDb) {
+      if (Number.isFinite(hash)) {
+        map.set(hash, stat);
+      }
+    }
+  }
+  return map;
+}

--- a/src/lib/inventory/compute-stat-totals.test.ts
+++ b/src/lib/inventory/compute-stat-totals.test.ts
@@ -19,15 +19,15 @@ describe("buildStatTotals", () => {
         { stat: "Class", value: 20 },
       ],
       [
-        { stat: "Weapons", value: 10 },
-        { stat: "Grenade", value: -10 },
+        { stat: "Weapons", value: 5 },
+        { stat: "Grenade", value: -5 },
       ],
     );
     expect(totals).toEqual({
-      Weapons: 40,
+      Weapons: 35,
       Health: 25,
       Class: 20,
-      Grenade: -10,
+      Grenade: -5,
     });
   });
 });
@@ -47,9 +47,9 @@ describe("parseTuningPairFromName", () => {
 
 describe("tuningDeltasFromDisplayName", () => {
   it("builds symmetric +/- magnitudes", () => {
-    expect(tuningDeltasFromDisplayName("+Class / -Super", 10)).toEqual([
-      { stat: "Class", value: 10 },
-      { stat: "Super", value: -10 },
+    expect(tuningDeltasFromDisplayName("+Class / -Super")).toEqual([
+      { stat: "Class", value: 5 },
+      { stat: "Super", value: -5 },
     ]);
   });
 });
@@ -73,7 +73,7 @@ describe("estimateStatTotalsFromLabels", () => {
       location: { kind: "vault" },
     };
     expect(estimateStatTotalsFromLabels(piece)).toEqual({
-      Weapons: 40,
+      Weapons: 35,
       Health: 25,
       Class: 20,
     });
@@ -125,7 +125,7 @@ describe("isTier5Piece", () => {
     expect(
       isTier5Piece({
         ...base,
-        statTotals: { Weapons: 40, Health: 25, Class: 20, Grenade: -10 },
+        statTotals: { Weapons: 35, Health: 25, Class: 20, Grenade: -5 },
       }),
     ).toBe(true);
     expect(

--- a/src/lib/inventory/compute-stat-totals.ts
+++ b/src/lib/inventory/compute-stat-totals.ts
@@ -9,7 +9,9 @@ export type StatDelta = { stat: ArmorStatName; value: number };
 
 /** Tier-5 intrinsic plug magnitudes (primary / secondary / tertiary). */
 const INTRINSIC_STAT_MAGNITUDES = [30, 25, 20] as const;
-const DEFAULT_TUNING_MAGNITUDE = 10;
+/** Armor 3.0 +5/−5 tuning mod when manifest rows are unavailable. */
+export const TUNING_PLUG_STAT_MAGNITUDE = 5;
+const DEFAULT_TUNING_MAGNITUDE = TUNING_PLUG_STAT_MAGNITUDE;
 
 /** Sum intrinsic armor_stats plugs plus optional tuning deltas. */
 export function buildStatTotals(
@@ -45,7 +47,7 @@ export function parseTuningPairFromName(
 /** Fallback when manifest rows are missing — assumes symmetric +/- magnitudes. */
 export function tuningDeltasFromDisplayName(
   name: string,
-  magnitude = 10,
+  magnitude = TUNING_PLUG_STAT_MAGNITUDE,
 ): StatDelta[] | null {
   const pair = parseTuningPairFromName(name);
   if (!pair) return null;

--- a/src/lib/inventory/derive.ts
+++ b/src/lib/inventory/derive.ts
@@ -241,8 +241,7 @@ export function deriveArmorPiece(
 
   if (
     isExotic &&
-    Object.keys(statTotals).length === 0 &&
-    lookups.destinyStatHashToArmorStat.size > 0
+    Object.keys(statTotals).length === 0
   ) {
     const fromInstance = instanceArmorStatTotals(
       item.itemInstanceId,

--- a/src/lib/inventory/instance-armor-stats.test.ts
+++ b/src/lib/inventory/instance-armor-stats.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildDestinyStatHashToArmorStat } from "@/lib/inventory/armor-stat-destiny-hashes";
+import { instanceArmorStatTotals } from "@/lib/inventory/instance-armor-stats";
+import type { ProfileResponse } from "@/lib/bungie/types";
+
+describe("instanceArmorStatTotals", () => {
+  it("maps Bungie ItemStats using fallback hashes when DB map is empty", () => {
+    const profile = {
+      itemComponents: {
+        stats: {
+          data: {
+            "6917530125283917710": {
+              stats: {
+                "2996146975": { statHash: 2996146975, value: 31 },
+                "392767087": { statHash: 392767087, value: 8 },
+                "1735777505": { statHash: 1735777505, value: 16 },
+                "2135857333": { statHash: 2135857333, value: 4 },
+                "4244567218": { statHash: 4244567218, value: 4 },
+                "144602215": { statHash: 144602215, value: 20 },
+              },
+            },
+          },
+        },
+      },
+    } as ProfileResponse;
+
+    const totals = instanceArmorStatTotals(
+      "6917530125283917710",
+      profile,
+      new Map(),
+    );
+
+    expect(totals).toEqual({
+      Weapons: 31,
+      Health: 8,
+      Grenade: 16,
+      Class: 4,
+      Melee: 4,
+      Super: 20,
+    });
+  });
+
+  it("prefers manifest-synced hash overrides from DB", () => {
+    const profile = {
+      itemComponents: {
+        stats: {
+          data: {
+            inst: {
+              stats: {
+                "999": { statHash: 999, value: 42 },
+              },
+            },
+          },
+        },
+      },
+    } as ProfileResponse;
+
+    const map = buildDestinyStatHashToArmorStat([[999, "Weapons"]]);
+    expect(instanceArmorStatTotals("inst", profile, map)).toEqual({
+      Weapons: 42,
+    });
+  });
+});

--- a/src/lib/inventory/instance-armor-stats.ts
+++ b/src/lib/inventory/instance-armor-stats.ts
@@ -1,3 +1,4 @@
+import { buildDestinyStatHashToArmorStat } from "@/lib/inventory/armor-stat-destiny-hashes";
 import type { ProfileResponse } from "@/lib/bungie/types";
 import type { ArmorStatName } from "@/lib/db/types";
 
@@ -10,9 +11,14 @@ export function instanceArmorStatTotals(
   const block = profile.itemComponents?.stats?.data?.[itemInstanceId]?.stats;
   if (!block) return null;
 
+  const hashToStat =
+    destinyStatHashToArmorStat.size > 0
+      ? destinyStatHashToArmorStat
+      : buildDestinyStatHashToArmorStat();
+
   const totals: Partial<Record<ArmorStatName, number>> = {};
   for (const entry of Object.values(block)) {
-    const stat = destinyStatHashToArmorStat.get(entry.statHash);
+    const stat = hashToStat.get(entry.statHash);
     if (!stat) continue;
     totals[stat] = entry.value;
   }

--- a/src/lib/manifest/exotic-stat-budget.test.ts
+++ b/src/lib/manifest/exotic-stat-budget.test.ts
@@ -82,6 +82,36 @@ describe("exotic stat budget", () => {
     expect(totals.Class).toBe(20);
   });
 
+  it("prefers singleInitialItemHash over reusable plug sets", () => {
+    const statPlugs = new Map([
+      [100, { stat: "Weapons" as const, value: 5 }],
+      [200, { stat: "Weapons" as const, value: 99 }],
+    ]);
+    const item = {
+      hash: 1,
+      sockets: {
+        socketEntries: [
+          {
+            socketTypeHash: 1,
+            singleInitialItemHash: 100,
+            reusablePlugSetHash: 9000,
+          },
+        ],
+      },
+    } as ManifestInventoryItemDefinition;
+    const plugSets = {
+      "9000": { hash: 9000, reusablePlugItems: [{ plugItemHash: 200 }] },
+    };
+
+    const totals = exoticStatBudgetFromItemSockets(item, {
+      statPlugs,
+      tuningPlugStats: new Map(),
+      plugToTuning: new Map(),
+      plugSets,
+    });
+    expect(totals.Weapons).toBe(5);
+  });
+
   it("mergeExoticStatTotals keeps the higher value per stat", () => {
     expect(
       mergeExoticStatTotals({ Weapons: 10 }, { Weapons: 40 }),

--- a/src/lib/manifest/exotic-stat-budget.ts
+++ b/src/lib/manifest/exotic-stat-budget.ts
@@ -31,10 +31,10 @@ function plugHashesForSocketEntry(
   >["socketEntries"][number],
   plugSets?: Record<string, ManifestPlugSetDefinition>,
 ): number[] {
-  const hashes: number[] = [];
   if (entry.singleInitialItemHash) {
-    hashes.push(entry.singleInitialItemHash);
+    return [entry.singleInitialItemHash];
   }
+  const hashes: number[] = [];
   for (const setHash of [
     entry.reusablePlugSetHash,
     entry.randomizedPlugSetHash,

--- a/src/lib/manifest/lookups.ts
+++ b/src/lib/manifest/lookups.ts
@@ -4,6 +4,7 @@ import type { ArmorSlot } from "@/lib/bungie/constants";
 import { SLOT_ORDER } from "@/lib/bungie/constants";
 import { getServiceRoleClient } from "@/lib/db/server";
 import type { ArmorStatName } from "@/lib/db/types";
+import { buildDestinyStatHashToArmorStat } from "@/lib/inventory/armor-stat-destiny-hashes";
 import { mergeExoticStatTotals } from "@/lib/manifest/exotic-stat-budget";
 import { exoticPieceIdentityKey } from "@/lib/optimizer/exotic-lock";
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -597,7 +598,7 @@ export async function getManifestLookups(force = false): Promise<ManifestLookups
         })
         .filter((e): e is readonly [ArmorStatName, string] => e !== null),
     ),
-    destinyStatHashToArmorStat: new Map(
+    destinyStatHashToArmorStat: buildDestinyStatHashToArmorStat(
       armorStatIcons
         .map((r) => {
           const hash = r.destiny_stat_hash;

--- a/src/lib/optimizer/bounds.test.ts
+++ b/src/lib/optimizer/bounds.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { DerivedArmorPieceJson } from "@/lib/db/types";
-import { computeStatBounds } from "@/lib/optimizer/bounds";
+import { ARMOR_STAT_NAMES } from "@/lib/db/types";
+import { computeStatBounds, estimateOptimizerComboCount } from "@/lib/optimizer/bounds";
+import { maxFeasibleStatTarget } from "@/lib/optimizer/combo-count";
+import { defaultStatConstraints } from "@/lib/optimizer/constraints";
 import { filterOptimizerPool } from "@/lib/optimizer/pool";
 import type { ExoticStatBudgetLookup } from "@/lib/inventory/exotic-stat-fallback";
+import { NO_ASSUMED_STAT_MODS } from "@/lib/optimizer/mod-offset";
+
+const NO_ASSUMED_MODS = NO_ASSUMED_STAT_MODS;
 
 function mockPiece(
   slot: DerivedArmorPieceJson["slot"],
@@ -42,7 +48,13 @@ describe("computeStatBounds", () => {
       mockPiece("classItem", "ci1", { Weapons: 26, Health: 16 }),
     ];
 
-    const bounds = computeStatBounds(pool);
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
     expect(bounds.Weapons).toEqual({
       min: 35 + 30 + 32 + 28 + 26,
       max: 40 + 30 + 32 + 28 + 26,
@@ -55,7 +67,13 @@ describe("computeStatBounds", () => {
 
   it("returns zeros when any slot is empty", () => {
     const pool = [mockPiece("helmet", "h1", { Weapons: 40 })];
-    const bounds = computeStatBounds(pool);
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
     expect(bounds.Weapons).toEqual({ min: 0, max: 0 });
   });
 
@@ -67,7 +85,13 @@ describe("computeStatBounds", () => {
       mockPiece("legs", "l1", { Weapons: 40 }),
       mockPiece("classItem", "ci1", { Weapons: 40 }),
     ];
-    const bounds = computeStatBounds(pool, { Grenade: 10 });
+    const bounds = computeStatBounds(
+      pool,
+      { Grenade: 10 },
+      { mode: "none" },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
     expect(bounds.Grenade.min).toBe(10);
     expect(bounds.Grenade.max).toBe(10);
     expect(bounds.Weapons.min).toBe(200);
@@ -84,7 +108,13 @@ describe("computeStatBounds", () => {
       mockPiece("classItem", "ci1", { Weapons: 10 }),
     ];
 
-    const bounds = computeStatBounds(pool, undefined, { mode: "any" });
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "any" },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
     expect(bounds.Weapons.max).toBe(140);
   });
 
@@ -97,11 +127,17 @@ describe("computeStatBounds", () => {
       mockPiece("legs", "l1", { Weapons: 40 }),
     ];
 
-    const bounds = computeStatBounds(pool, undefined, {
-      mode: "locked",
-      itemInstanceId: "ex-ci",
-      slot: "classItem",
-    });
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      {
+        mode: "locked",
+        itemInstanceId: "ex-ci",
+        slot: "classItem",
+      },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
     expect(bounds.Weapons.max).toBeGreaterThan(0);
     expect(bounds.Weapons.max).toBe(55 + 40 * 4);
   });
@@ -116,11 +152,17 @@ describe("computeStatBounds", () => {
       mockPiece("classItem", "ci1", { Weapons: 10 }),
     ];
 
-    const bounds = computeStatBounds(pool, undefined, {
-      mode: "locked",
-      itemInstanceId: "ex-h",
-      slot: "helmet",
-    });
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      {
+        mode: "locked",
+        itemInstanceId: "ex-h",
+        slot: "helmet",
+      },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
     expect(bounds.Weapons.max).toBe(70);
   });
 
@@ -137,10 +179,10 @@ describe("computeStatBounds", () => {
     };
     const leg = (slot: DerivedArmorPieceJson["slot"], id: string) => ({
       ...mockPiece(slot, id, {
-        Weapons: 40,
+        Weapons: 35,
         Health: 25,
         Class: 20,
-        Grenade: -10,
+        Grenade: -5,
       }),
       classType: 2,
       tier: 5,
@@ -168,12 +210,261 @@ describe("computeStatBounds", () => {
       },
       exoticStatBudget: budget,
     });
-    const bounds = computeStatBounds(pool, undefined, {
-      mode: "locked",
-      itemInstanceId: "speakers-sight",
-      slot: "classItem",
-    });
-    expect(bounds.Weapons.max).toBe(55 + 40 * 4);
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      {
+        mode: "locked",
+        itemInstanceId: "speakers-sight",
+        slot: "classItem",
+      },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
+    expect(bounds.Weapons.max).toBe(55 + 35 * 4);
     expect(bounds.Weapons.min).toBeGreaterThan(0);
+  });
+
+  it("estimates deduped five-slot combination count", () => {
+    const slots = [
+      "helmet",
+      "arms",
+      "chest",
+      "legs",
+      "classItem",
+    ] as const;
+    const pool: DerivedArmorPieceJson[] = [];
+    for (const slot of slots) {
+      pool.push(
+        mockPiece(slot, `${slot}-1`, { Weapons: 40, Health: 25 }),
+        mockPiece(slot, `${slot}-2`, { Weapons: 35, Health: 30 }),
+      );
+    }
+    expect(estimateOptimizerComboCount(pool)).toBe(2 ** 5);
+  });
+
+  it("shrinks achievable max for other stats when a stat target is pinned high", () => {
+    const slots = [
+      "helmet",
+      "arms",
+      "chest",
+      "legs",
+      "classItem",
+    ] as const;
+    const pool: DerivedArmorPieceJson[] = [];
+    for (const slot of slots) {
+      pool.push(
+        mockPiece(slot, `${slot}-w`, { Weapons: 40, Grenade: 5 }),
+        mockPiece(slot, `${slot}-g`, { Weapons: 10, Grenade: 35 }),
+      );
+    }
+
+    const independent = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      undefined,
+      NO_ASSUMED_MODS,
+    );
+    expect(independent.Grenade.max).toBe(35 * 5);
+
+    const constraints = defaultStatConstraints().map((row) =>
+      row.stat === "Weapons" ? { ...row, min: 200 } : row,
+    );
+    const constrained = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      constraints,
+      NO_ASSUMED_MODS,
+    );
+    expect(constrained.Grenade.max).toBe(5 * 5);
+    expect(constrained.Grenade.max).toBeLessThan(independent.Grenade.max);
+  });
+
+  it("shrinks achievable max when multiple stats compete for the mod pool", () => {
+    const slots = [
+      "helmet",
+      "arms",
+      "chest",
+      "legs",
+      "classItem",
+    ] as const;
+    const pool: DerivedArmorPieceJson[] = [];
+    for (const slot of slots) {
+      pool.push(
+        mockPiece(slot, `${slot}-w`, { Weapons: 40, Grenade: 5, Super: 10 }),
+        mockPiece(slot, `${slot}-g`, { Weapons: 10, Grenade: 35, Super: 20 }),
+      );
+    }
+
+    const independent = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      undefined,
+      { majorCount: 5, slotFill: true, artifice: true },
+    );
+    expect(independent.Grenade.max).toBe(35 * 5 + 50);
+
+    const constraints = [
+      { stat: "Weapons" as const, min: 196 },
+      { stat: "Grenade" as const, min: 100 },
+    ];
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      constraints,
+      { majorCount: 5, slotFill: true, artifice: true },
+    );
+    expect(bounds.Grenade.max).toBeLessThan(independent.Grenade.max);
+    expect(bounds.Grenade.max).toBeLessThan(200);
+    expect(bounds.Grenade.max).toBeLessThanOrEqual(
+      maxFeasibleStatTarget(
+        pool,
+        { mode: "none" },
+        constraints,
+        "Grenade",
+        {
+          assumedMods: { majorCount: 5, slotFill: true, artifice: true },
+          hi: independent.Grenade.max,
+        },
+      ),
+    );
+  });
+
+  it("includes assumed mod budget in joint bounds for targeted stats", () => {
+    const pool = ARMOR_STAT_NAMES.map((_, index) =>
+      mockPiece(
+        ["helmet", "arms", "chest", "legs", "classItem"][index]! as DerivedArmorPieceJson["slot"],
+        `p${index}`,
+        { Weapons: 30, Grenade: 10 },
+      ),
+    );
+    const constraints = defaultStatConstraints().map((row) =>
+      row.stat === "Weapons" ? { ...row, min: 200 } : row,
+    );
+    const bounds = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      constraints,
+      { majorCount: 5 },
+    );
+    expect(bounds.Weapons.min).toBeGreaterThanOrEqual(150);
+    expect(bounds.Weapons.max).toBeGreaterThanOrEqual(150);
+    expect(bounds.Weapons.max).toBeLessThanOrEqual(30 * 5 + 50);
+  });
+
+  it("tightens gray-band max using filtered combo count, not raw pool size", () => {
+    const slots = [
+      "helmet",
+      "arms",
+      "chest",
+      "legs",
+      "classItem",
+    ] as const;
+    const pool: DerivedArmorPieceJson[] = [];
+    for (const slot of slots) {
+      pool.push(
+        mockPiece(slot, `${slot}-high`, { Weapons: 40, Grenade: 5 }),
+      );
+      for (let i = 0; i < 8; i++) {
+        pool.push(
+          mockPiece(slot, `${slot}-low${i}`, {
+            Weapons: 10 + (i % 4),
+            Grenade: 35 + (i % 3),
+          }),
+        );
+      }
+    }
+    expect(estimateOptimizerComboCount(pool)).toBeGreaterThan(50_000);
+
+    const constraints = ARMOR_STAT_NAMES.map((stat) => ({
+      stat,
+      min: 0,
+    }));
+    constraints.find((row) => row.stat === "Weapons")!.min = 200;
+
+    const independent = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      undefined,
+      { majorCount: 5, slotFill: true, artifice: true },
+    );
+    expect(independent.Grenade.max).toBeGreaterThan(150);
+
+    const constrained = computeStatBounds(
+      pool,
+      undefined,
+      { mode: "none" },
+      constraints,
+      { majorCount: 5, slotFill: true, artifice: true },
+    );
+    expect(constrained.Grenade.max).toBeLessThan(independent.Grenade.max);
+    expect(constrained.Grenade.max).toBeLessThan(200);
+  });
+});
+
+describe("estimateOptimizerComboCount", () => {
+  function slotPieces(
+    slot: DerivedArmorPieceJson["slot"],
+    legendaryCount: number,
+    exoticCount = 0,
+  ): DerivedArmorPieceJson[] {
+    const pieces: DerivedArmorPieceJson[] = [];
+    for (let i = 0; i < legendaryCount; i++) {
+      pieces.push(
+        mockPiece(slot, `${slot}-l${i}`, {
+          Weapons: 40 + i,
+          Health: 25,
+        }),
+      );
+    }
+    for (let i = 0; i < exoticCount; i++) {
+      pieces.push(
+        mockPiece(
+          slot,
+          `${slot}-x${i}`,
+          { Weapons: 55 + i },
+          { isExotic: true },
+        ),
+      );
+    }
+    return pieces;
+  }
+
+  it("counts at most one exotic when mode is any", () => {
+    const pool = [
+      ...slotPieces("helmet", 2, 1),
+      ...slotPieces("arms", 2, 1),
+      ...slotPieces("chest", 2, 1),
+      ...slotPieces("legs", 2, 1),
+      ...slotPieces("classItem", 2, 1),
+    ];
+    const naiveProduct = Math.pow(3, 5);
+    const anyCount = estimateOptimizerComboCount(pool, { mode: "any" });
+    expect(anyCount).toBeLessThan(naiveProduct);
+    expect(anyCount).toBe(2 ** 5 + 5 * 1 * 2 ** 4);
+  });
+
+  it("shrinks dramatically when an exotic is locked to one slot", () => {
+    const pool = [
+      ...slotPieces("helmet", 20, 2),
+      ...slotPieces("arms", 20, 2),
+      ...slotPieces("chest", 20, 2),
+      ...slotPieces("legs", 20, 2),
+      ...slotPieces("classItem", 20, 2),
+    ];
+    const anyCount = estimateOptimizerComboCount(pool, { mode: "any" });
+    const lockedCount = estimateOptimizerComboCount(pool, {
+      mode: "locked",
+      itemInstanceId: "helmet-x0",
+      slot: "helmet",
+    });
+    expect(lockedCount).toBeLessThan(anyCount);
+    expect(lockedCount).toBe(2 * 20 ** 4);
   });
 });

--- a/src/lib/optimizer/bounds.ts
+++ b/src/lib/optimizer/bounds.ts
@@ -4,15 +4,44 @@ import {
   getPieceStatCeiling,
   getPieceStatValue,
 } from "@/lib/inventory/compute-stat-totals";
-import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import type { ArmorStatName, DerivedArmorPieceJson } from "@/lib/db/types";
+import {
+  hasStatTargets,
+  isActiveStatConstraint,
+  otherActiveStatConstraints,
+  partialCanReachMins,
+  satisfiesOtherStatConstraints,
+  totalsFromPieces,
+} from "@/lib/optimizer/constraints";
+import { dedupeSlotPieces } from "@/lib/optimizer/dedupe";
 import { addStatOffsets } from "@/lib/optimizer/fragment-offset";
 import {
+  DEFAULT_ASSUMED_STAT_MODS,
+  totalAssumedModBudget,
+  type AssumedStatMods,
+} from "@/lib/optimizer/mod-offset";
+import {
+  resolveLoadoutStatExtremum,
+  resolveLoadoutTotals,
+} from "@/lib/optimizer/resolve-loadout-totals";
+import {
+  estimateFilteredComboCount,
+  maxFeasibleStatTarget,
+} from "@/lib/optimizer/combo-count";
+import {
+  partialCanSatisfySetBonuses,
+  type SetBonusSelection,
+} from "@/lib/optimizer/set-bonus";
+import {
+  applyExoticLockToSlotGroups,
+  countExoticsInPieces,
   DEFAULT_EXOTIC_LOCK,
+  exoticAllowedInPartialCombo,
   pieceMatchesLockedExotic,
   resolveLockedExoticIdentityKey,
   type ExoticLock,
 } from "@/lib/optimizer/exotic-lock";
-import type { StatBounds } from "@/lib/optimizer/types";
+import type { StatBounds, StatConstraintRow } from "@/lib/optimizer/types";
 
 function emptyBounds(): StatBounds {
   return Object.fromEntries(
@@ -149,14 +178,623 @@ function minTotalForStat(
   return sumSlotExtrema(bySlot, stat, "min");
 }
 
+function applyFragmentOffsetToBounds(
+  bounds: StatBounds,
+  statOffset?: Partial<Record<ArmorStatName, number>>,
+): StatBounds {
+  if (!statOffset || Object.keys(statOffset).length === 0) {
+    return bounds;
+  }
+  const zero = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [stat, 0]),
+  ) as Record<ArmorStatName, number>;
+  const offset = addStatOffsets(
+    zero,
+    statOffset as Record<ArmorStatName, number>,
+  );
+  for (const stat of ARMOR_STAT_NAMES) {
+    bounds[stat] = {
+      min: bounds[stat].min + (offset[stat] ?? 0),
+      max: bounds[stat].max + (offset[stat] ?? 0),
+    };
+  }
+  return bounds;
+}
+
+/** Adds the shared mod pool to each stat's max (mods can stack on one stat). */
+function applyModBudgetToBounds(
+  bounds: StatBounds,
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+): StatBounds {
+  const modTotal = totalAssumedModBudget(assumedMods).total;
+  if (modTotal === 0) {
+    return bounds;
+  }
+  for (const stat of ARMOR_STAT_NAMES) {
+    bounds[stat] = {
+      min: bounds[stat].min,
+      max: bounds[stat].max + modTotal,
+    };
+  }
+  return bounds;
+}
+
+/** @deprecated Use applyFragmentOffsetToBounds + applyModBudgetToBounds. */
+function applyStatOffsetToBounds(
+  bounds: StatBounds,
+  statOffset?: Partial<Record<ArmorStatName, number>>,
+): StatBounds {
+  return applyFragmentOffsetToBounds(bounds, statOffset);
+}
+
+function independentStatBounds(
+  bySlot: Map<DerivedArmorPieceJson["slot"], DerivedArmorPieceJson[]>,
+  exoticLock: ExoticLock,
+): StatBounds | null {
+  const bounds = emptyBounds();
+  for (const stat of ARMOR_STAT_NAMES) {
+    const minTotal = minTotalForStat(bySlot, stat, exoticLock);
+    const maxTotal = maxTotalForStat(bySlot, stat, exoticLock);
+    if (minTotal == null || maxTotal == null) {
+      return null;
+    }
+    bounds[stat] = { min: minTotal, max: maxTotal };
+  }
+  return bounds;
+}
+
+function perSlotMaxima(
+  bySlot: Map<DerivedArmorPieceJson["slot"], DerivedArmorPieceJson[]>,
+): Record<ArmorStatName, number> {
+  const maxima = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [stat, 0]),
+  ) as Record<ArmorStatName, number>;
+  for (const slot of SLOT_ORDER) {
+    for (const piece of bySlot.get(slot) ?? []) {
+      for (const stat of ARMOR_STAT_NAMES) {
+        maxima[stat] = Math.max(maxima[stat], getPieceStatCeiling(piece, stat));
+      }
+    }
+  }
+  return maxima;
+}
+
+/** Joint slider bands disabled on the hot path (see useStatBoundsForSliders). */
+export const JOINT_BOUNDS_COMBO_LIMIT = 0;
+
+/** Above this deduped combo count, auto-search is skipped (manual run TBD). */
+export const SEARCH_AUTO_RUN_COMBO_LIMIT = 50_000;
+
+/** Deduped representative count for one slot's candidate list. */
+function dedupedRepresentativeCount(pieces: DerivedArmorPieceJson[]): number {
+  if (pieces.length === 0) return 0;
+  return dedupeSlotPieces(pieces).representatives.length;
+}
+
+function productSlotCounts(
+  slotPieces: Map<
+    DerivedArmorPieceJson["slot"],
+    DerivedArmorPieceJson[]
+  >,
+): number {
+  let product = 1;
+  for (const slot of SLOT_ORDER) {
+    const count = dedupedRepresentativeCount(slotPieces.get(slot) ?? []);
+    if (count === 0) return 0;
+    product *= count;
+  }
+  return product;
+}
+
+/**
+ * Deduped five-slot combination count (same shaping as search / joint bounds).
+ * Respects exotic lock rules: none = no exotics, locked = one pinned exotic,
+ * any = at most one exotic anywhere in the loadout (not one per slot).
+ */
+export function estimateOptimizerComboCount(
+  pool: DerivedArmorPieceJson[],
+  exoticLock: ExoticLock = DEFAULT_EXOTIC_LOCK,
+): number {
+  const bySlot = groupPoolBySlot(pool);
+
+  if (exoticLock.mode === "none" || exoticLock.mode === "locked") {
+    applyExoticLockToSlotGroups(bySlot, exoticLock, pool);
+    return productSlotCounts(bySlot);
+  }
+
+  // mode === "any" — sum all-legendary loadouts plus one exotic in each slot.
+  const legendariesBySlot = new Map<
+    DerivedArmorPieceJson["slot"],
+    DerivedArmorPieceJson[]
+  >();
+  for (const slot of SLOT_ORDER) {
+    legendariesBySlot.set(
+      slot,
+      (bySlot.get(slot) ?? []).filter((p) => !p.isExotic),
+    );
+  }
+
+  let total = productSlotCounts(legendariesBySlot);
+
+  for (const exoticSlot of SLOT_ORDER) {
+    const exotics = (bySlot.get(exoticSlot) ?? []).filter((p) => p.isExotic);
+    const exoticCount = dedupedRepresentativeCount(exotics);
+    if (exoticCount === 0) continue;
+
+    let otherProduct = 1;
+    for (const slot of SLOT_ORDER) {
+      if (slot === exoticSlot) continue;
+      const count = dedupedRepresentativeCount(
+        legendariesBySlot.get(slot) ?? [],
+      );
+      if (count === 0) return total;
+      otherProduct *= count;
+    }
+    total += exoticCount * otherProduct;
+  }
+
+  return total;
+}
+
+type PreparedSlotPool = {
+  slotPieces: DerivedArmorPieceJson[][];
+  perSlotMax: Record<ArmorStatName, number>;
+  lockedIdentityKey: string | null;
+  startTotals: Record<ArmorStatName, number>;
+  assumedMods: AssumedStatMods;
+};
+
+function prepareSlotPool(
+  pool: DerivedArmorPieceJson[],
+  statOffset: Partial<Record<ArmorStatName, number>> | undefined,
+  exoticLock: ExoticLock,
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+): PreparedSlotPool | null {
+  const bySlot = groupPoolBySlot(pool);
+  const lockedIdentityKey = resolveLockedExoticIdentityKey(exoticLock, pool);
+  applyExoticLockToSlotGroups(bySlot, exoticLock, pool);
+
+  for (const slot of SLOT_ORDER) {
+    if ((bySlot.get(slot)?.length ?? 0) === 0) {
+      return null;
+    }
+    const { representatives } = dedupeSlotPieces(bySlot.get(slot) ?? []);
+    bySlot.set(slot, representatives);
+  }
+
+  const zeroTotals = totalsFromPieces([]);
+  const startTotals =
+    statOffset && Object.keys(statOffset).length > 0
+      ? addStatOffsets(
+          zeroTotals,
+          statOffset as Record<ArmorStatName, number>,
+        )
+      : zeroTotals;
+
+  return {
+    slotPieces: SLOT_ORDER.map((slot) => bySlot.get(slot) ?? []),
+    perSlotMax: perSlotMaxima(bySlot),
+    lockedIdentityKey,
+    startTotals,
+    assumedMods,
+  };
+}
+
+function totalsAfterPiece(
+  partial: Record<ArmorStatName, number>,
+  piece: DerivedArmorPieceJson,
+  mode: "min" | "max",
+): Record<ArmorStatName, number> {
+  const next = { ...partial };
+  for (const stat of ARMOR_STAT_NAMES) {
+    next[stat] +=
+      mode === "max"
+        ? getPieceStatCeiling(piece, stat)
+        : getPieceStatValue(piece, stat);
+  }
+  return next;
+}
+
+function totalsCeilingAfterPiece(
+  partial: Record<ArmorStatName, number>,
+  piece: DerivedArmorPieceJson,
+): Record<ArmorStatName, number> {
+  const next = { ...partial };
+  for (const stat of ARMOR_STAT_NAMES) {
+    next[stat] += getPieceStatCeiling(piece, stat);
+  }
+  return next;
+}
+
+/**
+ * One-pass greedy five-piece build for a stat extrema while honoring other
+ * active minimums. Fast O(slots × pieces); tightens gray bands when the full
+ * joint enumeration is too large for the vault.
+ */
+function greedyLoadoutStatExtremum(
+  prepared: PreparedSlotPool,
+  constraints: StatConstraintRow[],
+  exceptStat: ArmorStatName,
+  exoticLock: ExoticLock,
+  mode: "min" | "max",
+  focusStat: ArmorStatName,
+  setBonusSelections: SetBonusSelection[] = [],
+): number | null {
+  const otherConstraints = otherActiveStatConstraints(constraints, exceptStat);
+  const slotCandidates = new Map(
+    SLOT_ORDER.map((slot, index) => [slot, prepared.slotPieces[index] ?? []]),
+  );
+  const chosen: DerivedArmorPieceJson[] = [];
+  let partial = { ...prepared.startTotals };
+  let partialCeiling = { ...prepared.startTotals };
+
+  for (let slotIndex = 0; slotIndex < SLOT_ORDER.length; slotIndex++) {
+    const remaining = SLOT_ORDER.length - slotIndex - 1;
+    const remainingSlots = SLOT_ORDER.slice(slotIndex + 1);
+    let bestPiece: DerivedArmorPieceJson | null = null;
+    let bestFocus = mode === "max" ? -Infinity : Infinity;
+
+    for (const piece of prepared.slotPieces[slotIndex] ?? []) {
+      if (
+        !exoticAllowedInPartialCombo(
+          piece,
+          chosen,
+          exoticLock,
+          prepared.lockedIdentityKey,
+        )
+      ) {
+        continue;
+      }
+      const nextCeiling = totalsCeilingAfterPiece(partialCeiling, piece);
+      if (
+        !partialCanReachMins(
+          nextCeiling,
+          remaining,
+          prepared.perSlotMax,
+          otherConstraints,
+          prepared.assumedMods,
+        )
+      ) {
+        continue;
+      }
+      if (
+        !partialCanSatisfySetBonuses(
+          [...chosen, piece],
+          remainingSlots,
+          slotCandidates,
+          setBonusSelections,
+        )
+      ) {
+        continue;
+      }
+
+      const focusValue =
+        mode === "max"
+          ? getPieceStatCeiling(piece, focusStat)
+          : getPieceStatValue(piece, focusStat);
+      if (mode === "max" ? focusValue > bestFocus : focusValue < bestFocus) {
+        bestFocus = focusValue;
+        bestPiece = piece;
+      }
+    }
+
+    if (bestPiece == null) {
+      return null;
+    }
+
+    chosen.push(bestPiece);
+    partial = totalsAfterPiece(partial, bestPiece, mode);
+    partialCeiling = totalsCeilingAfterPiece(partialCeiling, bestPiece);
+  }
+
+  if (exoticLock.mode === "any" && countExoticsInPieces(chosen) > 1) {
+    return null;
+  }
+
+  const fragmentOffset = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [stat, prepared.startTotals[stat] ?? 0]),
+  ) as Partial<Record<ArmorStatName, number>>;
+
+  const extremum = resolveLoadoutStatExtremum(
+    chosen,
+    otherConstraints,
+    fragmentOffset,
+    prepared.assumedMods,
+    focusStat,
+    mode,
+  );
+  return extremum;
+}
+
+/**
+ * Fast cross-stat achievable bands (greedy, not exact). Used for slider gray
+ * bars on large vaults where joint enumeration is impractical.
+ */
+export function computeHeuristicConstrainedStatBounds(
+  pool: DerivedArmorPieceJson[],
+  constraints: StatConstraintRow[],
+  statOffset?: Partial<Record<ArmorStatName, number>>,
+  exoticLock: ExoticLock = DEFAULT_EXOTIC_LOCK,
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+  setBonusSelections: SetBonusSelection[] = [],
+): StatBounds | null {
+  const prepared = prepareSlotPool(pool, statOffset, exoticLock, assumedMods);
+  if (prepared == null) {
+    return null;
+  }
+
+  const bySlot = groupPoolBySlot(pool);
+  const independent = independentStatBounds(bySlot, exoticLock);
+  if (independent == null) {
+    return null;
+  }
+  const cloned = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [
+      stat,
+      { min: independent[stat].min, max: independent[stat].max },
+    ]),
+  ) as StatBounds;
+  let bounds = applyFragmentOffsetToBounds(cloned, statOffset);
+  bounds = applyModBudgetToBounds(bounds, assumedMods);
+  const independentBounds = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [
+      stat,
+      { min: bounds[stat].min, max: bounds[stat].max },
+    ]),
+  ) as StatBounds;
+
+  for (const stat of ARMOR_STAT_NAMES) {
+    const othersActive = otherActiveStatConstraints(constraints, stat);
+    const maxVal = greedyLoadoutStatExtremum(
+      prepared,
+      constraints,
+      stat,
+      exoticLock,
+      "max",
+      stat,
+      setBonusSelections,
+    );
+    const minVal = greedyLoadoutStatExtremum(
+      prepared,
+      constraints,
+      stat,
+      exoticLock,
+      "min",
+      stat,
+      setBonusSelections,
+    );
+
+    let tightenedMax = bounds[stat].max;
+    if (maxVal != null) {
+      tightenedMax = Math.min(tightenedMax, maxVal);
+    }
+    if (othersActive.length > 0) {
+      const { count: filteredComboCount, capped: filteredComboCapped } =
+        estimateFilteredComboCount(pool, exoticLock, {
+          constraints,
+          setBonusSelections,
+          statOffset,
+          assumedMods,
+          cap: SEARCH_AUTO_RUN_COMBO_LIMIT + 1,
+        });
+      if (
+        !filteredComboCapped &&
+        filteredComboCount <= SEARCH_AUTO_RUN_COMBO_LIMIT
+      ) {
+        tightenedMax = Math.min(
+          tightenedMax,
+          maxFeasibleStatTarget(pool, exoticLock, constraints, stat, {
+            setBonusSelections,
+            statOffset,
+            assumedMods,
+            hi: tightenedMax,
+          }),
+        );
+      }
+    }
+    bounds[stat].max = tightenedMax;
+
+    if (minVal != null) {
+      bounds[stat].min = Math.max(bounds[stat].min, minVal);
+    }
+    if (bounds[stat].min > bounds[stat].max) {
+      const ceiling = maxVal ?? bounds[stat].max;
+      const floor = minVal ?? bounds[stat].min;
+      bounds[stat] = {
+        min: Math.min(floor, ceiling),
+        max: Math.max(floor, ceiling),
+      };
+    }
+    if (
+      bounds[stat].min === bounds[stat].max &&
+      bounds[stat].max > 0 &&
+      (maxVal != null || minVal != null)
+    ) {
+      // Single verified value — widen toward the independent floor for a visible band.
+      bounds[stat].min = Math.min(
+        independentBounds[stat].min,
+        bounds[stat].min,
+      );
+    }
+  }
+
+  return bounds;
+}
+
+/**
+ * Joint min/max per stat across real five-piece loadouts, honoring other stats'
+ * active minimums (but not this stat's own slider). Matches optimizer search
+ * ceilings and exotic rules.
+ */
+function jointStatBounds(
+  pool: DerivedArmorPieceJson[],
+  constraints: StatConstraintRow[],
+  statOffset: Partial<Record<ArmorStatName, number>> | undefined,
+  exoticLock: ExoticLock,
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+): StatBounds | null {
+  const bySlot = groupPoolBySlot(pool);
+  const lockedIdentityKey = resolveLockedExoticIdentityKey(exoticLock, pool);
+  applyExoticLockToSlotGroups(bySlot, exoticLock, pool);
+
+  for (const slot of SLOT_ORDER) {
+    if ((bySlot.get(slot)?.length ?? 0) === 0) {
+      return null;
+    }
+    const { representatives } = dedupeSlotPieces(bySlot.get(slot) ?? []);
+    bySlot.set(slot, representatives);
+  }
+
+  const perSlotMax = perSlotMaxima(bySlot);
+  const slotPieces = SLOT_ORDER.map((slot) => bySlot.get(slot) ?? []);
+  const bounds = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [
+      stat,
+      { min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY },
+    ]),
+  ) as StatBounds;
+  const seen = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [stat, false]),
+  ) as Record<ArmorStatName, boolean>;
+  let anyFeasible = false;
+
+  const zeroTotals = totalsFromPieces([]);
+  const startTotals =
+    statOffset && Object.keys(statOffset).length > 0
+      ? addStatOffsets(
+          zeroTotals,
+          statOffset as Record<ArmorStatName, number>,
+        )
+      : zeroTotals;
+
+  const visit = (
+    slotIndex: number,
+    chosen: DerivedArmorPieceJson[],
+    partialTotals: Record<ArmorStatName, number>,
+  ) => {
+    if (slotIndex >= SLOT_ORDER.length) {
+      if (exoticLock.mode === "any" && countExoticsInPieces(chosen) > 1) {
+        return;
+      }
+      const resolved = resolveLoadoutTotals(
+        chosen,
+        constraints,
+        statOffset ?? {},
+        assumedMods,
+      );
+      if (resolved == null) {
+        return;
+      }
+      for (const stat of ARMOR_STAT_NAMES) {
+        if (!satisfiesOtherStatConstraints(resolved.totals, constraints, stat)) {
+          continue;
+        }
+        anyFeasible = true;
+        const value = resolved.totals[stat] ?? 0;
+        if (!seen[stat]) {
+          bounds[stat] = { min: value, max: value };
+          seen[stat] = true;
+        } else {
+          bounds[stat].min = Math.min(bounds[stat].min, value);
+          bounds[stat].max = Math.max(bounds[stat].max, value);
+        }
+      }
+      return;
+    }
+
+    const remaining = SLOT_ORDER.length - slotIndex - 1;
+    for (const piece of slotPieces[slotIndex] ?? []) {
+      if (
+        !exoticAllowedInPartialCombo(
+          piece,
+          chosen,
+          exoticLock,
+          lockedIdentityKey,
+        )
+      ) {
+        continue;
+      }
+      const nextTotals = { ...partialTotals };
+      for (const stat of ARMOR_STAT_NAMES) {
+        nextTotals[stat] += getPieceStatCeiling(piece, stat);
+      }
+      let canExtend = false;
+      for (const stat of ARMOR_STAT_NAMES) {
+        if (
+          partialCanReachMins(
+            nextTotals,
+            remaining,
+            perSlotMax,
+            otherActiveStatConstraints(constraints, stat),
+            assumedMods,
+          )
+        ) {
+          canExtend = true;
+          break;
+        }
+      }
+      if (!canExtend) continue;
+      visit(slotIndex + 1, [...chosen, piece], nextTotals);
+    }
+  };
+
+  visit(0, [], { ...startTotals });
+
+  if (!anyFeasible) {
+    return null;
+  }
+  for (const stat of ARMOR_STAT_NAMES) {
+    if (!seen[stat]) {
+      bounds[stat] = { min: 0, max: 0 };
+    }
+  }
+  return bounds;
+}
+
+/**
+ * Joint achievable bands honoring other stats' active minimums. Expensive — not
+ * used on the live slider path; kept for tests and future async refinement.
+ */
+export function computeConstrainedStatBounds(
+  pool: DerivedArmorPieceJson[],
+  constraints: StatConstraintRow[],
+  statOffset?: Partial<Record<ArmorStatName, number>>,
+  exoticLock: ExoticLock = DEFAULT_EXOTIC_LOCK,
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+): StatBounds {
+  const bySlot = groupPoolBySlot(pool);
+  for (const slot of SLOT_ORDER) {
+    if ((bySlot.get(slot)?.length ?? 0) === 0) {
+      return emptyBounds();
+    }
+  }
+  const joint = jointStatBounds(
+    pool,
+    constraints,
+    statOffset,
+    exoticLock,
+    assumedMods,
+  );
+  if (joint != null) return joint;
+  const independent = independentStatBounds(bySlot, exoticLock);
+  if (independent == null) return emptyBounds();
+  return applyModBudgetToBounds(
+    applyFragmentOffsetToBounds(independent, statOffset),
+    assumedMods,
+  );
+}
+
 /**
  * Achievable min/max per stat from a filtered pool. Respects exotic lock rules
  * (at most one exotic; locked piece fixed to its slot). Powers gray range bars.
  */
 export function computeStatBounds(
   pool: DerivedArmorPieceJson[],
-  statOffset?: Partial<Record<(typeof ARMOR_STAT_NAMES)[number], number>>,
+  statOffset?: Partial<Record<ArmorStatName, number>>,
   exoticLock: ExoticLock = DEFAULT_EXOTIC_LOCK,
+  constraints?: StatConstraintRow[],
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+  setBonusSelections: SetBonusSelection[] = [],
 ): StatBounds {
   const bySlot = groupPoolBySlot(pool);
 
@@ -166,31 +804,73 @@ export function computeStatBounds(
     }
   }
 
-  const bounds = emptyBounds();
-  for (const stat of ARMOR_STAT_NAMES) {
-    const minTotal = minTotalForStat(bySlot, stat, exoticLock);
-    const maxTotal = maxTotalForStat(bySlot, stat, exoticLock);
-    if (minTotal == null || maxTotal == null) {
-      return emptyBounds();
+  let bounds: StatBounds | null = null;
+  if (constraints && hasStatTargets(constraints)) {
+    const comboCount = estimateOptimizerComboCount(pool, exoticLock);
+    if (comboCount <= JOINT_BOUNDS_COMBO_LIMIT) {
+      bounds = jointStatBounds(
+        pool,
+        constraints,
+        statOffset,
+        exoticLock,
+        assumedMods,
+      );
     }
-    bounds[stat] = { min: minTotal, max: maxTotal };
+    if (bounds == null) {
+      bounds = computeHeuristicConstrainedStatBounds(
+        pool,
+        constraints,
+        statOffset,
+        exoticLock,
+        assumedMods,
+        setBonusSelections,
+      );
+    }
+  }
+  if (bounds == null) {
+    bounds = independentStatBounds(bySlot, exoticLock);
+    bounds = bounds
+      ? applyModBudgetToBounds(
+          applyFragmentOffsetToBounds(bounds, statOffset),
+          assumedMods,
+        )
+      : null;
   }
 
-  if (!statOffset || Object.keys(statOffset).length === 0) {
-    return bounds;
-  }
-  const zero = Object.fromEntries(
-    ARMOR_STAT_NAMES.map((stat) => [stat, 0]),
-  ) as Record<(typeof ARMOR_STAT_NAMES)[number], number>;
-  const offset = addStatOffsets(
-    zero,
-    statOffset as Record<(typeof ARMOR_STAT_NAMES)[number], number>,
-  );
-  for (const stat of ARMOR_STAT_NAMES) {
-    bounds[stat] = {
-      min: bounds[stat].min + (offset[stat] ?? 0),
-      max: bounds[stat].max + (offset[stat] ?? 0),
-    };
+  if (bounds == null) {
+    return emptyBounds();
   }
   return bounds;
+}
+
+/** Fast preflight — false when gray-band max cannot reach an active minimum. */
+export function areConstraintsAchievable(
+  pool: DerivedArmorPieceJson[],
+  constraints: StatConstraintRow[],
+  statOffset?: Partial<Record<ArmorStatName, number>>,
+  exoticLock: ExoticLock = DEFAULT_EXOTIC_LOCK,
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+  setBonusSelections: SetBonusSelection[] = [],
+): boolean {
+  if (!hasStatTargets(constraints)) {
+    return true;
+  }
+  const bounds = computeHeuristicConstrainedStatBounds(
+    pool,
+    constraints,
+    statOffset,
+    exoticLock,
+    assumedMods,
+    setBonusSelections,
+  );
+  if (bounds == null) {
+    return false;
+  }
+  for (const row of constraints) {
+    if (!isActiveStatConstraint(row)) continue;
+    if ((bounds[row.stat]?.max ?? 0) < row.min) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/lib/optimizer/combo-count.test.ts
+++ b/src/lib/optimizer/combo-count.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import { ARMOR_STAT_NAMES } from "@/lib/db/types";
+import { estimateFilteredComboCount, maxFeasibleStatTarget } from "@/lib/optimizer/combo-count";
+import { SLOT_ORDER } from "@/lib/bungie/constants";
+
+function mockPiece(
+  slot: DerivedArmorPieceJson["slot"],
+  id: string,
+  statTotals: Partial<Record<string, number>>,
+  extra: Partial<DerivedArmorPieceJson> = {},
+): DerivedArmorPieceJson {
+  return {
+    itemInstanceId: id,
+    itemHash: 1,
+    slot,
+    classType: 0,
+    setHash: 1,
+    setName: "Test",
+    displayName: "Test",
+    archetypeHash: 1,
+    archetypeName: "Gunner",
+    tuningHash: 1,
+    tuningName: "+Weapons / -Grenade",
+    primaryStat: "Weapons",
+    secondaryStat: "Health",
+    tertiaryStat: "Class",
+    statTotals: statTotals as DerivedArmorPieceJson["statTotals"],
+    location: { kind: "vault" },
+    ...extra,
+  };
+}
+
+describe("estimateFilteredComboCount", () => {
+  it("matches raw pool count when no filters are active", () => {
+    const pool = SLOT_ORDER.map((slot) =>
+      mockPiece(slot, `id-${slot}`, { Weapons: 40, Health: 25 }),
+    );
+    const { count, capped } = estimateFilteredComboCount(pool);
+    expect(count).toBe(1);
+    expect(capped).toBe(false);
+  });
+
+  it("shrinks when a set bonus requires specific sets", () => {
+    const pool = SLOT_ORDER.flatMap((slot) => [
+      mockPiece(slot, `${slot}-10a`, { Weapons: 40 }, { setHash: 10 }),
+      mockPiece(slot, `${slot}-10b`, { Weapons: 41 }, { setHash: 10 }),
+      mockPiece(slot, `${slot}-20`, { Weapons: 42 }, { setHash: 20 }),
+    ]);
+    const raw = estimateFilteredComboCount(pool, { mode: "none" }).count;
+    const filtered = estimateFilteredComboCount(pool, { mode: "none" }, {
+      setBonusSelections: [{ setHash: 10, requiredCount: 2, perkHash: 1 }],
+    }).count;
+    expect(filtered).toBeLessThan(raw);
+    expect(filtered).toBeGreaterThan(0);
+  });
+
+  it("shrinks when stat minimums prune infeasible loadouts", () => {
+    const pool = SLOT_ORDER.map((slot, index) =>
+      mockPiece(slot, `id-${slot}`, {
+        Weapons: index === 0 ? 80 : 10,
+        Health: 25,
+      }),
+    );
+    const filtered = estimateFilteredComboCount(pool, { mode: "none" }, {
+      constraints: ARMOR_STAT_NAMES.map((stat) => ({
+        stat,
+        min: stat === "Weapons" ? 200 : 0,
+      })),
+      assumedMods: { majorCount: 0, slotFill: false },
+    }).count;
+    expect(filtered).toBe(0);
+  });
+
+  it("respects cap and reports capped=true", () => {
+    const pool = SLOT_ORDER.flatMap((slot) =>
+      Array.from({ length: 3 }, (_, index) =>
+        mockPiece(slot, `${slot}-${index}`, { Weapons: 40 + index }),
+      ),
+    );
+    const result = estimateFilteredComboCount(pool, { mode: "none" }, {
+      setBonusSelections: [{ setHash: 1, requiredCount: 1, perkHash: 1 }],
+      cap: 5,
+    });
+    expect(result.count).toBe(5);
+    expect(result.capped).toBe(true);
+  });
+});
+
+describe("maxFeasibleStatTarget", () => {
+  it("returns the highest feasible minimum for a stat under other targets", () => {
+    const pool = SLOT_ORDER.flatMap((slot) => [
+      mockPiece(slot, `${slot}-w`, { Weapons: 40, Grenade: 5 }),
+      mockPiece(slot, `${slot}-g`, { Weapons: 10, Grenade: 35 }),
+    ]);
+    const constraints = ARMOR_STAT_NAMES.map((stat) => ({
+      stat,
+      min: 0,
+    }));
+    constraints.find((row) => row.stat === "Weapons")!.min = 200;
+
+    const independentGrenadeMax = 35 * 5 + 50;
+    expect(independentGrenadeMax).toBeGreaterThan(150);
+
+    const maxGrenade = maxFeasibleStatTarget(
+      pool,
+      { mode: "none" },
+      constraints,
+      "Grenade",
+      { assumedMods: { majorCount: 5, slotFill: true, artifice: true } },
+    );
+    expect(maxGrenade).toBeLessThan(independentGrenadeMax);
+    expect(maxGrenade).toBeLessThan(200);
+    expect(
+      estimateFilteredComboCount(
+        pool,
+        { mode: "none" },
+        {
+          constraints: constraints.map((row) =>
+            row.stat === "Grenade" ? { ...row, min: maxGrenade } : row,
+          ),
+          assumedMods: { majorCount: 5, slotFill: true, artifice: true },
+          cap: 1,
+        },
+      ).count,
+    ).toBeGreaterThan(0);
+    expect(
+      estimateFilteredComboCount(
+        pool,
+        { mode: "none" },
+        {
+          constraints: constraints.map((row) =>
+            row.stat === "Grenade" ? { ...row, min: maxGrenade + 1 } : row,
+          ),
+          assumedMods: { majorCount: 5, slotFill: true, artifice: true },
+          cap: 1,
+        },
+      ).count,
+    ).toBe(0);
+  });
+});

--- a/src/lib/optimizer/combo-count.ts
+++ b/src/lib/optimizer/combo-count.ts
@@ -1,0 +1,272 @@
+import { SLOT_ORDER } from "@/lib/bungie/constants";
+import { ARMOR_STAT_NAMES, type ArmorStatName, type DerivedArmorPieceJson } from "@/lib/db/types";
+import { getPieceStatCeiling } from "@/lib/inventory/compute-stat-totals";
+import { estimateOptimizerComboCount } from "@/lib/optimizer/bounds";
+import {
+  hasStatTargets,
+  partialCanReachMins,
+  totalsFromPieces,
+} from "@/lib/optimizer/constraints";
+import { dedupeSlotPieces } from "@/lib/optimizer/dedupe";
+import {
+  applyExoticLockToSlotGroups,
+  countExoticsInPieces,
+  DEFAULT_EXOTIC_LOCK,
+  exoticAllowedInPartialCombo,
+  resolveLockedExoticIdentityKey,
+  type ExoticLock,
+} from "@/lib/optimizer/exotic-lock";
+import { addStatOffsets } from "@/lib/optimizer/fragment-offset";
+import {
+  DEFAULT_ASSUMED_STAT_MODS,
+  type AssumedStatMods,
+} from "@/lib/optimizer/mod-offset";
+import { resolveLoadoutTotals } from "@/lib/optimizer/resolve-loadout-totals";
+import {
+  partialCanSatisfySetBonuses,
+  satisfiesSetBonuses,
+  type SetBonusSelection,
+} from "@/lib/optimizer/set-bonus";
+import type { StatConstraintRow } from "@/lib/optimizer/types";
+import {
+  OPTIMIZER_STAT_MAX,
+  OPTIMIZER_STAT_MIN,
+  clampOptimizerStat,
+} from "@/lib/optimizer/stat-range";
+
+function groupPoolBySlot(pool: DerivedArmorPieceJson[]) {
+  const bySlot = new Map<
+    DerivedArmorPieceJson["slot"],
+    DerivedArmorPieceJson[]
+  >();
+  for (const slot of SLOT_ORDER) {
+    bySlot.set(slot, []);
+  }
+  for (const piece of pool) {
+    bySlot.get(piece.slot)?.push(piece);
+  }
+  return bySlot;
+}
+
+function perSlotMaxima(
+  bySlot: Map<DerivedArmorPieceJson["slot"], DerivedArmorPieceJson[]>,
+): Record<(typeof ARMOR_STAT_NAMES)[number], number> {
+  const maxima = Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [stat, 0]),
+  ) as Record<(typeof ARMOR_STAT_NAMES)[number], number>;
+  for (const slot of SLOT_ORDER) {
+    for (const piece of bySlot.get(slot) ?? []) {
+      for (const stat of ARMOR_STAT_NAMES) {
+        maxima[stat] = Math.max(maxima[stat], getPieceStatCeiling(piece, stat));
+      }
+    }
+  }
+  return maxima;
+}
+
+export type FilteredComboCountOptions = {
+  constraints?: StatConstraintRow[];
+  setBonusSelections?: SetBonusSelection[];
+  statOffset?: Partial<Record<(typeof ARMOR_STAT_NAMES)[number], number>>;
+  assumedMods?: AssumedStatMods;
+  /** Stop counting once this many feasible loadouts are found. */
+  cap?: number;
+};
+
+export type FilteredComboCountResult = {
+  count: number;
+  /** True when enumeration stopped early because `cap` was reached. */
+  capped: boolean;
+};
+
+/**
+ * Feasible five-piece loadout count after dedupe, exotic lock, set bonus, and
+ * stat-target pruning (verified at leaves when stat targets are active).
+ * Without filters, matches `estimateOptimizerComboCount`.
+ */
+export function estimateFilteredComboCount(
+  pool: DerivedArmorPieceJson[],
+  exoticLock: ExoticLock = DEFAULT_EXOTIC_LOCK,
+  options: FilteredComboCountOptions = {},
+): FilteredComboCountResult {
+  const constraints = options.constraints ?? [];
+  const setBonusSelections = options.setBonusSelections ?? [];
+  const assumedMods = options.assumedMods ?? DEFAULT_ASSUMED_STAT_MODS;
+  const fragmentOffset = options.statOffset ?? {};
+  const cap = options.cap;
+
+  if (
+    !hasStatTargets(constraints) &&
+    setBonusSelections.length === 0
+  ) {
+    return {
+      count: estimateOptimizerComboCount(pool, exoticLock),
+      capped: false,
+    };
+  }
+
+  const bySlot = groupPoolBySlot(pool);
+  const lockedIdentityKey = resolveLockedExoticIdentityKey(exoticLock, pool);
+  applyExoticLockToSlotGroups(bySlot, exoticLock, pool);
+
+  for (const slot of SLOT_ORDER) {
+    if ((bySlot.get(slot)?.length ?? 0) === 0) {
+      return { count: 0, capped: false };
+    }
+    const { representatives } = dedupeSlotPieces(bySlot.get(slot) ?? []);
+    bySlot.set(slot, representatives);
+  }
+
+  const perSlotMax = perSlotMaxima(bySlot);
+  const slotPieces = SLOT_ORDER.map((slot) => bySlot.get(slot) ?? []);
+  const verifyAtLeaves = hasStatTargets(constraints);
+  let count = 0;
+  let capped = false;
+
+  const zeroTotals = totalsFromPieces([]);
+  const startTotals =
+    Object.keys(fragmentOffset).length > 0
+      ? addStatOffsets(
+          zeroTotals,
+          fragmentOffset as Record<(typeof ARMOR_STAT_NAMES)[number], number>,
+        )
+      : zeroTotals;
+
+  const visit = (
+    slotIndex: number,
+    chosen: DerivedArmorPieceJson[],
+    partialTotals: Record<(typeof ARMOR_STAT_NAMES)[number], number>,
+  ): void => {
+    if (capped) return;
+
+    if (slotIndex >= SLOT_ORDER.length) {
+      if (exoticLock.mode === "any" && countExoticsInPieces(chosen) > 1) {
+        return;
+      }
+      if (!satisfiesSetBonuses(chosen, setBonusSelections)) {
+        return;
+      }
+      if (verifyAtLeaves) {
+        const resolved = resolveLoadoutTotals(
+          chosen,
+          constraints,
+          fragmentOffset,
+          assumedMods,
+        );
+        if (resolved == null) {
+          return;
+        }
+      }
+      count += 1;
+      if (cap != null && count >= cap) {
+        capped = true;
+      }
+      return;
+    }
+
+    const remaining = SLOT_ORDER.length - slotIndex;
+    const remainingSlots = SLOT_ORDER.slice(slotIndex);
+    for (const piece of slotPieces[slotIndex] ?? []) {
+      if (
+        !exoticAllowedInPartialCombo(
+          piece,
+          chosen,
+          exoticLock,
+          lockedIdentityKey,
+        )
+      ) {
+        continue;
+      }
+      const nextTotals = { ...partialTotals };
+      for (const stat of ARMOR_STAT_NAMES) {
+        nextTotals[stat] += getPieceStatCeiling(piece, stat);
+      }
+      if (
+        !partialCanReachMins(
+          nextTotals,
+          remaining - 1,
+          perSlotMax,
+          constraints,
+          assumedMods,
+        )
+      ) {
+        continue;
+      }
+      if (
+        !partialCanSatisfySetBonuses(
+          [...chosen, piece],
+          remainingSlots.slice(1),
+          bySlot,
+          setBonusSelections,
+        )
+      ) {
+        continue;
+      }
+      visit(slotIndex + 1, [...chosen, piece], nextTotals);
+      if (capped) return;
+    }
+  };
+
+  visit(0, [], startTotals);
+  return { count, capped };
+}
+
+export type StatTargetFeasibilityOptions = Omit<
+  FilteredComboCountOptions,
+  "constraints" | "cap"
+> & {
+  /** Upper bound for the binary search (defaults to 200). */
+  hi?: number;
+};
+
+function constraintsWithStatMin(
+  constraints: StatConstraintRow[],
+  focusStat: ArmorStatName,
+  min: number,
+): StatConstraintRow[] {
+  const clamped = clampOptimizerStat(min);
+  return constraints.map((row) =>
+    row.stat === focusStat ? { ...row, min: clamped } : row,
+  );
+}
+
+/**
+ * Highest minimum target on `focusStat` that still yields at least one verified
+ * loadout (same rules as search). Used to cap slider gray-band maxes.
+ */
+export function maxFeasibleStatTarget(
+  pool: DerivedArmorPieceJson[],
+  exoticLock: ExoticLock = DEFAULT_EXOTIC_LOCK,
+  constraints: StatConstraintRow[],
+  focusStat: ArmorStatName,
+  options: StatTargetFeasibilityOptions = {},
+): number {
+  const hi = clampOptimizerStat(
+    options.hi ?? OPTIMIZER_STAT_MAX,
+  );
+  const feasible = (min: number): boolean =>
+    estimateFilteredComboCount(pool, exoticLock, {
+      ...options,
+      constraints: constraintsWithStatMin(constraints, focusStat, min),
+      cap: 1,
+    }).count > 0;
+
+  if (!feasible(OPTIMIZER_STAT_MIN)) {
+    return OPTIMIZER_STAT_MIN;
+  }
+  if (feasible(hi)) {
+    return hi;
+  }
+
+  let lo = OPTIMIZER_STAT_MIN;
+  let top = hi;
+  while (lo < top) {
+    const mid = Math.ceil((lo + top) / 2);
+    if (feasible(mid)) {
+      lo = mid;
+    } else {
+      top = mid - 1;
+    }
+  }
+  return lo;
+}

--- a/src/lib/optimizer/constraints.test.ts
+++ b/src/lib/optimizer/constraints.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { ARMOR_STAT_NAMES } from "@/lib/db/types";
+import {
+  partialCanReachMins,
+  satisfiesConstraints,
+} from "@/lib/optimizer/constraints";
+
+describe("partialCanReachMins", () => {
+  it("includes assumed mod budget so high mins are not pruned too early", () => {
+    const perSlotMax = Object.fromEntries(
+      ARMOR_STAT_NAMES.map((stat) => [stat, stat === "Weapons" ? 30 : 25]),
+    ) as Record<(typeof ARMOR_STAT_NAMES)[number], number>;
+    const partial = Object.fromEntries(
+      ARMOR_STAT_NAMES.map((stat) => [stat, stat === "Weapons" ? 30 : 0]),
+    ) as Record<(typeof ARMOR_STAT_NAMES)[number], number>;
+
+    const withoutMods = partialCanReachMins(
+      partial,
+      4,
+      perSlotMax,
+      [{ stat: "Weapons", min: 158 }],
+    );
+    const withMods = partialCanReachMins(
+      partial,
+      4,
+      perSlotMax,
+      [{ stat: "Weapons", min: 158 }],
+      { majorCount: 4 },
+    );
+
+    expect(withoutMods).toBe(false);
+    expect(withMods).toBe(true);
+  });
+
+  it("rejects when combined mod deficits exceed the shared pool", () => {
+    const perSlotMax = {
+      Weapons: 30,
+      Grenade: 16,
+      Health: 25,
+      Class: 20,
+      Melee: 20,
+      Super: 20,
+    } as Record<(typeof ARMOR_STAT_NAMES)[number], number>;
+    const partial = Object.fromEntries(
+      ARMOR_STAT_NAMES.map((stat) => [stat, 0]),
+    ) as Record<(typeof ARMOR_STAT_NAMES)[number], number>;
+
+    const canReachBoth = partialCanReachMins(
+      partial,
+      5,
+      perSlotMax,
+      [
+        { stat: "Weapons", min: 200 },
+        { stat: "Grenade", min: 100 },
+      ],
+      { majorCount: 5, slotFill: true, artifice: true },
+    );
+    expect(canReachBoth).toBe(false);
+  });
+});
+
+describe("satisfiesConstraints", () => {
+  it("allows a single major mod to overshoot the 200 track cap", () => {
+    expect(
+      satisfiesConstraints(
+        {
+          Weapons: 205,
+          Health: 0,
+          Class: 0,
+          Grenade: 0,
+          Melee: 0,
+          Super: 0,
+        },
+        [{ stat: "Weapons", min: 200 }],
+      ),
+    ).toBe(true);
+  });
+
+  it("allows high armor totals on stats with low minimums", () => {
+    expect(
+      satisfiesConstraints(
+        {
+          Weapons: 205,
+          Health: 215,
+          Class: 90,
+          Grenade: 105,
+          Melee: 45,
+          Super: 75,
+        },
+        [
+          { stat: "Weapons", min: 200 },
+          { stat: "Health", min: 10 },
+          { stat: "Grenade", min: 100 },
+          { stat: "Super", min: 70 },
+        ],
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects per-stat totals far above the track maximum", () => {
+    expect(
+      satisfiesConstraints(
+        {
+          Weapons: 200,
+          Health: 125,
+          Class: 275,
+          Grenade: 100,
+          Melee: 50,
+          Super: 70,
+        },
+        [
+          { stat: "Weapons", min: 200 },
+          { stat: "Class", min: 50 },
+        ],
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts loadouts where tuning debuffs sum below zero on unused stats", () => {
+    expect(
+      satisfiesConstraints(
+        {
+          Weapons: 196,
+          Health: -7,
+          Class: 54,
+          Grenade: 121,
+          Melee: -1,
+          Super: 70,
+        },
+        [
+          { stat: "Weapons", min: 196 },
+          { stat: "Class", min: 50 },
+          { stat: "Grenade", min: 100 },
+          { stat: "Super", min: 70 },
+        ],
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/lib/optimizer/constraints.ts
+++ b/src/lib/optimizer/constraints.ts
@@ -4,6 +4,12 @@ import {
   type DerivedArmorPieceJson,
 } from "@/lib/db/types";
 import { getPieceStatValue } from "@/lib/inventory/compute-stat-totals";
+import {
+  ARTIFICE_ARMOR_STAT_MOD,
+  MAJOR_ARMOR_STAT_MOD,
+  totalAssumedModBudget,
+  type AssumedStatMods,
+} from "@/lib/optimizer/mod-offset";
 import type { StatConstraintRow } from "@/lib/optimizer/types";
 import { OPTIMIZER_STAT_MAX, OPTIMIZER_STAT_MIN } from "@/lib/optimizer/stat-range";
 
@@ -15,11 +21,74 @@ export function defaultStatConstraints(): StatConstraintRow[] {
 }
 
 export function hasStatTargets(constraints: StatConstraintRow[]): boolean {
-  return constraints.some((row) => row.min > OPTIMIZER_STAT_MIN);
+  return constraints.some(isActiveStatConstraint);
 }
 
-function isActiveConstraint(row: StatConstraintRow): boolean {
+export function statConstraintsEqual(
+  a: StatConstraintRow[],
+  b: StatConstraintRow[],
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((row, i) => {
+    const other = b[i]!;
+    return row.stat === other.stat && row.min === other.min;
+  });
+}
+
+export function isActiveStatConstraint(row: StatConstraintRow): boolean {
   return row.min > OPTIMIZER_STAT_MIN;
+}
+
+/** Per-stat build total cap on the 0–200 track (+ one major mod overshoot). */
+export function maxAllowedStatTotal(): number {
+  return OPTIMIZER_STAT_MAX + MAJOR_ARMOR_STAT_MOD;
+}
+
+/** Upper bound for an active target — tight at 200, looser on lower mins. */
+export function maxAllowedStatTotalForRow(row: StatConstraintRow): number {
+  if (!isActiveStatConstraint(row)) {
+    return Number.POSITIVE_INFINITY;
+  }
+  if (row.min >= OPTIMIZER_STAT_MAX) {
+    return OPTIMIZER_STAT_MAX + MAJOR_ARMOR_STAT_MOD;
+  }
+  // Still reject corrupted/impossible totals (see satisfiesConstraints test).
+  return OPTIMIZER_STAT_MAX + MAJOR_ARMOR_STAT_MOD * 5;
+}
+
+/** Active minimum targets on stats other than `exceptStat` (for slider achievable bands). */
+export function satisfiesOtherStatConstraints(
+  totals: Record<ArmorStatName, number>,
+  constraints: StatConstraintRow[],
+  exceptStat: ArmorStatName,
+): boolean {
+  for (const stat of ARMOR_STAT_NAMES) {
+    if (displayedStatTotal(totals[stat] ?? 0) < OPTIMIZER_STAT_MIN) {
+      return false;
+    }
+  }
+  for (const row of constraints) {
+    if (row.stat === exceptStat) continue;
+    if (!isActiveStatConstraint(row)) continue;
+    const value = totals[row.stat] ?? 0;
+    if (value < row.min) return false;
+    if (value > maxAllowedStatTotalForRow(row)) return false;
+  }
+  return true;
+}
+
+export function otherActiveStatConstraints(
+  constraints: StatConstraintRow[],
+  exceptStat: ArmorStatName,
+): StatConstraintRow[] {
+  return constraints.filter(
+    (row) => row.stat !== exceptStat && isActiveStatConstraint(row),
+  );
+}
+
+/** In-game armor stats floor at 0 (tuning debuffs on unused stats may sum below zero). */
+export function displayedStatTotal(value: number): number {
+  return Math.max(OPTIMIZER_STAT_MIN, value);
 }
 
 export function totalsFromPieces(
@@ -41,13 +110,16 @@ export function satisfiesConstraints(
   constraints: StatConstraintRow[],
 ): boolean {
   for (const stat of ARMOR_STAT_NAMES) {
-    const value = totals[stat] ?? 0;
-    if (value < OPTIMIZER_STAT_MIN) return false;
+    if (displayedStatTotal(totals[stat] ?? 0) < OPTIMIZER_STAT_MIN) {
+      return false;
+    }
   }
   for (const row of constraints) {
-    if (!isActiveConstraint(row)) continue;
+    if (!isActiveStatConstraint(row)) continue;
     const value = totals[row.stat] ?? 0;
-    if (value < row.min || value > OPTIMIZER_STAT_MAX) return false;
+    if (value < row.min) return false;
+    // Targets top out at 200, but a single +10 assumed mod can land slightly above.
+    if (value > maxAllowedStatTotalForRow(row)) return false;
   }
   return true;
 }
@@ -60,7 +132,7 @@ export function scoreSolution(
   let score = 0;
   for (let i = 0; i < constraints.length; i++) {
     const row = constraints[i]!;
-    if (!isActiveConstraint(row)) continue;
+    if (!isActiveStatConstraint(row)) continue;
     const value = totals[row.stat] ?? 0;
     const waste = Math.max(0, value - row.min);
     score += waste * Math.pow(10, constraints.length - i);
@@ -73,13 +145,31 @@ export function partialCanReachMins(
   remainingSlots: number,
   perSlotMax: Record<ArmorStatName, number>,
   constraints: StatConstraintRow[],
+  assumedMods?: AssumedStatMods,
 ): boolean {
-  for (const row of constraints) {
-    if (!isActiveConstraint(row)) continue;
-    const maxPossible =
+  const activeRows = constraints.filter(isActiveStatConstraint);
+  if (activeRows.length === 0) {
+    return true;
+  }
+
+  let modBudget = 0;
+  if (assumedMods) {
+    modBudget = totalAssumedModBudget(assumedMods).total;
+    if (assumedMods.artifice !== false) {
+      modBudget += ARTIFICE_ARMOR_STAT_MOD;
+    }
+  }
+
+  let modDeficitSum = 0;
+  for (const row of activeRows) {
+    const armorCeiling =
       (partialTotals[row.stat] ?? 0) +
       remainingSlots * (perSlotMax[row.stat] ?? 0);
-    if (maxPossible < row.min) return false;
+    if (armorCeiling + modBudget < row.min) {
+      return false;
+    }
+    modDeficitSum += Math.max(0, row.min - armorCeiling);
   }
-  return true;
+
+  return modDeficitSum <= modBudget;
 }

--- a/src/lib/optimizer/exotic-lock.test.ts
+++ b/src/lib/optimizer/exotic-lock.test.ts
@@ -120,6 +120,21 @@ describe("exotic lock", () => {
     expect(unique[0]?.itemInstanceId).toBe("ex-current");
   });
 
+  it("resolves stale instance id when only one exotic occupies the slot", () => {
+    const exo = piece("helmet", "ex-new", true);
+    exo.displayName = "Cenotaph Mask";
+    const next = normalizeExoticLock(
+      { mode: "locked", itemInstanceId: "ex-stale", slot: "helmet" },
+      [exo],
+      0,
+    );
+    expect(next).toEqual({
+      mode: "locked",
+      itemInstanceId: "ex-new",
+      slot: "helmet",
+    });
+  });
+
   it("normalizes a locked duplicate to the representative instance", () => {
     const dupA = piece("helmet", "ex-dup-a", true);
     dupA.itemHash = 4242;

--- a/src/lib/optimizer/exotic-lock.ts
+++ b/src/lib/optimizer/exotic-lock.ts
@@ -37,10 +37,23 @@ export function resolveLockedExoticIdentityKey(
   lookupPieces: DerivedArmorPieceJson[],
 ): string | null {
   if (lock.mode !== "locked") return null;
-  const locked = lookupPieces.find(
+  const direct = lookupPieces.find(
     (p) => p.itemInstanceId === lock.itemInstanceId,
   );
-  return locked ? exoticPieceIdentityKey(locked) : null;
+  if (direct?.isExotic) return exoticPieceIdentityKey(direct);
+
+  const slotExotics = lookupPieces.filter(
+    (p) => p.isExotic && p.slot === lock.slot,
+  );
+  if (slotExotics.length === 0) return null;
+
+  const keys = new Set(slotExotics.map((p) => exoticPieceIdentityKey(p)));
+  if (keys.size === 1) return [...keys][0]!;
+
+  const fallback = slotExotics.find(
+    (p) => p.itemInstanceId === lock.itemInstanceId,
+  );
+  return fallback ? exoticPieceIdentityKey(fallback) : null;
 }
 
 export function pieceMatchesLockedExotic(
@@ -216,14 +229,34 @@ function pickRepresentativeExoticCopy(
 }
 
 /** Map a locked instance to the canonical copy when duplicates exist. */
+export function resolveLockedExoticInInventory(
+  lock: ExoticLock,
+  inventory: DerivedArmorPieceJson[],
+  classType: number,
+): DerivedArmorPieceJson | null {
+  if (lock.mode !== "locked") return null;
+  const owned = ownedExoticsForClass(inventory, classType);
+  const byId = owned.find((p) => p.itemInstanceId === lock.itemInstanceId);
+  if (byId) return byId;
+
+  const inSlot = owned.filter((p) => p.slot === lock.slot);
+  if (inSlot.length === 1) return inSlot[0]!;
+
+  const keysForSlot = new Set(inSlot.map((p) => exoticPieceIdentityKey(p)));
+  if (keysForSlot.size === 1 && inSlot[0]) {
+    return inSlot[0];
+  }
+
+  return null;
+}
+
 export function normalizeExoticLock(
   lock: ExoticLock,
   inventory: DerivedArmorPieceJson[],
   classType: number,
 ): ExoticLock {
   if (lock.mode !== "locked") return lock;
-  const owned = ownedExoticsForClass(inventory, classType);
-  const locked = owned.find((p) => p.itemInstanceId === lock.itemInstanceId);
+  const locked = resolveLockedExoticInInventory(lock, inventory, classType);
   if (!locked) return { mode: "any" };
   const lockedKey = exoticPieceIdentityKey(locked);
   const representative = uniqueOwnedExoticsForClass(inventory, classType).find(

--- a/src/lib/optimizer/mod-offset.test.ts
+++ b/src/lib/optimizer/mod-offset.test.ts
@@ -1,24 +1,39 @@
 import { describe, expect, it } from "vitest";
 import {
-  computeAssumedModStatOffset,
-  MAJOR_ARMOR_STAT_MOD,
-  MINOR_ARMOR_STAT_MOD,
+  NO_ASSUMED_STAT_MODS,
+  totalAssumedModBudget,
 } from "@/lib/optimizer/mod-offset";
 
-describe("computeAssumedModStatOffset", () => {
-  it("returns zero when no mods are assumed", () => {
-    const offset = computeAssumedModStatOffset({ major: false, minor: false });
-    expect(offset.Weapons).toBe(0);
-    expect(offset.Grenade).toBe(0);
+describe("totalAssumedModBudget", () => {
+  it("returns zero when slot fill is disabled", () => {
+    const budget = totalAssumedModBudget(NO_ASSUMED_STAT_MODS);
+    expect(budget.total).toBe(0);
   });
 
-  it("adds major mod budget per piece", () => {
-    const offset = computeAssumedModStatOffset({ major: true, minor: false });
-    expect(offset.Weapons).toBe(MAJOR_ARMOR_STAT_MOD * 5);
+  it("fills remaining slots with minor mods when majors are partial", () => {
+    const budget = totalAssumedModBudget({ majorCount: 3 });
+    expect(budget.majorTotal).toBe(30);
+    expect(budget.minorCount).toBe(2);
+    expect(budget.minorTotal).toBe(10);
+    expect(budget.total).toBe(40);
   });
 
-  it("stacks major and minor per piece", () => {
-    const offset = computeAssumedModStatOffset({ major: true, minor: true });
-    expect(offset.Weapons).toBe((MAJOR_ARMOR_STAT_MOD + MINOR_ARMOR_STAT_MOD) * 5);
+  it("uses all minor mods when major count is zero", () => {
+    const budget = totalAssumedModBudget({ majorCount: 0 });
+    expect(budget.majorTotal).toBe(0);
+    expect(budget.minorCount).toBe(5);
+    expect(budget.total).toBe(25);
+  });
+
+  it("uses only major mods when major count is five", () => {
+    const budget = totalAssumedModBudget({ majorCount: 5 });
+    expect(budget.total).toBe(50);
+    expect(budget.minorCount).toBe(0);
+  });
+
+  it("does not multiply by active target count", () => {
+    const budget = totalAssumedModBudget({ majorCount: 5 });
+    expect(budget.total).toBe(50);
+    expect(budget.total).not.toBe(50 * 4);
   });
 });

--- a/src/lib/optimizer/mod-offset.ts
+++ b/src/lib/optimizer/mod-offset.ts
@@ -7,38 +7,82 @@ import {
 export const MAJOR_ARMOR_STAT_MOD = 10;
 /** Standard Armor 3.0 minor stat mod (+5). */
 export const MINOR_ARMOR_STAT_MOD = 5;
+/** Artifice armor extra +3 stat mod (separate socket, not a major/minor slot). */
+export const ARTIFICE_ARMOR_STAT_MOD = 3;
 
 export type AssumedStatMods = {
-  major: boolean;
-  minor: boolean;
+  /** How many major (+10) stat mods to assume (0–5, one per armor piece). */
+  majorCount: number;
+  /**
+   * When true (default), each remaining armor piece assumes a minor (+5) mod.
+   * Set false only for tests or “no assumed mods” (e.g. majorCount 0 → zero budget).
+   */
+  slotFill?: boolean;
+  /**
+   * When true (default), assume one +3 artifice mod toward an active minimum
+   * (does not consume major/minor slots — matches a single artifice +3 in DIM).
+   */
+  artifice?: boolean;
 };
 
 export const DEFAULT_ASSUMED_STAT_MODS: AssumedStatMods = {
-  major: true,
-  minor: false,
+  majorCount: 5,
+  slotFill: true,
+  artifice: true,
+};
+
+/** Zero assumed mod budget — for bounds/search tests without mod inflation. */
+export const NO_ASSUMED_STAT_MODS: AssumedStatMods = {
+  majorCount: 0,
+  slotFill: false,
+};
+
+const MAX_MAJOR_MODS = 5;
+
+export type AssumedModBudget = {
+  majorCount: number;
+  majorTotal: number;
+  minorCount: number;
+  minorTotal: number;
+  /** Combined +10/+5 mod points available across the whole loadout. */
+  total: number;
 };
 
 /**
- * Optimistic mod budget when each armor piece can slot one major and/or minor
- * stat mod toward a single stat (+10 / +5). Five pieces → up to +50 / +75 on
- * one stat. Used for achievable-range bars and search feasibility.
+ * Shared mod pool for the loadout — not duplicated per target stat.
+ * Each armor piece has one stat mod slot: major (+10) or minor (+5), not both.
  */
-export function computeAssumedModStatOffset(
+export function totalAssumedModBudget(
   options: AssumedStatMods,
   pieceCount = 5,
-  /** When set, mod budget applies only to these stats (one mod focus per build). */
-  targetStats?: readonly ArmorStatName[],
+): AssumedModBudget {
+  const majorCount = Math.min(
+    MAX_MAJOR_MODS,
+    Math.min(pieceCount, Math.max(0, Math.round(options.majorCount))),
+  );
+  const majorTotal = majorCount * MAJOR_ARMOR_STAT_MOD;
+  const slotFill = options.slotFill !== false;
+  const minorCount = slotFill ? Math.max(0, pieceCount - majorCount) : 0;
+  const minorTotal = minorCount * MINOR_ARMOR_STAT_MOD;
+  return {
+    majorCount,
+    majorTotal,
+    minorCount,
+    minorTotal,
+    total: majorTotal + minorTotal,
+  };
+}
+
+/**
+ * @deprecated Use `totalAssumedModBudget` + `resolveLoadoutTotals` instead.
+ * Returns all zeros — mod budget is no longer folded into per-stat offsets.
+ */
+export function computeAssumedModStatOffset(
+  _options: AssumedStatMods,
+  _pieceCount = 5,
+  _targetStats?: readonly ArmorStatName[],
 ): Record<ArmorStatName, number> {
-  const perPiece =
-    (options.major ? MAJOR_ARMOR_STAT_MOD : 0) +
-    (options.minor ? MINOR_ARMOR_STAT_MOD : 0);
-  const total = perPiece * pieceCount;
-  const applyTo =
-    targetStats && targetStats.length > 0 ? targetStats : ARMOR_STAT_NAMES;
   return Object.fromEntries(
-    ARMOR_STAT_NAMES.map((stat) => [
-      stat,
-      applyTo.includes(stat) ? total : 0,
-    ]),
+    ARMOR_STAT_NAMES.map((stat) => [stat, 0]),
   ) as Record<ArmorStatName, number>;
 }

--- a/src/lib/optimizer/process.worker.ts
+++ b/src/lib/optimizer/process.worker.ts
@@ -1,6 +1,11 @@
 /// <reference lib="webworker" />
 
-import { computeStatBounds } from "@/lib/optimizer/bounds";
+import {
+  computeStatBounds,
+  estimateOptimizerComboCount,
+  SEARCH_AUTO_RUN_COMBO_LIMIT,
+} from "@/lib/optimizer/bounds";
+import { DEFAULT_EXOTIC_LOCK } from "@/lib/optimizer/exotic-lock";
 import { searchLoadouts } from "@/lib/optimizer/search";
 import type { WorkerRequest, WorkerResponse } from "@/lib/optimizer/types";
 
@@ -18,28 +23,40 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   cancelled = false;
 
   try {
-    const bounds = computeStatBounds(
-      message.payload.pool,
-      message.payload.statOffset,
-      message.payload.exoticLock,
-    );
-    const boundsMsg: WorkerResponse = {
-      type: "bounds",
+    const progressMsg = (percent: number): WorkerResponse => ({
+      type: "progress",
       id: message.id,
-      bounds,
-    };
-    self.postMessage(boundsMsg);
+      percent,
+    });
+    self.postMessage(progressMsg(0));
+
+    const exoticLock = message.payload.exoticLock ?? DEFAULT_EXOTIC_LOCK;
+    const comboCount = estimateOptimizerComboCount(
+      message.payload.pool,
+      exoticLock,
+    );
+
+    if (comboCount <= SEARCH_AUTO_RUN_COMBO_LIMIT) {
+      const bounds = computeStatBounds(
+        message.payload.pool,
+        message.payload.statOffset,
+        exoticLock,
+        message.payload.constraints,
+        message.payload.assumedStatMods,
+      );
+      const boundsMsg: WorkerResponse = {
+        type: "bounds",
+        id: message.id,
+        bounds,
+      };
+      self.postMessage(boundsMsg);
+    }
 
     const solutions = searchLoadouts(
       message.payload,
       (percent) => {
         if (cancelled) return;
-        const progressMsg: WorkerResponse = {
-          type: "progress",
-          id: message.id,
-          percent,
-        };
-        self.postMessage(progressMsg);
+        self.postMessage(progressMsg(percent));
       },
       () => cancelled,
     );

--- a/src/lib/optimizer/resolve-loadout-totals.test.ts
+++ b/src/lib/optimizer/resolve-loadout-totals.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import { ARMOR_STAT_NAMES } from "@/lib/db/types";
+import { SLOT_ORDER } from "@/lib/bungie/constants";
+import {
+  DEFAULT_ASSUMED_STAT_MODS,
+  MAJOR_ARMOR_STAT_MOD,
+  MINOR_ARMOR_STAT_MOD,
+  totalAssumedModBudget,
+} from "@/lib/optimizer/mod-offset";
+import {
+  maxVerifiedTotalSum,
+  resolveLoadoutTotals,
+} from "@/lib/optimizer/resolve-loadout-totals";
+
+function mockPiece(
+  slot: DerivedArmorPieceJson["slot"],
+  id: string,
+  statTotals: Partial<Record<string, number>>,
+  extra: Partial<DerivedArmorPieceJson> = {},
+): DerivedArmorPieceJson {
+  return {
+    itemInstanceId: id,
+    itemHash: 1,
+    slot,
+    classType: 0,
+    setHash: 1,
+    setName: "Test",
+    displayName: "Test",
+    archetypeHash: 1,
+    archetypeName: "Gunner",
+    tuningHash: 1,
+    tuningName: "+Weapons / -Grenade",
+    primaryStat: "Weapons",
+    secondaryStat: "Health",
+    tertiaryStat: "Class",
+    statTotals: statTotals as DerivedArmorPieceJson["statTotals"],
+    location: { kind: "vault" },
+    ...extra,
+  };
+}
+
+function fivePiecePool(
+  perSlot: Partial<Record<string, number>>,
+  slotOverrides: Partial<
+    Record<DerivedArmorPieceJson["slot"], Partial<DerivedArmorPieceJson>>
+  > = {},
+): DerivedArmorPieceJson[] {
+  return SLOT_ORDER.map((slot) => {
+    const override = slotOverrides[slot] ?? {};
+    return mockPiece(slot, `id-${slot}`, perSlot, override);
+  });
+}
+
+describe("totalAssumedModBudget", () => {
+  it("returns 50 total mod points for 5 majors, not per target stat", () => {
+    const budget = totalAssumedModBudget({ majorCount: 5 });
+    expect(budget.majorTotal).toBe(50);
+    expect(budget.total).toBe(50);
+  });
+
+  it("fills unfilled slots with minor mods", () => {
+    const budget = totalAssumedModBudget({ majorCount: 3 });
+    expect(budget.majorTotal).toBe(MAJOR_ARMOR_STAT_MOD * 3);
+    expect(budget.minorTotal).toBe(MINOR_ARMOR_STAT_MOD * 2);
+    expect(budget.total).toBe(40);
+  });
+});
+
+describe("resolveLoadoutTotals", () => {
+  it("adds up to +50 on a single target with five committed pieces", () => {
+    const pieces = fivePiecePool({
+      Weapons: 30,
+      Health: 25,
+      Class: 20,
+    });
+    const resolved = resolveLoadoutTotals(
+      pieces,
+      [{ stat: "Weapons", min: 150 }],
+      {},
+      { majorCount: 5 },
+    );
+    expect(resolved).not.toBeNull();
+    expect(resolved!.totals.Weapons).toBe(150);
+    const armorSum = 30 * 5 + 25 * 5 + 20 * 5;
+    expect(
+      ARMOR_STAT_NAMES.reduce((sum, stat) => sum + resolved!.totals[stat], 0),
+    ).toBeLessThanOrEqual(armorSum + 50);
+  });
+
+  it("cannot zero out both debuff penalties from uncommitted variants", () => {
+    const pieces = fivePiecePool(
+      { Weapons: 30, Health: 25, Class: 20, Grenade: 10, Melee: 10 },
+      {
+        helmet: {
+          tuningCommitted: false,
+          tuningVariants: [
+            { Weapons: 35, Health: 25, Class: 20, Grenade: 5, Melee: 10 },
+            { Weapons: 35, Health: 25, Class: 20, Grenade: 10, Melee: 5 },
+          ],
+        },
+      },
+    );
+    const resolved = resolveLoadoutTotals(
+      pieces,
+      ARMOR_STAT_NAMES.map((stat) => ({ stat, min: 0 })),
+      {},
+      DEFAULT_ASSUMED_STAT_MODS,
+    );
+    expect(resolved).not.toBeNull();
+    const helmetBranch = resolved!.tuningBySlot?.helmet;
+    expect(helmetBranch).toBeDefined();
+    const grenade = helmetBranch!.Grenade ?? 10;
+    const melee = helmetBranch!.Melee ?? 10;
+    expect(grenade === 5 || melee === 5).toBe(true);
+    expect(grenade === 10 && melee === 10).toBe(false);
+  });
+
+  it("assigns split major/minor mods across multiple targets without exceeding cap", () => {
+    const pieces = fivePiecePool({
+      Weapons: 38,
+      Health: 25,
+      Class: 20,
+      Grenade: 20,
+      Melee: 13,
+      Super: 10,
+    });
+    const resolved = resolveLoadoutTotals(
+      pieces,
+      [
+        { stat: "Weapons", min: 200 },
+        { stat: "Health", min: 50 },
+        { stat: "Grenade", min: 100 },
+        { stat: "Melee", min: 63 },
+      ],
+      {},
+      { majorCount: 3 },
+    );
+    expect(resolved).not.toBeNull();
+    expect(resolved!.totals.Weapons).toBeGreaterThanOrEqual(200);
+    expect(resolved!.totals.Weapons).toBeLessThanOrEqual(210);
+    expect(resolved!.totals.Health).toBeGreaterThanOrEqual(50);
+    expect(resolved!.totals.Grenade).toBeGreaterThanOrEqual(100);
+    expect(resolved!.totals.Melee).toBeGreaterThanOrEqual(63);
+  });
+
+  it("rejects loadouts that need more mod points than the shared pool", () => {
+    const pieces = fivePiecePool({ Weapons: 10 });
+    const resolved = resolveLoadoutTotals(
+      pieces,
+      ARMOR_STAT_NAMES.map((stat) => ({
+        stat,
+        min: stat === "Weapons" ? 200 : 0,
+      })),
+      {},
+      { majorCount: 5 },
+    );
+    expect(resolved).toBeNull();
+  });
+
+  it("caps total sum at armor + mod pool + fragments for many active targets", () => {
+    const pieces = fivePiecePool({
+      Weapons: 40,
+      Health: 25,
+      Class: 20,
+      Grenade: 10,
+    });
+    const constraints = ARMOR_STAT_NAMES.map((stat) => ({
+      stat,
+      min: stat === "Weapons" ? 200 : stat === "Health" ? 50 : 50,
+    }));
+    const fragmentOffset = { Grenade: 10 };
+    const assumedMods = { majorCount: 5 };
+
+    const resolved = resolveLoadoutTotals(
+      pieces,
+      constraints,
+      fragmentOffset,
+      assumedMods,
+    );
+
+    const ceiling = maxVerifiedTotalSum(pieces, fragmentOffset, assumedMods);
+    if (resolved != null) {
+      const sum = ARMOR_STAT_NAMES.reduce(
+        (acc, stat) => acc + resolved.totals[stat],
+        0,
+      );
+      expect(sum).toBeLessThanOrEqual(ceiling);
+    }
+  });
+});

--- a/src/lib/optimizer/resolve-loadout-totals.ts
+++ b/src/lib/optimizer/resolve-loadout-totals.ts
@@ -1,0 +1,365 @@
+import {
+  ARMOR_STAT_NAMES,
+  type ArmorStatName,
+  type DerivedArmorPieceJson,
+} from "@/lib/db/types";
+import {
+  getPieceStatTotals,
+  resolvePieceStatTotals,
+} from "@/lib/inventory/compute-stat-totals";
+import {
+  isActiveStatConstraint,
+  maxAllowedStatTotalForRow,
+  satisfiesConstraints,
+} from "@/lib/optimizer/constraints";
+import type { StatConstraintRow } from "@/lib/optimizer/types";
+import { addStatOffsets } from "@/lib/optimizer/fragment-offset";
+import {
+  ARTIFICE_ARMOR_STAT_MOD,
+  DEFAULT_ASSUMED_STAT_MODS,
+  MAJOR_ARMOR_STAT_MOD,
+  MINOR_ARMOR_STAT_MOD,
+  totalAssumedModBudget,
+  type AssumedStatMods,
+} from "@/lib/optimizer/mod-offset";
+import type { OptimizerSlotKey } from "@/lib/optimizer/types";
+import { SLOT_ORDER } from "@/lib/bungie/constants";
+
+/** One debuff branch for an uncommitted piece — full per-stat map. */
+export type TuningAssignment = Partial<Record<ArmorStatName, number>>;
+
+export type ResolvedLoadout = {
+  totals: Record<ArmorStatName, number>;
+  /** Per slot: which tuning branch was used (undefined = committed statTotals). */
+  tuningBySlot?: Partial<Record<OptimizerSlotKey, TuningAssignment>>;
+  /** How many mod points (+10 / +5) placed on each stat. */
+  modAllocation?: Partial<Record<ArmorStatName, number>>;
+};
+
+function zeroTotals(): Record<ArmorStatName, number> {
+  return Object.fromEntries(
+    ARMOR_STAT_NAMES.map((stat) => [stat, 0]),
+  ) as Record<ArmorStatName, number>;
+}
+
+function sumStatMaps(
+  maps: Partial<Record<ArmorStatName, number>>[],
+): Record<ArmorStatName, number> {
+  const totals = zeroTotals();
+  for (const map of maps) {
+    for (const stat of ARMOR_STAT_NAMES) {
+      totals[stat] += map[stat] ?? 0;
+    }
+  }
+  return totals;
+}
+
+/** Candidate stat maps for one piece — exactly one branch must be chosen. */
+function pieceTuningCandidates(
+  piece: DerivedArmorPieceJson,
+): Partial<Record<ArmorStatName, number>>[] {
+  if (
+    piece.tuningCommitted === false &&
+    piece.tuningVariants != null &&
+    piece.tuningVariants.length > 0
+  ) {
+    return piece.tuningVariants;
+  }
+  return [resolvePieceStatTotals(piece)];
+}
+
+function activeConstraintRows(
+  constraints: StatConstraintRow[],
+): StatConstraintRow[] {
+  return constraints.filter(isActiveStatConstraint);
+}
+
+type ModAllocatorState = {
+  totals: Record<ArmorStatName, number>;
+  modAllocation: Partial<Record<ArmorStatName, number>>;
+  majorRemaining: number;
+  minorRemaining: number;
+};
+
+type StatDeficit = {
+  stat: ArmorStatName;
+  deficit: number;
+};
+
+function activeDeficits(
+  totals: Record<ArmorStatName, number>,
+  activeRows: StatConstraintRow[],
+): StatDeficit[] {
+  return activeRows
+    .map((row) => ({
+      stat: row.stat,
+      deficit: row.min - (totals[row.stat] ?? 0),
+    }))
+    .filter((row) => row.deficit > 0)
+    .sort((a, b) => b.deficit - a.deficit);
+}
+
+/**
+ * Assign finite major (+10) and minor (+5) mod pools toward active minimums.
+ * Only stats with active constraints may receive assumed mods.
+ */
+function allocateAssumedMods(
+  armorWithFragments: Record<ArmorStatName, number>,
+  constraints: StatConstraintRow[],
+  assumedMods: AssumedStatMods,
+): ModAllocatorState | null {
+  const budget = totalAssumedModBudget(assumedMods);
+  const activeRows = activeConstraintRows(constraints);
+  const totals = { ...armorWithFragments };
+  const modAllocation: Partial<Record<ArmorStatName, number>> = {};
+  let majorLeft = budget.majorCount;
+  let minorLeft = budget.minorCount;
+
+  if (assumedMods.artifice !== false) {
+    for (const row of activeRows) {
+      const deficit = row.min - (totals[row.stat] ?? 0);
+      if (deficit <= 0 || deficit > ARTIFICE_ARMOR_STAT_MOD) {
+        continue;
+      }
+      const cap = maxAllowedStatTotalForRow(row);
+      const current = totals[row.stat] ?? 0;
+      if (current + ARTIFICE_ARMOR_STAT_MOD > cap) {
+        continue;
+      }
+      totals[row.stat] = current + ARTIFICE_ARMOR_STAT_MOD;
+      modAllocation[row.stat] =
+        (modAllocation[row.stat] ?? 0) + ARTIFICE_ARMOR_STAT_MOD;
+    }
+  }
+
+  while (majorLeft > 0 || minorLeft > 0) {
+    const needs = activeDeficits(totals, activeRows);
+    if (needs.length === 0) {
+      break;
+    }
+
+    let placed = false;
+    for (const { stat, deficit } of needs) {
+      const row = activeRows.find((r) => r.stat === stat);
+      if (!row) continue;
+      const cap = maxAllowedStatTotalForRow(row);
+      const current = totals[stat] ?? 0;
+      const canMajor =
+        majorLeft > 0 && current + MAJOR_ARMOR_STAT_MOD <= cap;
+      const canMinor =
+        minorLeft > 0 && current + MINOR_ARMOR_STAT_MOD <= cap;
+
+      const useMinor =
+        canMinor &&
+        (!canMajor ||
+          deficit <= MINOR_ARMOR_STAT_MOD ||
+          current + MAJOR_ARMOR_STAT_MOD > cap);
+      const useMajor = canMajor && !useMinor;
+
+      if (!useMajor && !useMinor) {
+        continue;
+      }
+
+      const delta = useMajor ? MAJOR_ARMOR_STAT_MOD : MINOR_ARMOR_STAT_MOD;
+      totals[stat] = current + delta;
+      modAllocation[stat] = (modAllocation[stat] ?? 0) + delta;
+      if (useMajor) {
+        majorLeft -= 1;
+      } else {
+        minorLeft -= 1;
+      }
+      placed = true;
+      break;
+    }
+
+    if (!placed) {
+      return null;
+    }
+  }
+
+  if (activeDeficits(totals, activeRows).length > 0) {
+    return null;
+  }
+
+  return {
+    totals,
+    modAllocation,
+    majorRemaining: majorLeft,
+    minorRemaining: minorLeft,
+  };
+}
+
+function resolveWithTuningChoices(
+  pieces: DerivedArmorPieceJson[],
+  variantIndices: number[],
+  constraints: StatConstraintRow[],
+  fragmentOffset: Partial<Record<ArmorStatName, number>>,
+  assumedMods: AssumedStatMods,
+): ResolvedLoadout | null {
+  const branchMaps: Partial<Record<ArmorStatName, number>>[] = [];
+  const tuningBySlot: Partial<Record<OptimizerSlotKey, TuningAssignment>> = {};
+
+  for (let i = 0; i < pieces.length; i++) {
+    const piece = pieces[i]!;
+    const candidates = pieceTuningCandidates(piece);
+    const branch = candidates[variantIndices[i]!] ?? candidates[0]!;
+    branchMaps.push(branch);
+    if (
+      piece.tuningCommitted === false &&
+      piece.tuningVariants != null &&
+      piece.tuningVariants.length > 0
+    ) {
+      tuningBySlot[SLOT_ORDER[i]! as OptimizerSlotKey] = branch;
+    }
+  }
+
+  const armorTotals = sumStatMaps(branchMaps);
+  const withFragments = addStatOffsets(
+    armorTotals,
+    fragmentOffset as Record<ArmorStatName, number>,
+  );
+
+  const allocated = allocateAssumedMods(
+    withFragments,
+    constraints,
+    assumedMods,
+  );
+  if (allocated == null) {
+    return null;
+  }
+
+  if (!satisfiesConstraints(allocated.totals, constraints)) {
+    return null;
+  }
+
+  return {
+    totals: allocated.totals,
+    ...(Object.keys(tuningBySlot).length > 0 ? { tuningBySlot } : {}),
+    ...(Object.keys(allocated.modAllocation).length > 0
+      ? { modAllocation: allocated.modAllocation }
+      : {}),
+  };
+}
+
+/**
+ * Returns verified loadout totals after picking one tuning branch per piece
+ * and allocating the shared assumed-mod pool. Null when no valid assignment
+ * satisfies constraints.
+ */
+export function resolveLoadoutTotals(
+  pieces: DerivedArmorPieceJson[],
+  constraints: StatConstraintRow[],
+  fragmentOffset: Partial<Record<ArmorStatName, number>> = {},
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+): ResolvedLoadout | null {
+  if (pieces.length !== SLOT_ORDER.length) {
+    return null;
+  }
+
+  const candidateLists = pieces.map(pieceTuningCandidates);
+
+  function visit(
+    slotIndex: number,
+    variantIndices: number[],
+  ): ResolvedLoadout | null {
+    if (slotIndex >= pieces.length) {
+      return resolveWithTuningChoices(
+        pieces,
+        variantIndices,
+        constraints,
+        fragmentOffset,
+        assumedMods,
+      );
+    }
+
+    for (let v = 0; v < candidateLists[slotIndex]!.length; v++) {
+      const resolved = visit(slotIndex + 1, [...variantIndices, v]);
+      if (resolved != null) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+
+  return visit(0, []);
+}
+
+/**
+ * Best verified value for one stat across all tuning branches on a fixed
+ * five-piece loadout. Used by slider bounds — honors constraints on other
+ * stats only (not the focus stat's own target).
+ */
+export function resolveLoadoutStatExtremum(
+  pieces: DerivedArmorPieceJson[],
+  constraints: StatConstraintRow[],
+  fragmentOffset: Partial<Record<ArmorStatName, number>> = {},
+  assumedMods: AssumedStatMods = DEFAULT_ASSUMED_STAT_MODS,
+  focusStat: ArmorStatName,
+  mode: "min" | "max",
+): number | null {
+  if (pieces.length !== SLOT_ORDER.length) {
+    return null;
+  }
+
+  const candidateLists = pieces.map(pieceTuningCandidates);
+  let best: number | null = null;
+
+  function visit(slotIndex: number, variantIndices: number[]): void {
+    if (slotIndex >= pieces.length) {
+      const resolved = resolveWithTuningChoices(
+        pieces,
+        variantIndices,
+        constraints,
+        fragmentOffset,
+        assumedMods,
+      );
+      if (resolved == null) {
+        return;
+      }
+      const value = resolved.totals[focusStat] ?? 0;
+      if (best == null) {
+        best = value;
+      } else if (mode === "max") {
+        best = Math.max(best, value);
+      } else {
+        best = Math.min(best, value);
+      }
+      return;
+    }
+
+    for (let v = 0; v < candidateLists[slotIndex]!.length; v++) {
+      visit(slotIndex + 1, [...variantIndices, v]);
+    }
+  }
+
+  visit(0, []);
+  return best;
+}
+
+/** Sum of raw armor stats from committed rolls (ignores tuning variants). */
+export function armorStatSumFromPieces(
+  pieces: DerivedArmorPieceJson[],
+): number {
+  let sum = 0;
+  for (const piece of pieces) {
+    const totals = getPieceStatTotals(piece);
+    for (const stat of ARMOR_STAT_NAMES) {
+      sum += totals[stat] ?? 0;
+    }
+  }
+  return sum;
+}
+
+/** Upper bound sanity check: armor + mod pool + net fragment offset. */
+export function maxVerifiedTotalSum(
+  pieces: DerivedArmorPieceJson[],
+  fragmentOffset: Partial<Record<ArmorStatName, number>>,
+  assumedMods: AssumedStatMods,
+): number {
+  const armorSum = armorStatSumFromPieces(pieces);
+  const fragmentNet = ARMOR_STAT_NAMES.reduce(
+    (acc, stat) => acc + (fragmentOffset[stat] ?? 0),
+    0,
+  );
+  return armorSum + totalAssumedModBudget(assumedMods).total + fragmentNet;
+}

--- a/src/lib/optimizer/run-search.ts
+++ b/src/lib/optimizer/run-search.ts
@@ -1,4 +1,9 @@
-import { computeStatBounds } from "@/lib/optimizer/bounds";
+import {
+  computeStatBounds,
+  estimateOptimizerComboCount,
+  SEARCH_AUTO_RUN_COMBO_LIMIT,
+} from "@/lib/optimizer/bounds";
+import { DEFAULT_EXOTIC_LOCK } from "@/lib/optimizer/exotic-lock";
 import { searchLoadouts } from "@/lib/optimizer/search";
 import type {
   OptimizerRequest,
@@ -17,11 +22,27 @@ export async function runOptimizerSearch(
   onProgress?: (percent: number) => void,
   isCancelled?: () => boolean,
 ): Promise<OptimizerSearchResult> {
-  const bounds = computeStatBounds(
-    payload.pool,
-    payload.statOffset,
-    payload.exoticLock,
-  );
+  onProgress?.(0);
+
+  const exoticLock = payload.exoticLock ?? DEFAULT_EXOTIC_LOCK;
+  const comboCount = estimateOptimizerComboCount(payload.pool, exoticLock);
+  const bounds =
+    comboCount <= SEARCH_AUTO_RUN_COMBO_LIMIT
+      ? computeStatBounds(
+          payload.pool,
+          payload.statOffset,
+          exoticLock,
+          payload.constraints,
+          payload.assumedStatMods,
+        )
+      : computeStatBounds(
+          payload.pool,
+          payload.statOffset,
+          exoticLock,
+          undefined,
+          payload.assumedStatMods,
+        );
+
   await new Promise<void>((resolve) => {
     setTimeout(resolve, 0);
   });

--- a/src/lib/optimizer/search.test.ts
+++ b/src/lib/optimizer/search.test.ts
@@ -12,6 +12,7 @@ function mockPiece(
   slot: DerivedArmorPieceJson["slot"],
   id: string,
   statTotals: Partial<Record<string, number>>,
+  extra: Partial<DerivedArmorPieceJson> = {},
 ): DerivedArmorPieceJson {
   return {
     itemInstanceId: id,
@@ -30,6 +31,7 @@ function mockPiece(
     tertiaryStat: "Class",
     statTotals: statTotals as DerivedArmorPieceJson["statTotals"],
     location: { kind: "vault" },
+    ...extra,
   };
 }
 
@@ -53,15 +55,42 @@ describe("searchLoadouts", () => {
     expect(solutions.length).toBeGreaterThan(0);
   });
 
-  it("rejects negative stat totals when min is pinned at zero", () => {
+  it("floors negative stat totals to zero for constraint checks", () => {
     const totals = totalsFromPieces([
-      mockPiece("helmet", "h1", { Grenade: -10 }),
+      mockPiece("helmet", "h1", { Grenade: -5 }),
     ]);
     const constraints = ARMOR_STAT_NAMES.map((stat) => ({
       stat,
       min: 0,
     }));
-    expect(satisfiesConstraints(totals, constraints)).toBe(false);
+    expect(totals.Grenade).toBe(-5);
+    expect(satisfiesConstraints(totals, constraints)).toBe(true);
+  });
+
+  it("still searches when set bonuses and stat targets are both active", () => {
+    const pool = SLOT_ORDER.flatMap((slot) => [
+      {
+        ...mockPiece(slot, `${slot}-10`, { Weapons: 40, Health: 30 }),
+        setHash: 10,
+      },
+      {
+        ...mockPiece(slot, `${slot}-20`, { Weapons: 35, Health: 20 }),
+        setHash: 20,
+      },
+    ]);
+    const solutions = searchLoadouts({
+      pool,
+      constraints: [
+        { stat: "Weapons", min: 180 },
+        { stat: "Health", min: 100 },
+      ],
+      setBonusSelections: [
+        { setHash: 10, requiredCount: 2, perkHash: 1 },
+        { setHash: 20, requiredCount: 2, perkHash: 2 },
+      ],
+      assumedStatMods: { majorCount: 5 },
+    });
+    expect(solutions.length).toBeGreaterThan(0);
   });
 
   it("enforces set bonus piece counts", () => {
@@ -84,12 +113,20 @@ describe("searchLoadouts", () => {
     }
   });
 
-  it("counts alternate tuning branches toward stat targets", () => {
+  it("uses verified tuning branches for uncommitted pieces", () => {
     const pool = SLOT_ORDER.map((slot, index) => {
       if (index === 0) {
         return {
-          ...mockPiece(slot, `id-${slot}`, { Weapons: 30 }),
-          tuningVariants: [{ Weapons: 39 }],
+          ...mockPiece(slot, `id-${slot}`, {
+            Weapons: 30,
+            Grenade: 10,
+            Melee: 10,
+          }),
+          tuningCommitted: false,
+          tuningVariants: [
+            { Weapons: 35, Grenade: 5, Melee: 10 },
+            { Weapons: 39, Grenade: 10, Melee: 10 },
+          ],
         };
       }
       return mockPiece(slot, `id-${slot}`, { Weapons: 25 });
@@ -98,11 +135,253 @@ describe("searchLoadouts", () => {
       pool,
       constraints: ARMOR_STAT_NAMES.map((stat) => ({
         stat,
-        min: stat === "Weapons" ? 139 : 0,
+        min: stat === "Weapons" ? 135 : 0,
       })),
-      statOffset: { Weapons: 0 },
+      assumedStatMods: { majorCount: 0, slotFill: false },
     });
     expect(solutions.length).toBeGreaterThan(0);
-    expect(solutions[0]!.totals.Weapons).toBeGreaterThanOrEqual(139);
+    expect(solutions[0]!.totals.Weapons).toBeGreaterThanOrEqual(135);
+    expect(solutions[0]!.totals.Weapons).toBeLessThanOrEqual(39 + 25 * 4);
+    const helmetBranch = solutions[0]!.resolved?.tuningBySlot?.helmet;
+    expect(helmetBranch).toBeDefined();
+    expect(helmetBranch!.Weapons).toBeGreaterThanOrEqual(35);
+  });
+
+  it("finds builds when stat mins require assumed mods during branch pruning", () => {
+    const pool = SLOT_ORDER.map((slot) =>
+      mockPiece(slot, `id-${slot}`, {
+        Weapons: 30,
+        Health: 25,
+        Class: 20,
+        Grenade: 10,
+        Melee: 10,
+        Super: 10,
+      }),
+    );
+    const solutions = searchLoadouts({
+      pool,
+      constraints: [{ stat: "Weapons", min: 158 }],
+      assumedStatMods: { majorCount: 4 },
+    });
+    expect(solutions.length).toBeGreaterThan(0);
+    expect(solutions[0]!.totals.Weapons).toBeGreaterThanOrEqual(158);
+  });
+
+  it("finds builds with dual set bonuses, locked exotic, and mod-assisted mins", () => {
+    const pool = SLOT_ORDER.flatMap((slot) => {
+      const pieces = [
+        mockPiece(
+          slot,
+          `${slot}-10`,
+          {
+            Weapons: 30,
+            Health: 25,
+            Class: 20,
+            Grenade: 10,
+            Melee: 10,
+            Super: 10,
+          },
+          { setHash: 10 },
+        ),
+        mockPiece(
+          slot,
+          `${slot}-20`,
+          {
+            Weapons: 28,
+            Health: 25,
+            Class: 20,
+            Grenade: 10,
+            Melee: 10,
+            Super: 10,
+          },
+          { setHash: 20 },
+        ),
+      ];
+      if (slot === "helmet") {
+        pieces.push({
+          ...mockPiece(
+            slot,
+            "helmet-x",
+            {
+              Weapons: 35,
+              Health: 20,
+              Class: 15,
+              Grenade: 10,
+              Melee: 10,
+              Super: 10,
+            },
+            { setHash: 99 },
+          ),
+          isExotic: true,
+        });
+      }
+      return pieces;
+    });
+    const solutions = searchLoadouts({
+      pool,
+      constraints: [
+        { stat: "Weapons", min: 158 },
+        { stat: "Health", min: 14 },
+        { stat: "Class", min: 50 },
+        { stat: "Grenade", min: 55 },
+        { stat: "Melee", min: 12 },
+        { stat: "Super", min: 65 },
+      ],
+      setBonusSelections: [
+        { setHash: 10, requiredCount: 2, perkHash: 1 },
+        { setHash: 20, requiredCount: 2, perkHash: 2 },
+      ],
+      assumedStatMods: { majorCount: 4 },
+      exoticLock: {
+        mode: "locked",
+        itemInstanceId: "helmet-x",
+        slot: "helmet",
+      },
+    });
+    expect(solutions.length).toBeGreaterThan(0);
+  });
+
+  it("finds warlock-style multi-target builds with dual 2pc sets", () => {
+    const pool = SLOT_ORDER.flatMap((slot) => {
+      const pieces = [
+        mockPiece(
+          slot,
+          `${slot}-ferro`,
+          {
+            Weapons: 40,
+            Health: 22,
+            Class: 14,
+            Grenade: 20,
+            Melee: 8,
+            Super: 14,
+          },
+          { setHash: 10, setName: "Ferropotent", classType: 2 },
+        ),
+        mockPiece(
+          slot,
+          `${slot}-smoke`,
+          {
+            Weapons: 38,
+            Health: 24,
+            Class: 12,
+            Grenade: 22,
+            Melee: 9,
+            Super: 13,
+          },
+          { setHash: 20, setName: "Smoke Jumper", classType: 2 },
+        ),
+      ];
+      return pieces;
+    });
+    const solutions = searchLoadouts({
+      pool,
+      constraints: [
+        { stat: "Weapons", min: 200 },
+        { stat: "Health", min: 10 },
+        { stat: "Class", min: 50 },
+        { stat: "Grenade", min: 100 },
+        { stat: "Melee", min: 10 },
+        { stat: "Super", min: 70 },
+      ],
+      setBonusSelections: [
+        { setHash: 10, requiredCount: 2, perkHash: 1 },
+        { setHash: 20, requiredCount: 2, perkHash: 2 },
+      ],
+      assumedStatMods: { majorCount: 3 },
+    });
+    expect(solutions.length).toBeGreaterThan(0);
+    expect(solutions[0]!.totals.Weapons).toBeGreaterThanOrEqual(200);
+    expect(solutions[0]!.totals.Grenade).toBeGreaterThanOrEqual(100);
+    expect(solutions[0]!.totals.Super).toBeGreaterThanOrEqual(70);
+  });
+
+  it("finds multi-target builds with split major/minor mod budget", () => {
+    const pool = SLOT_ORDER.map((slot) =>
+      mockPiece(slot, `id-${slot}`, {
+        Weapons: 38,
+        Health: 25,
+        Class: 20,
+        Grenade: 20,
+        Melee: 13,
+        Super: 10,
+      }),
+    );
+    const solutions = searchLoadouts({
+      pool,
+      constraints: [
+        { stat: "Weapons", min: 200 },
+        { stat: "Health", min: 50 },
+        { stat: "Grenade", min: 100 },
+        { stat: "Melee", min: 63 },
+      ],
+      assumedStatMods: { majorCount: 3 },
+    });
+    expect(solutions.length).toBeGreaterThan(0);
+  });
+
+  it("accepts a +10 mod overshoot when meeting a 200 minimum", () => {
+    const pool = SLOT_ORDER.map((slot) =>
+      mockPiece(slot, `id-${slot}`, {
+        Weapons: 39,
+        Health: 25,
+        Class: 20,
+        Grenade: 18,
+        Melee: 10,
+        Super: 14,
+      }),
+    );
+    const solutions = searchLoadouts({
+      pool,
+      constraints: [{ stat: "Weapons", min: 200 }],
+      assumedStatMods: { majorCount: 3 },
+    });
+    expect(solutions.length).toBeGreaterThan(0);
+    expect(solutions[0]!.totals.Weapons).toBeGreaterThanOrEqual(200);
+    expect(solutions[0]!.totals.Weapons).toBeLessThanOrEqual(210);
+  });
+
+  it("returns immediately when targets exceed achievable bounds", () => {
+    const pool = SLOT_ORDER.map((slot) =>
+      mockPiece(slot, `id-${slot}`, { Weapons: 40, Health: 25 }),
+    );
+    const solutions = searchLoadouts({
+      pool,
+      constraints: ARMOR_STAT_NAMES.map((stat) => ({
+        stat,
+        min: stat === "Weapons" ? 250 : 0,
+      })),
+      assumedStatMods: { majorCount: 4 },
+    });
+    expect(solutions).toEqual([]);
+  });
+
+  it("does not inflate totals with duplicated mod budget across targets", () => {
+    const pool = SLOT_ORDER.map((slot) =>
+      mockPiece(slot, `id-${slot}`, {
+        Weapons: 40,
+        Health: 25,
+        Class: 20,
+        Grenade: 10,
+      }),
+    );
+    const solutions = searchLoadouts({
+      pool,
+      constraints: [
+        { stat: "Weapons", min: 200 },
+        { stat: "Health", min: 50 },
+        { stat: "Class", min: 50 },
+        { stat: "Grenade", min: 50 },
+        { stat: "Melee", min: 50 },
+        { stat: "Super", min: 50 },
+      ],
+      assumedStatMods: { majorCount: 5 },
+    });
+    for (const solution of solutions) {
+      const sum = ARMOR_STAT_NAMES.reduce(
+        (acc, stat) => acc + solution.totals[stat],
+        0,
+      );
+      expect(sum).toBeLessThanOrEqual(40 * 5 + 10 * 4 + 20 * 5 + 50);
+    }
   });
 });

--- a/src/lib/optimizer/search.ts
+++ b/src/lib/optimizer/search.ts
@@ -1,11 +1,13 @@
 import { SLOT_ORDER } from "@/lib/bungie/constants";
 import { ARMOR_STAT_NAMES, type DerivedArmorPieceJson } from "@/lib/db/types";
 import { getPieceStatCeiling } from "@/lib/inventory/compute-stat-totals";
+import { areConstraintsAchievable } from "@/lib/optimizer/bounds";
+import { estimateFilteredComboCount } from "@/lib/optimizer/combo-count";
 import {
   partialCanReachMins,
-  satisfiesConstraints,
   scoreSolution,
   totalsFromPieces,
+  hasStatTargets,
 } from "@/lib/optimizer/constraints";
 import { dedupeSlotPieces } from "@/lib/optimizer/dedupe";
 import {
@@ -16,6 +18,8 @@ import {
   resolveLockedExoticIdentityKey,
 } from "@/lib/optimizer/exotic-lock";
 import { addStatOffsets } from "@/lib/optimizer/fragment-offset";
+import { DEFAULT_ASSUMED_STAT_MODS } from "@/lib/optimizer/mod-offset";
+import { resolveLoadoutTotals } from "@/lib/optimizer/resolve-loadout-totals";
 import {
   partialCanSatisfySetBonuses,
   satisfiesSetBonuses,
@@ -61,6 +65,42 @@ export function searchLoadouts(
   const topN = request.topN ?? 20;
   const exoticLock = request.exoticLock ?? DEFAULT_EXOTIC_LOCK;
   const setBonusSelections = request.setBonusSelections ?? [];
+  const assumedMods = request.assumedStatMods ?? DEFAULT_ASSUMED_STAT_MODS;
+  const fragmentOffset = request.statOffset ?? {};
+
+  if (
+    hasStatTargets(request.constraints) ||
+    setBonusSelections.length > 0
+  ) {
+    const { count: anyFeasible } = estimateFilteredComboCount(
+      request.pool,
+      exoticLock,
+      {
+        constraints: request.constraints,
+        setBonusSelections,
+        statOffset: fragmentOffset,
+        assumedMods,
+        cap: 1,
+      },
+    );
+    if (anyFeasible === 0) {
+      onProgress?.(100);
+      return [];
+    }
+  } else if (
+    !areConstraintsAchievable(
+      request.pool,
+      request.constraints,
+      fragmentOffset,
+      exoticLock,
+      assumedMods,
+      setBonusSelections,
+    )
+  ) {
+    onProgress?.(100);
+    return [];
+  }
+
   const bySlot = groupPoolBySlot(request.pool);
   const lockedIdentityKey = resolveLockedExoticIdentityKey(
     exoticLock,
@@ -129,25 +169,33 @@ export function searchLoadouts(
       if (!satisfiesSetBonuses(chosen, setBonusSelections)) {
         return;
       }
-      if (satisfiesConstraints(partialTotals, request.constraints)) {
-        const slots = Object.fromEntries(
-          chosen.map((piece, i) => [SLOT_ORDER[i]!, piece.itemInstanceId]),
-        ) as OptimizerSolution["slots"];
-        const interchangeable = Object.fromEntries(
-          chosen.map((piece, i) => [
-            SLOT_ORDER[i]!,
-            membersByInstanceId.get(piece.itemInstanceId) ?? [
-              piece.itemInstanceId,
-            ],
-          ]),
-        ) as NonNullable<OptimizerSolution["interchangeable"]>;
-        candidates.push({
-          slots,
-          totals: partialTotals,
-          signature: solutionSignature(partialTotals),
-          interchangeable,
-        });
+      const resolved = resolveLoadoutTotals(
+        chosen,
+        request.constraints,
+        fragmentOffset,
+        assumedMods,
+      );
+      if (resolved == null) {
+        return;
       }
+      const slots = Object.fromEntries(
+        chosen.map((piece, i) => [SLOT_ORDER[i]!, piece.itemInstanceId]),
+      ) as OptimizerSolution["slots"];
+      const interchangeable = Object.fromEntries(
+        chosen.map((piece, i) => [
+          SLOT_ORDER[i]!,
+          membersByInstanceId.get(piece.itemInstanceId) ?? [
+            piece.itemInstanceId,
+          ],
+        ]),
+      ) as NonNullable<OptimizerSolution["interchangeable"]>;
+      candidates.push({
+        slots,
+        totals: resolved.totals,
+        signature: solutionSignature(resolved.totals),
+        interchangeable,
+        resolved,
+      });
       return;
     }
 
@@ -180,6 +228,7 @@ export function searchLoadouts(
           remaining - 1,
           perSlotMax,
           request.constraints,
+          assumedMods,
         )
       ) {
         continue;
@@ -200,10 +249,10 @@ export function searchLoadouts(
 
   const zeroTotals = totalsFromPieces([]);
   const startTotals =
-    request.statOffset && Object.keys(request.statOffset).length > 0
+    Object.keys(fragmentOffset).length > 0
       ? addStatOffsets(
           zeroTotals,
-          request.statOffset as Record<(typeof ARMOR_STAT_NAMES)[number], number>,
+          fragmentOffset as Record<(typeof ARMOR_STAT_NAMES)[number], number>,
         )
       : zeroTotals;
   visit(0, [], startTotals);

--- a/src/lib/optimizer/set-bonus.ts
+++ b/src/lib/optimizer/set-bonus.ts
@@ -39,6 +39,17 @@ export function partialCanSatisfySetBonuses(
 ): boolean {
   if (selections.length === 0) return true;
   const counts = countPiecesBySetHash(chosen);
+  let totalNeed = 0;
+  for (const sel of selections) {
+    const have = counts.get(sel.setHash) ?? 0;
+    const need = sel.requiredCount - have;
+    if (need > 0) {
+      totalNeed += need;
+    }
+  }
+  if (totalNeed > remainingSlots.length) {
+    return false;
+  }
   for (const sel of selections) {
     const have = counts.get(sel.setHash) ?? 0;
     const need = sel.requiredCount - have;

--- a/src/lib/optimizer/stat-range.ts
+++ b/src/lib/optimizer/stat-range.ts
@@ -5,6 +5,9 @@ export const OPTIMIZER_STAT_MAX = 200;
 /** Tier milestone ticks on the 0–200 stat track (D2ArmorPicker-style). */
 export const OPTIMIZER_STAT_TIER_MARKS = [50, 100, 150, 200] as const;
 
+/** Clickable min-target presets on the stat slider track. */
+export const OPTIMIZER_STAT_SEGMENTS = [0, 50, 100, 200] as const;
+
 export function clampOptimizerStat(value: number): number {
   return Math.round(
     Math.min(OPTIMIZER_STAT_MAX, Math.max(OPTIMIZER_STAT_MIN, value)),

--- a/src/lib/optimizer/types.ts
+++ b/src/lib/optimizer/types.ts
@@ -1,5 +1,7 @@
 import type { ArmorStatName, DerivedArmorPieceJson } from "@/lib/db/types";
 import type { ExoticLock } from "@/lib/optimizer/exotic-lock";
+import type { AssumedStatMods } from "@/lib/optimizer/mod-offset";
+import type { ResolvedLoadout } from "@/lib/optimizer/resolve-loadout-totals";
 import type { SetBonusSelection } from "@/lib/optimizer/set-bonus";
 
 /** Per-stat minimum target; array order = priority. min 0 = no target. */
@@ -11,8 +13,10 @@ export type StatConstraintRow = {
 export type OptimizerRequest = {
   pool: DerivedArmorPieceJson[];
   constraints: StatConstraintRow[];
-  /** Fixed armor-stat bonus from selected subclass fragments (and similar plugs). */
+  /** Fragment (and similar) flat per-stat offset — not assumed armor mods. */
   statOffset?: Partial<Record<ArmorStatName, number>>;
+  /** Shared major/minor mod pool assumed across the loadout. */
+  assumedStatMods?: AssumedStatMods;
   exoticLock?: ExoticLock;
   setBonusSelections?: SetBonusSelection[];
   pinnedInstanceIds?: string[];
@@ -38,6 +42,8 @@ export type OptimizerSolution = {
    * the chosen piece (always includes the chosen piece itself).
    */
   interchangeable?: Record<OptimizerSlotKey, string[]>;
+  /** Verified tuning branches and mod allocation when available. */
+  resolved?: ResolvedLoadout;
 };
 
 export type WorkerRunMessage = {

--- a/src/lib/optimizer/use-optimizer-auto-run.ts
+++ b/src/lib/optimizer/use-optimizer-auto-run.ts
@@ -4,11 +4,17 @@ import { useEffect, useRef } from "react";
 import { hasStatTargets } from "@/lib/optimizer/constraints";
 import type { OptimizerRequest } from "@/lib/optimizer/types";
 
-const AUTO_RUN_DEBOUNCE_MS = 300;
+/** Request debounce lives in `searchConstraints`; run as soon as that commits. */
+const AUTO_RUN_DEBOUNCE_MS = 0;
 
+/**
+ * Schedules automatic optimizer runs when `canAutoRun` is true.
+ * Does not cancel in-flight work when auto-run is disabled (large vault) —
+ * hard aborts are handled separately in the view layer.
+ */
 export function useOptimizerAutoRun(
   request: OptimizerRequest,
-  canRun: boolean,
+  canAutoRun: boolean,
   run: (payload: OptimizerRequest) => void,
   cancel: () => void,
 ) {
@@ -21,10 +27,9 @@ export function useOptimizerAutoRun(
   });
 
   useEffect(() => {
-    const shouldRun = canRun && hasStatTargets(request.constraints);
-
-    if (!shouldRun) {
-      cancelRef.current();
+    const hasTargets = hasStatTargets(request.constraints);
+    const hasSetBonuses = (request.setBonusSelections?.length ?? 0) > 0;
+    if (!canAutoRun || (!hasTargets && !hasSetBonuses)) {
       return;
     }
 
@@ -34,6 +39,7 @@ export function useOptimizerAutoRun(
 
     return () => {
       window.clearTimeout(timer);
+      cancelRef.current();
     };
-  }, [canRun, request]);
+  }, [canAutoRun, request]);
 }

--- a/src/lib/optimizer/use-stat-bounds-for-sliders.ts
+++ b/src/lib/optimizer/use-stat-bounds-for-sliders.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ArmorStatName, DerivedArmorPieceJson } from "@/lib/db/types";
+import { computeStatBounds } from "@/lib/optimizer/bounds";
+import type { ExoticLock } from "@/lib/optimizer/exotic-lock";
+import type { AssumedStatMods } from "@/lib/optimizer/mod-offset";
+import type { SetBonusSelection } from "@/lib/optimizer/set-bonus";
+import type { StatBounds, StatConstraintRow } from "@/lib/optimizer/types";
+
+export type UseStatBoundsForSlidersArgs = {
+  pool: DerivedArmorPieceJson[];
+  /** Fragment-only flat per-stat offset. */
+  statOffset: Partial<Record<ArmorStatName, number>>;
+  assumedStatMods: AssumedStatMods;
+  exoticLock: ExoticLock;
+  constraints: StatConstraintRow[];
+  setBonusSelections?: SetBonusSelection[];
+};
+
+/**
+ * Achievable ranges for stat sliders. Uses fast greedy cross-stat tightening
+ * when targets are set; exact joint bounds only on tiny pools.
+ */
+export function useStatBoundsForSliders({
+  pool,
+  statOffset,
+  assumedStatMods,
+  exoticLock,
+  constraints,
+  setBonusSelections = [],
+}: UseStatBoundsForSlidersArgs): StatBounds {
+  return useMemo(
+    () =>
+      computeStatBounds(
+        pool,
+        statOffset,
+        exoticLock,
+        constraints,
+        assumedStatMods,
+        setBonusSelections,
+      ),
+    [pool, statOffset, assumedStatMods, exoticLock, constraints, setBonusSelections],
+  );
+}

--- a/src/lib/optimizer/user-build-speakers-sight.test.ts
+++ b/src/lib/optimizer/user-build-speakers-sight.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import { searchLoadouts } from "@/lib/optimizer/search";
+import { verifyLoadout } from "@/lib/optimizer/verify-loadout";
+import { resolveLoadoutTotals } from "@/lib/optimizer/resolve-loadout-totals";
+import { estimateFilteredComboCount } from "@/lib/optimizer/combo-count";
+import { computeStatBounds } from "@/lib/optimizer/bounds";
+import { DEFAULT_EXOTIC_LOCK } from "@/lib/optimizer/exotic-lock";
+
+/** Real manifest set hashes from inventory cache. */
+const FERROPOTENT_HASH = 3_734_029_045;
+const SMOKE_JUMPER_HASH = 2_751_989_785;
+
+/** User DIM loadout instance ids (Warlock Speaker's Sight + Ferropotent / Smoke Jumper). */
+export const USER_DIM_INSTANCE_IDS = [
+  "6917530125283917710",
+  "6917530167771126356",
+  "6917530146795020473",
+  "6917530159911796935",
+  "6917530147186685296",
+] as const;
+
+/**
+ * Stat totals from Bungie ItemStats (304) on Speaker's Sight plus cached
+ * legendary `statTotals` rows (sparse — only non-zero stats stored).
+ */
+function userBuildPool(): DerivedArmorPieceJson[] {
+  const base = {
+    classType: 2,
+    archetypeHash: 1,
+    archetypeName: "Gunner",
+    tuningHash: 1,
+    tuningName: "+Weapons",
+    tuningCommitted: true,
+    tier: 5 as const,
+    location: { kind: "vault" as const },
+  };
+
+  return [
+    {
+      ...base,
+      itemInstanceId: USER_DIM_INSTANCE_IDS[0],
+      itemHash: 50_291_571,
+      slot: "helmet",
+      isExotic: true,
+      setHash: null,
+      setName: null,
+      displayName: "Speaker's Sight",
+      primaryStat: "Weapons" as const,
+      secondaryStat: "Health" as const,
+      tertiaryStat: "Grenade" as const,
+      statTotals: {
+        Weapons: 31,
+        Health: 8,
+        Grenade: 16,
+        Class: 4,
+        Melee: 4,
+        Super: 20,
+      },
+    },
+    {
+      ...base,
+      itemInstanceId: USER_DIM_INSTANCE_IDS[1],
+      itemHash: 9_002,
+      slot: "arms",
+      setHash: FERROPOTENT_HASH,
+      setName: "Ferropotent",
+      displayName: "Ferropotent",
+      primaryStat: "Weapons" as const,
+      secondaryStat: "Grenade" as const,
+      tertiaryStat: "Super" as const,
+      statTotals: {
+        Melee: -5,
+        Super: 20,
+        Grenade: 25,
+        Weapons: 35,
+      },
+    },
+    {
+      ...base,
+      itemInstanceId: USER_DIM_INSTANCE_IDS[2],
+      itemHash: 9_003,
+      slot: "chest",
+      setHash: SMOKE_JUMPER_HASH,
+      setName: "Smoke Jumper Set",
+      displayName: "Smoke Jumper Set",
+      tuningName: "+Grenade",
+      primaryStat: "Weapons" as const,
+      secondaryStat: "Grenade" as const,
+      tertiaryStat: "Super" as const,
+      statTotals: {
+        Super: 20,
+        Health: -5,
+        Grenade: 30,
+        Weapons: 30,
+      },
+    },
+    {
+      ...base,
+      itemInstanceId: USER_DIM_INSTANCE_IDS[3],
+      itemHash: 9_004,
+      slot: "legs",
+      setHash: FERROPOTENT_HASH,
+      setName: "Ferropotent",
+      displayName: "Ferropotent",
+      primaryStat: "Weapons" as const,
+      secondaryStat: "Grenade" as const,
+      tertiaryStat: "Class" as const,
+      statTotals: {
+        Class: 20,
+        Health: -5,
+        Grenade: 25,
+        Weapons: 35,
+      },
+    },
+    {
+      ...base,
+      itemInstanceId: USER_DIM_INSTANCE_IDS[4],
+      itemHash: 9_005,
+      slot: "classItem",
+      setHash: SMOKE_JUMPER_HASH,
+      setName: "Smoke Jumper Set",
+      displayName: "Smoke Jumper Set",
+      primaryStat: "Weapons" as const,
+      secondaryStat: "Grenade" as const,
+      tertiaryStat: "Class" as const,
+      statTotals: {
+        Class: 20,
+        Health: -5,
+        Grenade: 25,
+        Weapons: 35,
+      },
+    },
+  ];
+}
+
+const SCREENSHOT_CONSTRAINTS = [
+  { stat: "Weapons" as const, min: 200 },
+  { stat: "Class" as const, min: 50 },
+  { stat: "Grenade" as const, min: 100 },
+  { stat: "Super" as const, min: 70 },
+];
+
+const SET_BONUSES = [
+  { setHash: FERROPOTENT_HASH, requiredCount: 2, perkHash: FERROPOTENT_HASH },
+  { setHash: SMOKE_JUMPER_HASH, requiredCount: 2, perkHash: SMOKE_JUMPER_HASH },
+];
+
+const ASSUMED_MODS = { majorCount: 5, slotFill: true, artifice: true };
+
+describe("Speaker's Sight user build (real stat totals)", () => {
+  const pool = userBuildPool();
+  const locked = {
+    mode: "locked" as const,
+    itemInstanceId: USER_DIM_INSTANCE_IDS[0],
+    slot: "helmet" as const,
+  };
+
+  it("finds zero loadouts when exotics are excluded (default lock)", () => {
+    const { count } = estimateFilteredComboCount(pool, DEFAULT_EXOTIC_LOCK, {
+      constraints: SCREENSHOT_CONSTRAINTS,
+      setBonusSelections: SET_BONUSES,
+      assumedMods: ASSUMED_MODS,
+      cap: 1,
+    });
+    expect(count).toBe(0);
+  });
+
+  it("rejects Weapons 200 — five +10 mods cannot close the gap on these rolls", () => {
+    const five = pool;
+    expect(
+      resolveLoadoutTotals(five, SCREENSHOT_CONSTRAINTS, {}, ASSUMED_MODS),
+    ).toBeNull();
+    expect(
+      searchLoadouts({
+        pool,
+        constraints: SCREENSHOT_CONSTRAINTS,
+        setBonusSelections: SET_BONUSES,
+        assumedStatMods: ASSUMED_MODS,
+        exoticLock: locked,
+      }).length,
+    ).toBe(0);
+  });
+
+  it("finds the build at Weapons 196 with Speaker's Sight locked", () => {
+    const constraints = SCREENSHOT_CONSTRAINTS.map((row) =>
+      row.stat === "Weapons" ? { ...row, min: 196 } : row,
+    );
+    const solutions = searchLoadouts({
+      pool,
+      constraints,
+      setBonusSelections: SET_BONUSES,
+      assumedStatMods: ASSUMED_MODS,
+      exoticLock: locked,
+    });
+    expect(solutions.length).toBeGreaterThan(0);
+    const totals = solutions[0]!.totals;
+    expect(totals.Weapons).toBeGreaterThanOrEqual(196);
+    expect(totals.Grenade).toBeGreaterThanOrEqual(100);
+    expect(totals.Super).toBeGreaterThanOrEqual(70);
+    expect(totals.Class).toBeGreaterThanOrEqual(50);
+  });
+
+  it("verifyLoadout fails when Speaker's Sight has empty statTotals", () => {
+    const five = pool.map((p) =>
+      p.isExotic
+        ? {
+            ...p,
+            statTotals: {},
+            primaryStat: null,
+            secondaryStat: null,
+            tertiaryStat: null,
+          }
+        : p,
+    );
+    const result = verifyLoadout(five, {
+      constraints: SCREENSHOT_CONSTRAINTS.map((row) =>
+        row.stat === "Weapons" ? { ...row, min: 196 } : row,
+      ),
+      assumedMods: ASSUMED_MODS,
+      setBonusSelections: SET_BONUSES,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows stacked tuning debuffs on non-target stats (Health floors at 0)", () => {
+    const result = verifyLoadout(pool, {
+      constraints: SCREENSHOT_CONSTRAINTS.map((row) =>
+        row.stat === "Weapons" ? { ...row, min: 196 } : row,
+      ),
+      assumedMods: ASSUMED_MODS,
+      setBonusSelections: SET_BONUSES,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("slider gray bands stay non-zero with set bonuses on the user build", () => {
+    const constraints = [
+      { stat: "Weapons" as const, min: 196 },
+      { stat: "Class" as const, min: 50 },
+      { stat: "Grenade" as const, min: 100 },
+      { stat: "Super" as const, min: 70 },
+    ];
+    const mods = { majorCount: 3, slotFill: true, artifice: true };
+    const bounds = computeStatBounds(
+      pool,
+      {},
+      locked,
+      constraints,
+      mods,
+      SET_BONUSES,
+    );
+    expect(bounds.Weapons.max).toBeGreaterThan(0);
+    expect(bounds.Grenade.max).toBeGreaterThan(0);
+    expect(bounds.Weapons.max).toBeGreaterThanOrEqual(bounds.Weapons.min);
+    expect(bounds.Grenade.max).toBeGreaterThan(bounds.Grenade.min);
+  });
+
+  it("does not zero bounds when greedy fails on a tiny pool", () => {
+    const bounds = computeStatBounds(
+      pool,
+      {},
+      locked,
+      [
+        { stat: "Weapons" as const, min: 200 },
+        { stat: "Super" as const, min: 200 },
+      ],
+      { majorCount: 3, slotFill: true, artifice: true },
+      SET_BONUSES,
+    );
+    expect(bounds.Weapons.max).toBeGreaterThan(0);
+    expect(bounds.Super.max).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/optimizer/verify-loadout.test.ts
+++ b/src/lib/optimizer/verify-loadout.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { SLOT_ORDER } from "@/lib/bungie/constants";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import { verifyLoadout } from "@/lib/optimizer/verify-loadout";
+
+function piece(
+  slot: DerivedArmorPieceJson["slot"],
+  stats: Partial<Record<string, number>>,
+  setHash = 10,
+): DerivedArmorPieceJson {
+  return {
+    itemInstanceId: `id-${slot}`,
+    itemHash: 1,
+    slot,
+    classType: 2,
+    setHash,
+    setName: "Test",
+    displayName: "Test",
+    archetypeHash: 1,
+    archetypeName: "Gunner",
+    tuningHash: 1,
+    tuningName: "+Weapons / -Grenade",
+    primaryStat: "Weapons",
+    secondaryStat: "Health",
+    tertiaryStat: "Class",
+    statTotals: stats as DerivedArmorPieceJson["statTotals"],
+    location: { kind: "vault" },
+  };
+}
+
+describe("verifyLoadout", () => {
+  it("accepts a feasible five-piece loadout", () => {
+    const pool = SLOT_ORDER.map((slot) =>
+      piece(slot, {
+        Weapons: 40,
+        Health: 22,
+        Class: 14,
+        Grenade: 20,
+        Melee: 8,
+        Super: 14,
+      }),
+    );
+    const result = verifyLoadout(pool, {
+      constraints: [
+        { stat: "Weapons", min: 200 },
+        { stat: "Grenade", min: 100 },
+        { stat: "Super", min: 70 },
+      ],
+      assumedMods: { majorCount: 3 },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("explains set bonus mismatch", () => {
+    const pool = SLOT_ORDER.map((slot) => piece(slot, { Weapons: 40 }, 99));
+    const result = verifyLoadout(pool, {
+      constraints: [{ stat: "Weapons", min: 0 }],
+      setBonusSelections: [{ setHash: 10, requiredCount: 2, perkHash: 1 }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/set bonus/i);
+    }
+  });
+});

--- a/src/lib/optimizer/verify-loadout.ts
+++ b/src/lib/optimizer/verify-loadout.ts
@@ -1,0 +1,109 @@
+import { SLOT_ORDER } from "@/lib/bungie/constants";
+import type { DerivedArmorPieceJson } from "@/lib/db/types";
+import {
+  satisfiesConstraints,
+  totalsFromPieces,
+} from "@/lib/optimizer/constraints";
+import { totalAssumedModBudget } from "@/lib/optimizer/mod-offset";
+import {
+  resolveLoadoutTotals,
+  type ResolvedLoadout,
+} from "@/lib/optimizer/resolve-loadout-totals";
+import {
+  satisfiesSetBonuses,
+  type SetBonusSelection,
+} from "@/lib/optimizer/set-bonus";
+import type { StatConstraintRow } from "@/lib/optimizer/types";
+import type { AssumedStatMods } from "@/lib/optimizer/mod-offset";
+import type { ArmorStatName } from "@/lib/db/types";
+import { ARMOR_STAT_NAMES } from "@/lib/db/types";
+
+export type VerifyLoadoutOptions = {
+  constraints: StatConstraintRow[];
+  fragmentOffset?: Partial<Record<ArmorStatName, number>>;
+  assumedMods?: AssumedStatMods;
+  setBonusSelections?: SetBonusSelection[];
+};
+
+export type VerifyLoadoutResult =
+  | { ok: true; resolved: ResolvedLoadout }
+  | { ok: false; reason: string };
+
+/**
+ * Verify a specific five-piece loadout and return a human-readable failure reason.
+ * Useful when debugging “no builds” reports against known armor pieces.
+ */
+export function verifyLoadout(
+  pieces: DerivedArmorPieceJson[],
+  options: VerifyLoadoutOptions,
+): VerifyLoadoutResult {
+  if (pieces.length !== SLOT_ORDER.length) {
+    return {
+      ok: false,
+      reason: `Expected ${SLOT_ORDER.length} pieces (one per slot), got ${pieces.length}.`,
+    };
+  }
+
+  const slots = new Set(pieces.map((p) => p.slot));
+  for (const slot of SLOT_ORDER) {
+    if (!slots.has(slot)) {
+      return { ok: false, reason: `Missing armor slot: ${slot}.` };
+    }
+  }
+
+  const setBonusSelections = options.setBonusSelections ?? [];
+  if (!satisfiesSetBonuses(pieces, setBonusSelections)) {
+    return {
+      ok: false,
+      reason: "Set bonus piece counts are not met (check setHash on each piece).",
+    };
+  }
+
+  const assumedMods = options.assumedMods ?? { majorCount: 5 };
+  const fragmentOffset = options.fragmentOffset ?? {};
+  const budget = totalAssumedModBudget(assumedMods);
+
+  const armorOnly = totalsFromPieces(pieces);
+  const resolved = resolveLoadoutTotals(
+    pieces,
+    options.constraints,
+    fragmentOffset,
+    assumedMods,
+  );
+
+  if (resolved != null) {
+    return { ok: true, resolved };
+  }
+
+  const lines: string[] = [
+    "Could not assign tuning branches and assumed mods to meet all targets.",
+    `Armor-only totals (committed rolls): ${formatTotals(armorOnly)}`,
+    `Assumed mod budget: +${budget.total} (${budget.majorCount} major, ${budget.minorCount} minor).`,
+  ];
+
+  for (const row of options.constraints) {
+    if (row.min <= 0) continue;
+    const value = armorOnly[row.stat] ?? 0;
+    if (value < row.min) {
+      lines.push(
+        `${row.stat}: armor sum ${value} is below min ${row.min} (needs +${row.min - value} from tuning/mods).`,
+      );
+    }
+  }
+
+  const withFrags = { ...armorOnly };
+  for (const stat of ARMOR_STAT_NAMES) {
+    withFrags[stat] += fragmentOffset[stat] ?? 0;
+  }
+  if (!satisfiesConstraints(withFrags, options.constraints)) {
+    lines.push(
+      `Even ignoring mods, totals violate constraints: ${formatTotals(withFrags)}`,
+    );
+  }
+
+  return { ok: false, reason: lines.join(" ") };
+}
+
+function formatTotals(totals: Record<ArmorStatName, number>): string {
+  return ARMOR_STAT_NAMES.map((s) => `${s}=${totals[s] ?? 0}`).join(", ");
+}

--- a/supabase/migrations/0022_backfill_armor_stat_destiny_hashes.sql
+++ b/supabase/migrations/0022_backfill_armor_stat_destiny_hashes.sql
@@ -1,0 +1,13 @@
+-- Backfill Bungie statTypeHash values for profile ItemStats (component 304) mapping.
+-- Stable Armor 3.0 DestinyStatDefinition hashes; safe to apply on every environment.
+
+update public.armor_stat_icons
+set destiny_stat_hash = case stat
+  when 'Weapons' then 2996146975
+  when 'Health' then 392767087
+  when 'Class' then 2135857333
+  when 'Grenade' then 1735777505
+  when 'Melee' then 4244567218
+  when 'Super' then 144602215
+end
+where destiny_stat_hash is null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "spike"]
+  "exclude": ["node_modules", "spike", "scripts"]
 }


### PR DESCRIPTION
## Summary

This PR completes the **stat-calculation and bounds** layer for the Optimize tab. It builds on `main` (`1d38f59` — optimizer tab, worker search, exotic lock, set bonuses, subclass fragments, stat sliders).

### What this PR adds
- Shared loadout verification (`resolve-loadout-totals`) — search accepts/rejects builds using correct tuning branches and a finite shared mod pool instead of per-stat ceilings
- Stat slider gray bands tightened via filtered combo counts, so large vaults with tight filters (locked exotic + stat targets) show realistic achievable ranges instead of the full 0–200 track
- Assumed stat mods panel, class switcher, combo-count helpers, debug verify-loadout tooling
- Migration `0022_backfill_armor_stat_destiny_hashes.sql`

### Already on `main` (not re-introduced here)
- Optimize tab shell, Web Worker search, exotic lock, set bonus picker, subclass fragments
- Stat range sliders, result cards, pool filtering, `statTotals` derivation, exotic stat budgets
- Manifest migrations 0017–0021

### Out of scope — future PRs (see `docs/loadout-optimizer-handoff.md`)
- Saved build goals (DB persistence)
- Equivalence groups / interchangeable piece tagging
- Cross-goal vault advisor ("safe to shard")
- DIM-style stat enable/disable, drag priority, per-stat max
- Pin/exclude specific armor pieces
- Mod/tuning breakdown in result card UI (backend metadata exists; UI not wired)
- Auto-search on huge vaults (>50k deduped combos) — manual "Generate builds" only

**Net:** Merging this gives a working v1 optimizer with honest stat math. It does not include the multi-goal vault-cleaning features from the original product spec.

## Test plan
- [x] `npx vitest run src/lib/optimizer/` (78 tests pass)
- [ ] Open Optimize tab with locked Speaker's Sight + stat targets — confirm gray bands cap near actual max (e.g. Grenade ~122, not 200)
- [ ] Set Grenade min above achievable max — confirm 0 builds returned and band matches
- [ ] Run optimizer with assumed major/minor mods — confirm result totals are physically plausible
- [ ] Apply migration `npm run db:push` in a dev environment with Supabase linked