### PR TITLE
Server-side latency wins: parallelize independent Bungie/Supabase work

### DIFF
--- a/src/lib/inventory/drop-feed.ts
+++ b/src/lib/inventory/drop-feed.ts
@@ -165,6 +165,19 @@ export async function listDropFeed(
   return (data ?? []).map(rowToEntry);
 }
 
+/** Feed size only — avoids fetching the per-row `piece` JSON blobs just to count them. */
+export async function countDropFeed(userId: string): Promise<number> {
+  const sb = getServiceRoleClient();
+  const { count, error } = await sb
+    .from("inventory_drop_feed")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId);
+  if (error) {
+    throw new Error(`inventory_drop_feed count failed: ${error.message}`);
+  }
+  return count ?? 0;
+}
+
 export async function clearDropFeed(userId: string): Promise<void> {
   const sb = getServiceRoleClient();
   const { error } = await sb

--- a/src/lib/inventory/sync.ts
+++ b/src/lib/inventory/sync.ts
@@ -107,21 +107,19 @@ export async function syncUserInventory(
     );
 
   // The manifest lookups (Supabase — possibly a cold full-table load) don't
-  // depend on the Bungie profile (network), so fetch them concurrently. The
-  // cache-miss path is then bound by whichever is slower, not their sum.
-  let lookups: Awaited<ReturnType<typeof getManifestLookups>>;
-  let profile: ProfileResponse;
-  try {
-    [lookups, profile] = await Promise.all([
-      getManifestLookups(),
-      withBungieAccessTokenRetry(session.userId, fetchProfile),
-    ]);
-  } catch (err) {
+  // depend on the Bungie profile (network), so fetch them concurrently; the
+  // cache-miss path is then bound by whichever is slower, not their sum. The
+  // two now race, so on the rare double failure a Bungie-maintenance error may
+  // surface ahead of a lookups error — both are fatal here, so that's fine.
+  const [lookups, profile] = await Promise.all([
+    getManifestLookups(),
+    withBungieAccessTokenRetry(session.userId, fetchProfile),
+  ]).catch((err) => {
     if (err instanceof BungieApiError && err.maintenance) {
       throw new InventoryNotReady("Bungie API is in maintenance.", 503);
     }
     throw err;
-  }
+  });
 
   const warnings: string[] = [];
   if (!lookups.version) {

--- a/src/lib/inventory/sync.ts
+++ b/src/lib/inventory/sync.ts
@@ -11,7 +11,7 @@ import type { Session } from "@/lib/auth/session";
 import type { DerivedArmorPieceJson, InventoryCacheRow, Json } from "@/lib/db/types";
 import type { ProfileResponse } from "@/lib/bungie/types";
 import { deriveAllArmorPieces } from "./derive";
-import { listDropFeed, recordNewDropsFromSync } from "./drop-feed";
+import { countDropFeed, recordNewDropsFromSync } from "./drop-feed";
 
 /** Raw item counts from GetProfile — used to detect withheld inventory components. */
 function rawInventoryItemCounts(profile: ProfileResponse): {
@@ -74,7 +74,7 @@ export async function syncUserInventory(
         const items = existing.items as DerivedArmorPieceJson[] | null;
         let feedCount = 0;
         try {
-          feedCount = (await listDropFeed(session.userId)).length;
+          feedCount = await countDropFeed(session.userId);
         } catch {
           // Drop-feed tables not migrated yet — inventory cache is still valid.
         }
@@ -92,14 +92,6 @@ export async function syncUserInventory(
     }
   }
 
-  const lookups = await getManifestLookups();
-  const warnings: string[] = [];
-  if (!lookups.version) {
-    warnings.push(
-      "Manifest is still loading — inventory may be incomplete until it finishes.",
-    );
-  }
-
   const fetchProfile = (token: string) =>
     withUserRateLimit(session.userId, () =>
       withBackoff(
@@ -114,14 +106,28 @@ export async function syncUserInventory(
       ),
     );
 
-  let profile;
+  // The manifest lookups (Supabase — possibly a cold full-table load) don't
+  // depend on the Bungie profile (network), so fetch them concurrently. The
+  // cache-miss path is then bound by whichever is slower, not their sum.
+  let lookups: Awaited<ReturnType<typeof getManifestLookups>>;
+  let profile: ProfileResponse;
   try {
-    profile = await withBungieAccessTokenRetry(session.userId, fetchProfile);
+    [lookups, profile] = await Promise.all([
+      getManifestLookups(),
+      withBungieAccessTokenRetry(session.userId, fetchProfile),
+    ]);
   } catch (err) {
     if (err instanceof BungieApiError && err.maintenance) {
       throw new InventoryNotReady("Bungie API is in maintenance.", 503);
     }
     throw err;
+  }
+
+  const warnings: string[] = [];
+  if (!lookups.version) {
+    warnings.push(
+      "Manifest is still loading — inventory may be incomplete until it finishes.",
+    );
   }
 
   const rawCounts = rawInventoryItemCounts(profile);
@@ -150,7 +156,7 @@ export async function syncUserInventory(
   let feedCount = 0;
   try {
     newPieces = await recordNewDropsFromSync(session.userId, items);
-    feedCount = (await listDropFeed(session.userId)).length;
+    feedCount = await countDropFeed(session.userId);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("schema cache") || msg.includes("inventory_seen_instances")) {

--- a/src/lib/manifest/sync.ts
+++ b/src/lib/manifest/sync.ts
@@ -132,21 +132,29 @@ export async function syncManifest({
     throw new Error(`No manifest paths for locale '${locale}'`);
   }
 
-  // Slices are independent static CDN downloads, so fetch them concurrently.
-  // The DestinyInventoryItemDefinition slice (50MB+) dominates wall-clock time;
-  // overlapping the smaller slices with it removes their cost from the total.
-  const fetchedSlices = await Promise.all(
-    TABLES_OF_INTEREST.map(async (table) => {
-      const path = componentPaths[table];
-      if (!path) {
-        throw new Error(`Manifest index missing path for ${table}`);
-      }
-      return [table, await fetchManifestSlice(path)] as const;
-    }),
-  );
-  const slices: Record<string, Record<string, unknown>> = Object.fromEntries(
-    fetchedSlices,
-  );
+  // Slices are independent static CDN downloads, so overlap them to cut the
+  // sequential wall-clock cost. Fetch a few at a time rather than all 8 at once:
+  // the DestinyInventoryItemDefinition body alone is 50MB+, and a full Promise.all
+  // would hold every raw response (plus its parsed object) in memory together —
+  // an OOM risk on a memory-capped function. A small batch keeps the peak near
+  // the sequential footprint while still hiding the smaller slices' download time.
+  const SLICE_FETCH_CONCURRENCY = 3;
+  const slices: Record<string, Record<string, unknown>> = {};
+  for (let i = 0; i < TABLES_OF_INTEREST.length; i += SLICE_FETCH_CONCURRENCY) {
+    const batch = TABLES_OF_INTEREST.slice(i, i + SLICE_FETCH_CONCURRENCY);
+    const fetched = await Promise.all(
+      batch.map(async (table) => {
+        const path = componentPaths[table];
+        if (!path) {
+          throw new Error(`Manifest index missing path for ${table}`);
+        }
+        return [table, await fetchManifestSlice(path)] as const;
+      }),
+    );
+    for (const [table, slice] of fetched) {
+      slices[table] = slice;
+    }
+  }
 
   const derived = deriveManifestData({
     version,

--- a/src/lib/manifest/sync.ts
+++ b/src/lib/manifest/sync.ts
@@ -132,14 +132,21 @@ export async function syncManifest({
     throw new Error(`No manifest paths for locale '${locale}'`);
   }
 
-  const slices: Record<string, Record<string, unknown>> = {};
-  for (const table of TABLES_OF_INTEREST) {
-    const path = componentPaths[table];
-    if (!path) {
-      throw new Error(`Manifest index missing path for ${table}`);
-    }
-    slices[table] = await fetchManifestSlice(path);
-  }
+  // Slices are independent static CDN downloads, so fetch them concurrently.
+  // The DestinyInventoryItemDefinition slice (50MB+) dominates wall-clock time;
+  // overlapping the smaller slices with it removes their cost from the total.
+  const fetchedSlices = await Promise.all(
+    TABLES_OF_INTEREST.map(async (table) => {
+      const path = componentPaths[table];
+      if (!path) {
+        throw new Error(`Manifest index missing path for ${table}`);
+      }
+      return [table, await fetchManifestSlice(path)] as const;
+    }),
+  );
+  const slices: Record<string, Record<string, unknown>> = Object.fromEntries(
+    fetchedSlices,
+  );
 
   const derived = deriveManifestData({
     version,

--- a/src/lib/manifest/version-check.ts
+++ b/src/lib/manifest/version-check.ts
@@ -36,6 +36,12 @@ export async function checkManifestVersion(
   }
 
   const sb = getServiceRoleClient();
+  // The live version comes from Bungie (network) and is independent of the
+  // Supabase schema-health queries below, so start it now and await it after —
+  // it overlaps the queries instead of running sequentially after them.
+  const liveVersionPromise = getDestinyManifest()
+    .then((manifest) => manifest.version)
+    .catch(() => null);
   const [
     cachedRes,
     statPairsRes,
@@ -86,13 +92,7 @@ export async function checkManifestVersion(
   const armorSetsCount = armorSetsRes.count ?? 0;
   const setPerksCount = setPerksRes.count ?? 0;
 
-  let liveVersion: string | null = null;
-  try {
-    const manifest = await getDestinyManifest();
-    liveVersion = manifest.version;
-  } catch {
-    liveVersion = null;
-  }
+  const liveVersion = await liveVersionPromise;
 
   const versionMismatch =
     liveVersion !== null && cachedVersion !== null && cachedVersion !== liveVersion;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the dashboard render/animation PR, focused on **server-side latency**. Each change parallelizes work that was running sequentially without a data dependency, or avoids over-fetching. All are verifiable by inspection (same operations, just concurrent / counted) — no behavior or DB end-state changes.

### Changes

1. **`syncManifest`: download manifest slices with bounded concurrency** (`manifest/sync.ts`)
   - The 8 `DestinyDefinition` slices were fetched in a sequential `for` loop. They're independent static CDN downloads (`fetchManifestSlice` is a plain `fetch`, not rate-limited), so they now overlap. Fetched in **small batches (3 at a time)** rather than all at once: a full `Promise.all` would hold all 8 raw response bodies + parsed objects in memory together, and the item-definition slice alone is 50MB+ — an OOM risk on a memory-capped function. Batching keeps peak memory near the sequential footprint while still hiding the smaller slices' download time.

2. **`checkManifestVersion`: overlap the live-version fetch with schema-health queries** (`manifest/version-check.ts`)
   - The 10 Supabase count/health queries ran first, *then* the Bungie live-version fetch ran sequentially after. The Bungie call is independent, so it's kicked off before the `Promise.all` and awaited after — overlapping the two. `.catch(() => null)` preserves the prior failure-tolerant behavior (and means it can never become an unhandled rejection).

3. **`syncUserInventory`: parallelize lookups + profile, and count the drop feed** (`inventory/sync.ts`, `inventory/drop-feed.ts`)
   - **Parallel:** the manifest lookups (Supabase — possibly a cold full-table load) had no data dependency on the Bungie `GetProfile` fetch (network), yet ran sequentially. They now run via `Promise.all`, so the cache-miss path is bound by the slower of the two rather than their sum. Maintenance→`InventoryNotReady` handling and the missing-version warning are preserved.
   - **Count, don't fetch:** `feedCount` was `listDropFeed().length`, which pulls up to 50 rows of per-piece JSON blobs just to count them. Added `countDropFeed()` (a `head: true` count query) and used it in both the cache-hit and post-sync paths.

## Code-quality review

Ran the diff through the `thermo-nuclear-code-quality-review` rubric (async-correctness focus): **no blockers**, both parallelizations confirmed unhandled-rejection-safe, `countDropFeed` confirmed equivalent under the ≤50 trim invariant. Applied its feedback:
- **Bounded the manifest-slice concurrency** (the memory finding above) instead of an unbounded `Promise.all`.
- **Simplified** the inventory `Promise.all` error handling to a `const` destructure + inline `.catch` and documented the conscious error-precedence tradeoff of racing the two fetches.

## Verification

Compared against the `main` baseline — **zero new regressions**:

| Check | `main` baseline | This branch |
|---|---|---|
| ESLint (changed files) | clean | clean |
| `tsc --noEmit` | 18 errors (pre-existing `*.test.ts` fixtures) | 18 (identical) |
| `npm run test:unit` | 4 failing in optimizer tests (pre-existing) | 4 (identical), 146 passing |

The pre-existing failures are in optimizer test fixtures that don't import any file changed here.

## Deliberately deferred (needs a live DB to verify)

- **`recordNewDropsFromSync` loads all `inventory_seen_instances` for the user** to diff against the current inventory — grows with lifetime vault history. The clean fix is to insert the current instance IDs with `upsert(..., { ignoreDuplicates: true }).select()` and treat the returned rows as the new drops (`ON CONFLICT DO NOTHING ... RETURNING` returns only inserted rows), dropping the full-table read entirely. This depends on PostgREST `RETURNING` semantics and touches a user-facing feature (new-drops feed); with no live Supabase in this environment and no existing tests, I left it out rather than ship an unverifiable correctness-sensitive change. Recommended as the next follow-up.
- **Manifest table replace** (`replaceDerivedTables`) does 14 sequential deletes + 14 sequential chunked inserts; FK ordering makes safe parallelization non-trivial, so left as-is.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b822fd7-6365-48b1-9626-d768f2b1d62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b822fd7-6365-48b1-9626-d768f2b1d62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

