### PR TITLE
Reduce dashboard re-render lag + add subtle, reduced-motion-aware animations

### DIFF
--- a/src/components/dashboard/dashboard-workspace.tsx
+++ b/src/components/dashboard/dashboard-workspace.tsx
@@ -207,6 +207,7 @@ export function DashboardWorkspace({
                 onFiltersChange={onFiltersChange}
                 savedViews={savedViewsMenuProps}
                 inventorySyncedAt={dataHealth.inventorySyncedAt}
+                filteringActive={mode === "table"}
               />
             </div>
           ) : null}

--- a/src/components/dashboard/inventory-table-view.tsx
+++ b/src/components/dashboard/inventory-table-view.tsx
@@ -52,6 +52,9 @@ const TABLE_SCROLL_GUTTER =
 /** Approximate single-row height; the virtualizer remeasures real rows on mount. */
 const ESTIMATED_ROW_HEIGHT_PX = 48;
 
+/** Stable empty result so the filter memo keeps identity while the tab is hidden. */
+const EMPTY_ROWS: DerivedArmorPieceJson[] = [];
+
 function formatLocation(piece: DerivedArmorPieceJson): string {
   const loc = piece.location;
   if (loc.kind === "vault") return "Vault";
@@ -80,6 +83,8 @@ interface InventoryTableViewProps {
   onFiltersChange: (next: GridFiltersJson) => void;
   savedViews?: SavedViewsBarProps;
   inventorySyncedAt: string | null;
+  /** When false (tab hidden), skip the full inventory filter + sort pass. */
+  filteringActive?: boolean;
 }
 
 export function InventoryTableView({
@@ -93,6 +98,7 @@ export function InventoryTableView({
   onFiltersChange,
   savedViews,
   inventorySyncedAt,
+  filteringActive = true,
 }: InventoryTableViewProps) {
   const { pinnedHashes, togglePin } = usePinnedArmorSets();
   const {
@@ -113,8 +119,11 @@ export function InventoryTableView({
     [filters, deferredSearch],
   );
   const filteredRows = useMemo(
-    () => filterInventoryPieces(inventory, filtersForFiltering),
-    [inventory, filtersForFiltering],
+    () =>
+      filteringActive
+        ? filterInventoryPieces(inventory, filtersForFiltering)
+        : EMPTY_ROWS,
+    [filteringActive, inventory, filtersForFiltering],
   );
 
   const emptyState = useMemo(

--- a/src/components/dashboard/workspace-view-mode-tabs.tsx
+++ b/src/components/dashboard/workspace-view-mode-tabs.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useLayoutEffect, useRef, useState } from "react";
 import {
   Compass,
   SlidersHorizontal,
   SquaresFour,
   Table,
 } from "@phosphor-icons/react/dist/ssr";
+import type { Icon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { chromeToolbarShellClass } from "@/components/ui/chrome-square-icon-button";
 
@@ -16,74 +18,98 @@ interface WorkspaceViewModeTabsProps {
   onModeChange: (mode: WorkspaceViewMode) => void;
 }
 
+const TABS: Array<{ value: WorkspaceViewMode; label: string; Icon: Icon }> = [
+  { value: "table", label: "Table", Icon: Table },
+  { value: "grid", label: "Tracker", Icon: SquaresFour },
+  { value: "optimizer", label: "Optimize", Icon: SlidersHorizontal },
+  { value: "plan", label: "Plan", Icon: Compass },
+];
+
 const segmentBtn =
-  "flex h-9 shrink-0 items-center gap-1.5 px-3 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50";
+  "relative z-10 flex h-9 shrink-0 items-center gap-1.5 px-3 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50";
 
 export function WorkspaceViewModeTabs({
   mode,
   onModeChange,
 }: WorkspaceViewModeTabsProps) {
+  const groupRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [indicator, setIndicator] = useState({ left: 0, width: 0 });
+  const [indicatorReady, setIndicatorReady] = useState(false);
+  // Stays false on first paint so the pill snaps to the initial tab without a
+  // slide; flips true on user selection so subsequent switches animate.
+  const [animateIndicator, setAnimateIndicator] = useState(false);
+
+  const activeIndex = TABS.findIndex((tab) => tab.value === mode);
+
+  useLayoutEffect(() => {
+    const update = () => {
+      const group = groupRef.current;
+      const tab = activeIndex >= 0 ? tabRefs.current[activeIndex] : null;
+      if (!group || !tab) return;
+      const groupRect = group.getBoundingClientRect();
+      const tabRect = tab.getBoundingClientRect();
+      setIndicator({
+        left: tabRect.left - groupRect.left,
+        width: tabRect.width,
+      });
+      setIndicatorReady(true);
+    };
+
+    update();
+    const group = groupRef.current;
+    if (!group) return;
+    const observer = new ResizeObserver(update);
+    observer.observe(group);
+    return () => observer.disconnect();
+  }, [activeIndex]);
+
+  const handleSelect = (next: WorkspaceViewMode) => {
+    if (next !== mode) setAnimateIndicator(true);
+    onModeChange(next);
+  };
+
   return (
     <div
-      className={cn(chromeToolbarShellClass, "pointer-events-auto")}
+      ref={groupRef}
+      className={cn(chromeToolbarShellClass, "relative pointer-events-auto")}
       role="tablist"
       aria-label="Workspace view"
     >
-      <button
-        type="button"
-        role="tab"
-        aria-selected={mode === "table"}
+      <span
+        aria-hidden
         className={cn(
-          segmentBtn,
-          mode === "table" && "bg-accent text-foreground",
+          "pointer-events-none absolute inset-y-0 z-0 bg-accent",
+          animateIndicator &&
+            "transition-[left,width] duration-200 ease-out motion-reduce:transition-none",
+          !indicatorReady && "opacity-0",
         )}
-        onClick={() => onModeChange("table")}
-      >
-        <Table className="h-4 w-4" weight="duotone" aria-hidden />
-        Table
-      </button>
-      <button
-        type="button"
-        role="tab"
-        aria-selected={mode === "grid"}
-        className={cn(
-          segmentBtn,
-          "border-l border-border",
-          mode === "grid" && "bg-accent text-foreground",
-        )}
-        onClick={() => onModeChange("grid")}
-      >
-        <SquaresFour className="h-4 w-4" weight="duotone" aria-hidden />
-        Tracker
-      </button>
-      <button
-        type="button"
-        role="tab"
-        aria-selected={mode === "optimizer"}
-        className={cn(
-          segmentBtn,
-          "border-l border-border",
-          mode === "optimizer" && "bg-accent text-foreground",
-        )}
-        onClick={() => onModeChange("optimizer")}
-      >
-        <SlidersHorizontal className="h-4 w-4" weight="duotone" aria-hidden />
-        Optimize
-      </button>
-      <button
-        type="button"
-        role="tab"
-        aria-selected={mode === "plan"}
-        className={cn(
-          segmentBtn,
-          "border-l border-border",
-          mode === "plan" && "bg-accent text-foreground",
-        )}
-        onClick={() => onModeChange("plan")}
-      >
-        <Compass className="h-4 w-4" weight="duotone" aria-hidden />
-        Plan
-      </button>
+        style={{ left: indicator.left, width: indicator.width }}
+        onTransitionEnd={() => setAnimateIndicator(false)}
+      />
+      {TABS.map((tab, index) => {
+        const active = mode === tab.value;
+        return (
+          <button
+            key={tab.value}
+            ref={(node) => {
+              tabRefs.current[index] = node;
+            }}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            className={cn(
+              segmentBtn,
+              index > 0 && "border-l border-border",
+              active && "text-foreground",
+            )}
+            onClick={() => handleSelect(tab.value)}
+          >
+            <tab.Icon className="h-4 w-4" weight="duotone" aria-hidden />
+            {tab.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/dashboard/workspace-view-mode-tabs.tsx
+++ b/src/components/dashboard/workspace-view-mode-tabs.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useLayoutEffect, useRef, useState } from "react";
 import {
   Compass,
   SlidersHorizontal,
@@ -9,6 +8,7 @@ import {
 } from "@phosphor-icons/react/dist/ssr";
 import type { Icon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import { useSlidingIndicator } from "@/lib/hooks/use-sliding-indicator";
 import { chromeToolbarShellClass } from "@/components/ui/chrome-square-icon-button";
 
 export type WorkspaceViewMode = "grid" | "table" | "optimizer" | "plan";
@@ -32,40 +32,19 @@ export function WorkspaceViewModeTabs({
   mode,
   onModeChange,
 }: WorkspaceViewModeTabsProps) {
-  const groupRef = useRef<HTMLDivElement>(null);
-  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const [indicator, setIndicator] = useState({ left: 0, width: 0 });
-  const [indicatorReady, setIndicatorReady] = useState(false);
-  // Stays false on first paint so the pill snaps to the initial tab without a
-  // slide; flips true on user selection so subsequent switches animate.
-  const [animateIndicator, setAnimateIndicator] = useState(false);
-
   const activeIndex = TABS.findIndex((tab) => tab.value === mode);
-
-  useLayoutEffect(() => {
-    const update = () => {
-      const group = groupRef.current;
-      const tab = activeIndex >= 0 ? tabRefs.current[activeIndex] : null;
-      if (!group || !tab) return;
-      const groupRect = group.getBoundingClientRect();
-      const tabRect = tab.getBoundingClientRect();
-      setIndicator({
-        left: tabRect.left - groupRect.left,
-        width: tabRect.width,
-      });
-      setIndicatorReady(true);
-    };
-
-    update();
-    const group = groupRef.current;
-    if (!group) return;
-    const observer = new ResizeObserver(update);
-    observer.observe(group);
-    return () => observer.disconnect();
-  }, [activeIndex]);
+  const {
+    groupRef,
+    registerTab,
+    indicatorStyle,
+    indicatorReady,
+    animating,
+    beginSlide,
+    endSlide,
+  } = useSlidingIndicator(activeIndex);
 
   const handleSelect = (next: WorkspaceViewMode) => {
-    if (next !== mode) setAnimateIndicator(true);
+    if (next !== mode) beginSlide();
     onModeChange(next);
   };
 
@@ -73,31 +52,28 @@ export function WorkspaceViewModeTabs({
     <div
       ref={groupRef}
       className={cn(chromeToolbarShellClass, "relative pointer-events-auto")}
-      role="tablist"
+      role="group"
       aria-label="Workspace view"
     >
       <span
         aria-hidden
         className={cn(
           "pointer-events-none absolute inset-y-0 z-0 bg-accent",
-          animateIndicator &&
+          animating &&
             "transition-[left,width] duration-200 ease-out motion-reduce:transition-none",
           !indicatorReady && "opacity-0",
         )}
-        style={{ left: indicator.left, width: indicator.width }}
-        onTransitionEnd={() => setAnimateIndicator(false)}
+        style={indicatorStyle}
+        onTransitionEnd={endSlide}
       />
       {TABS.map((tab, index) => {
         const active = mode === tab.value;
         return (
           <button
             key={tab.value}
-            ref={(node) => {
-              tabRefs.current[index] = node;
-            }}
+            ref={registerTab(index)}
             type="button"
-            role="tab"
-            aria-selected={active}
+            aria-pressed={active}
             className={cn(
               segmentBtn,
               index > 0 && "border-l border-border",

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -19,8 +19,10 @@ export const checkboxBoxClassName =
 /**
  * Inner check icon used inside `checkboxBoxClassName`. The mark eases in (it
  * only mounts when checked) so toggling a filter feels tactile rather than
- * snapping; `motion-reduce` keeps it instant for reduced-motion users. Shared
- * by the standalone `<Checkbox>` and `<DropdownMenuCheckboxItem>`.
+ * snapping; `motion-reduce` keeps it instant for reduced-motion users. Reused
+ * by every check mark in the app — standalone `<Checkbox>`,
+ * `<DropdownMenuCheckboxItem>`, and the armor-set listbox — so the entrance
+ * stays consistent.
  */
 export const checkboxIconClassName =
   "h-3 w-3 animate-in zoom-in-75 fade-in-0 duration-150 motion-reduce:animate-none";

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -16,8 +16,14 @@ import { cn } from "@/lib/utils";
 export const checkboxBoxClassName =
   "flex h-4 w-4 shrink-0 items-center justify-center border border-current/40 transition-colors";
 
-/** Inner check icon size used inside `checkboxBoxClassName`. */
-export const checkboxIconClassName = "h-3 w-3";
+/**
+ * Inner check icon used inside `checkboxBoxClassName`. The mark eases in (it
+ * only mounts when checked) so toggling a filter feels tactile rather than
+ * snapping; `motion-reduce` keeps it instant for reduced-motion users. Shared
+ * by the standalone `<Checkbox>` and `<DropdownMenuCheckboxItem>`.
+ */
+export const checkboxIconClassName =
+  "h-3 w-3 animate-in zoom-in-75 fade-in-0 duration-150 motion-reduce:animate-none";
 
 const Checkbox = React.forwardRef<
   React.ComponentRef<typeof CheckboxPrimitive.Root>,

--- a/src/components/workspace/class-switcher.tsx
+++ b/src/components/workspace/class-switcher.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useLayoutEffect, useRef, useState } from "react";
 import { CLASS_NAMES } from "@/lib/bungie/constants";
 import type { GridFilterClass } from "@/lib/workspace/grid-filters-schema";
+import { useSlidingIndicator } from "@/lib/hooks/use-sliding-indicator";
 import { cn } from "@/lib/utils";
 
 const CLASS_OPTIONS: Array<{ value: GridFilterClass; label: string }> = [
@@ -61,43 +61,22 @@ export function ClassSwitcher({
   className,
 }: ClassSwitcherProps) {
   const condensed = variant === "condensed";
-  const groupRef = useRef<HTMLDivElement>(null);
-  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const [indicator, setIndicator] = useState({ left: 0, width: 0 });
-  const [indicatorReady, setIndicatorReady] = useState(false);
-  const [animateIndicator, setAnimateIndicator] = useState(false);
-
   const activeIndex = CLASS_OPTIONS.findIndex((tab) => tab.value === value);
+  const {
+    groupRef,
+    registerTab,
+    indicatorStyle,
+    indicatorReady,
+    animating,
+    beginSlide,
+    endSlide,
+  } = useSlidingIndicator(activeIndex);
 
   const handleSelect = (next: GridFilterClass) => {
-    if (next !== value) {
-      setAnimateIndicator(true);
-    }
+    if (next !== value) beginSlide();
     onChange(next);
   };
   const isLastTab = activeIndex === CLASS_OPTIONS.length - 1;
-
-  useLayoutEffect(() => {
-    const update = () => {
-      const group = groupRef.current;
-      const tab = activeIndex >= 0 ? tabRefs.current[activeIndex] : null;
-      if (!group || !tab) return;
-      const groupRect = group.getBoundingClientRect();
-      const tabRect = tab.getBoundingClientRect();
-      setIndicator({
-        left: tabRect.left - groupRect.left,
-        width: tabRect.width,
-      });
-      setIndicatorReady(true);
-    };
-
-    update();
-    const group = groupRef.current;
-    if (!group) return;
-    const observer = new ResizeObserver(update);
-    observer.observe(group);
-    return () => observer.disconnect();
-  }, [activeIndex, condensed, value]);
 
   return (
     <div
@@ -115,7 +94,7 @@ export function ClassSwitcher({
         aria-hidden
         className={cn(
           "pointer-events-none absolute inset-y-0 z-0 border",
-          animateIndicator &&
+          animating &&
             "transition-[left,width] duration-200 ease-out motion-reduce:transition-none",
           CLASS_TAB_INDICATOR_CLASS,
           condensed &&
@@ -123,20 +102,15 @@ export function ClassSwitcher({
           condensed && isLastTab && "border-r-transparent",
           !indicatorReady && "opacity-0",
         )}
-        style={{
-          left: indicator.left,
-          width: indicator.width,
-        }}
-        onTransitionEnd={() => setAnimateIndicator(false)}
+        style={indicatorStyle}
+        onTransitionEnd={endSlide}
       />
       {CLASS_OPTIONS.map((tab, index) => {
         const active = value === tab.value;
         return (
           <button
             key={tab.value}
-            ref={(node) => {
-              tabRefs.current[index] = node;
-            }}
+            ref={registerTab(index)}
             type="button"
             className={classTabButtonClass(active, condensed)}
             onClick={() => handleSelect(tab.value)}

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -374,10 +374,6 @@ const GridTile = memo(function GridTile({
     () => buildEphemeralTrackerPayload(descriptor, inventory, lookupPayload),
     [descriptor, inventory, lookupPayload],
   );
-  const handleCompareClick = useCallback(
-    () => onCompareClick(descriptor),
-    [onCompareClick, descriptor],
-  );
   return (
     <div
       className="shrink-0 overflow-hidden"
@@ -397,7 +393,7 @@ const GridTile = memo(function GridTile({
         <TrackerGridContent
           payload={payload}
           hasInventory={hasInventory}
-          onCompareClick={handleCompareClick}
+          onCompareClick={() => onCompareClick(descriptor)}
         />
       </div>
     </div>

--- a/src/components/workspace/grid-workspace.tsx
+++ b/src/components/workspace/grid-workspace.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  memo,
   useCallback,
   useDeferredValue,
   useLayoutEffect,
@@ -209,6 +210,12 @@ export function GridWorkspace({
     useState<TrackerDescriptor | null>(null);
   const compareOpen = compareAnchor !== null;
 
+  // Stable identity so memoized tiles don't re-render when the parent updates
+  // for unrelated reasons (scroll, compare open/close).
+  const handleCompareClick = useCallback((descriptor: TrackerDescriptor) => {
+    setCompareAnchor(descriptor);
+  }, []);
+
   const hasTopMessage = Boolean(banners) || Boolean(syncWarning);
   const totalSize = virtualizer.getTotalSize();
 
@@ -311,7 +318,7 @@ export function GridWorkspace({
                             }
                             lookupPayload={lookupPayload}
                             hasInventory={hasInventory}
-                            onCompareClick={() => setCompareAnchor(d)}
+                            onCompareClick={handleCompareClick}
                           />
                         ))}
                       </div>
@@ -347,10 +354,16 @@ interface GridTileProps {
   inventory: DerivedArmorPieceJson[];
   lookupPayload: GridLookupPayload;
   hasInventory: boolean;
-  onCompareClick: () => void;
+  onCompareClick: (descriptor: TrackerDescriptor) => void;
 }
 
-function GridTile({
+/**
+ * Memoized so a parent re-render (scroll, compare open/close) doesn't rebuild
+ * every visible tile's payload and re-reconcile its ~25 tooltip cells. Props
+ * are referentially stable per tile: the descriptor and pre-bucketed inventory
+ * keep identity until enumeration or inventory actually changes.
+ */
+const GridTile = memo(function GridTile({
   descriptor,
   inventory,
   lookupPayload,
@@ -360,6 +373,10 @@ function GridTile({
   const payload = useMemo(
     () => buildEphemeralTrackerPayload(descriptor, inventory, lookupPayload),
     [descriptor, inventory, lookupPayload],
+  );
+  const handleCompareClick = useCallback(
+    () => onCompareClick(descriptor),
+    [onCompareClick, descriptor],
   );
   return (
     <div
@@ -380,9 +397,9 @@ function GridTile({
         <TrackerGridContent
           payload={payload}
           hasInventory={hasInventory}
-          onCompareClick={onCompareClick}
+          onCompareClick={handleCompareClick}
         />
       </div>
     </div>
   );
-}
+});

--- a/src/lib/hooks/use-sliding-indicator.ts
+++ b/src/lib/hooks/use-sliding-indicator.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+// `useLayoutEffect` warns when it runs on the server, but client components are
+// still server-rendered for the initial HTML. Fall back to `useEffect` there;
+// the indicator stays hidden (`indicatorReady === false`) until measured, so
+// there is no hydration mismatch either way.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export interface SlidingIndicator {
+  /** Attach to the segment container (the indicator is positioned relative to it). */
+  groupRef: React.RefObject<HTMLDivElement | null>;
+  /** Ref callback for each segment button, by index. */
+  registerTab: (index: number) => (node: HTMLButtonElement | null) => void;
+  /** Inline `left`/`width` (px) for the indicator element. */
+  indicatorStyle: { left: number; width: number };
+  /** False until the first measurement lands — hide the indicator so it doesn't flash at 0,0. */
+  indicatorReady: boolean;
+  /** True while a slide is in flight — gate the transition on this so it never animates on first paint. */
+  animating: boolean;
+  /** Call on a user-driven active-index change to enable the slide. */
+  beginSlide: () => void;
+  /** Wire to the indicator's `onTransitionEnd` to reset `animating`. */
+  endSlide: () => void;
+}
+
+/**
+ * Measures the active segment in a segmented control and exposes the geometry
+ * for a sliding indicator pill. Re-measures on active-index change and on
+ * container resize. Shared by `ClassSwitcher` and `WorkspaceViewModeTabs`.
+ */
+export function useSlidingIndicator(activeIndex: number): SlidingIndicator {
+  const groupRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 });
+  const [indicatorReady, setIndicatorReady] = useState(false);
+  const [animating, setAnimating] = useState(false);
+
+  useIsomorphicLayoutEffect(() => {
+    const update = () => {
+      const group = groupRef.current;
+      const tab = activeIndex >= 0 ? tabRefs.current[activeIndex] : null;
+      if (!group || !tab) return;
+      const groupRect = group.getBoundingClientRect();
+      const tabRect = tab.getBoundingClientRect();
+      setIndicatorStyle({
+        left: tabRect.left - groupRect.left,
+        width: tabRect.width,
+      });
+      setIndicatorReady(true);
+    };
+
+    update();
+    const group = groupRef.current;
+    if (!group) return;
+    const observer = new ResizeObserver(update);
+    observer.observe(group);
+    return () => observer.disconnect();
+  }, [activeIndex]);
+
+  return {
+    groupRef,
+    registerTab: (index) => (node) => {
+      tabRefs.current[index] = node;
+    },
+    indicatorStyle,
+    indicatorReady,
+    animating,
+    beginSlide: () => setAnimating(true),
+    endSlide: () => setAnimating(false),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A focused pass over the dashboard for **latency/lag** and **subtle motion**, scoped tightly per change. Driven by a thorough read of the rendering hot paths (tracker grid, inventory table, shared UI primitives) and a code-quality review pass.

### Performance (latency / lag)

1. **Skip inventory filtering while the table tab is hidden** (`inventory-table-view.tsx`, `dashboard-workspace.tsx`)
   - The table and grid tabs share one `filters` object, and the table stays mounted (CSS-hidden) after first visit. Every keystroke/filter change on the **grid** tab was still running a full `filterInventoryPieces()` multi-pass + sort over the entire vault in the hidden table.
   - Gated the filter memo behind a `filteringActive` prop (default `true`), mirroring the existing `enumerationActive` gate in `GridWorkspace`. `DashboardWorkspace` passes `mode === "table"`.

2. **Memoize `GridTile`** (`grid-workspace.tsx`)
   - A parent re-render (virtualizer scroll, compare dialog open/close) re-rendered every visible tile, rebuilding its payload and reconciling ~25 tooltip cells each.
   - Wrapped `GridTile` in `React.memo` and hoisted a stable `onCompareClick` handler. Tiles now only re-render when their `descriptor` or pre-bucketed `inventory` actually changes.

### Subtle animations (all reduced-motion aware)

3. **Checkbox checkmark eases in** (`checkbox.tsx`)
   - Added a small `zoom + fade` entrance on the shared check-icon class. The indicator only mounts when checked, so it animates on check. `motion-reduce:animate-none` keeps it instant. Shared by `<Checkbox>`, `<DropdownMenuCheckboxItem>`, and the armor-set listbox.

4. **Sliding active indicator on the view-mode tabs** (`workspace-view-mode-tabs.tsx`)
   - The Table/Tracker/Optimize/Plan tabs snapped their active background. Added a sliding pill behind the active tab: measured via `ResizeObserver`, no slide on first paint, `motion-reduce:transition-none` disables the transition. Collapsed the four duplicated buttons into a data-driven map.

### Code-quality review fixes (applied from `thermo-nuclear-code-quality-review`)

5. **Extracted a shared `useSlidingIndicator` hook** (`src/lib/hooks/use-sliding-indicator.ts`)
   - The sliding-indicator mechanism (refs, measurement state, `ResizeObserver` layout effect) was ~40 lines duplicated between the new tabs and the existing `ClassSwitcher`. Hoisted it into one hook consumed by both, removing the duplication (net **−52 lines** across the two components). The hook routes through an isomorphic layout effect so neither call site logs the SSR `useLayoutEffect` warning.
6. **Aligned the view-mode tabs to `role="group"` / `aria-pressed`** — matching `ClassSwitcher` and the optimizer segmented control, instead of a half-implemented `tablist` contract (no roving tabindex / tabpanels existed).
7. **Dropped a redundant inner `useCallback`** in `GridTile` (dead ceremony — `TrackerGridContent` isn't memoized; the load-bearing stable handler is the parent's).
8. **Fixed the `checkboxIconClassName` doc** to list all three consumers.

## Verification

Dependencies + Playwright Chromium installed in a fresh workspace. Compared every gate against the `main` baseline — **zero new regressions**:

| Check | `main` baseline | This branch |
|---|---|---|
| ESLint | 37 problems (18 err / 19 warn) | 37 (identical) |
| `tsc --noEmit` | 18 errors (all pre-existing `*.test.ts` fixtures) | 18 (identical) |
| Storybook (full suite) | 8 failing in untouched files (clipboard mock + data fixtures) | 8 (identical) |
| `checkbox` + `workspace-view-mode-tabs` + `class-switcher` stories | — | **16/16 pass** (interaction + a11y, incl. `ClassSwitcher` click→`aria-pressed`) |

The pre-existing lint/tsc/Storybook failures live in files this PR does not touch (optimizer hook, test fixtures, share-link clipboard mock) and are out of scope.

## Notes / follow-ups (not in this PR)

- `next build` is currently red on `main` because `tsconfig` includes `*.test.ts` and several optimizer test fixtures are out of sync with `DerivedArmorPieceJson`. Unrelated to this change.
- A server-side audit surfaced additional latency opportunities (parallelizing awaits in `syncUserInventory`, parallel manifest-slice downloads in `manifest/sync.ts`, drop-feed diff without a full-table `SELECT`). Left out here to keep this PR surgical and low-risk.
- `react-rnd` / `react-zoom-pan-pinch` appear to be unused dead dependencies from the retired pannable canvas.
- The three panel-gating booleans (`filteringActive` / `enumerationActive` / `sessionActive`) could be standardized to one name in a follow-up; this PR keeps the existing local convention.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b822fd7-6365-48b1-9626-d768f2b1d62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b822fd7-6365-48b1-9626-d768f2b1d62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

